### PR TITLE
Add simplification for field access outside let/in expressions

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1368,14 +1368,14 @@ expressionVisitorHelp node context =
                     onlyErrors []
 
         Expression.RecordAccess record (Node _ fieldName) ->
-            case Node.value record of
+            case Node.value (AstHelpers.removeParens record) of
                 Expression.RecordExpr setters ->
                     onlyErrors (recordAccessChecks (Node.range node) Nothing fieldName setters)
 
                 Expression.RecordUpdateExpression (Node recordNameRange _) setters ->
                     onlyErrors (recordAccessChecks (Node.range node) (Just recordNameRange) fieldName setters)
 
-                Expression.ParenthesizedExpression (Node _ (Expression.LetExpression { expression })) ->
+                Expression.LetExpression { expression } ->
                     onlyErrors (recordAccessLetInChecks (Node.range node) (Node.range expression))
 
                 _ ->

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10289,6 +10289,22 @@ a = { b = 3 }.b
 a = (3)
 """
                         ]
+        , test "should simplify record accesses for explicit records in parentheses" <|
+            \() ->
+                """module A exposing (..)
+a = (({ b = 3 })).b
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Field access can be simplified"
+                            , details = details
+                            , under = "(({ b = 3 })).b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (3)
+"""
+                        ]
         , test "shouldn't simplify record accesses for explicit records if it can't find the field" <|
             \() ->
                 """module A exposing (..)
@@ -10307,6 +10323,22 @@ a = foo { d | b = f x y }.b
                             { message = "Field access can be simplified"
                             , details = details
                             , under = "{ d | b = f x y }.b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = foo (f x y)
+"""
+                        ]
+        , test "should simplify record accesses for record updates in parentheses" <|
+            \() ->
+                """module A exposing (..)
+a = foo (({ d | b = f x y })).b
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Field access can be simplified"
+                            , details = details
+                            , under = "(({ d | b = f x y })).b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = foo (f x y)
@@ -10342,6 +10374,22 @@ a = (let b = c in f x).e
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (let b = c in (f x).e)
+"""
+                        ]
+        , test "should simplify record accesses for let/in expressions in parentheses" <|
+            \() ->
+                """module A exposing (..)
+a = (((let b = c in f x))).e
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Field access can be simplified"
+                            , details = [ "Accessing the field outside a let expression can be simplified to access the field inside it" ]
+                            , under = "(((let b = c in f x))).e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (((let b = c in (f x))).e)
 """
                         ]
         , test "should simplify nested record accesses for let/in expressions (inner)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10303,4 +10303,20 @@ a = { d | b = 3 }.c
 a = d.c
 """
                         ]
+        , test "should simplify record accesses for let/in expressions" <|
+            \() ->
+                """module A exposing (..)
+a = (let b = c in f x).e
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Field access can be simplified"
+                            , details = [ "Accessing the field outside a let expression can be simplified to access the field inside it" ]
+                            , under = "(let b = c in f x).e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (let b = c in (f x).e)
+"""
+                        ]
         ]


### PR DESCRIPTION
Related to #33 

This only solves the `let/in` case which is more visibly correct