### PR TITLE
Simplify record access simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1218,10 +1218,10 @@ expressionVisitorHelp node context =
                     onlyErrors [ injectRecordAccessIntoLetExpression "a let/in" (Node.range record) expression field ]
 
                 Expression.IfBlock _ _ _ ->
-                    onlyErrors (distributeFieldAccess False "an if/then/else" record field)
+                    onlyErrors (distributeFieldAccess "an if/then/else" record field)
 
                 Expression.CaseExpression _ ->
-                    onlyErrors (distributeFieldAccess False "a case/of" record field)
+                    onlyErrors (distributeFieldAccess "a case/of" record field)
 
                 _ ->
                     onlyErrors []
@@ -1230,13 +1230,13 @@ expressionVisitorHelp node context =
             onlyErrors []
 
 
-distributeFieldAccess : Bool -> String -> Node Expression -> Node String -> List (Error {})
-distributeFieldAccess isLet kind ((Node recordRange _) as record) (Node fieldRange fieldName) =
+distributeFieldAccess : String -> Node Expression -> Node String -> List (Error {})
+distributeFieldAccess kind ((Node recordRange _) as record) (Node fieldRange fieldName) =
     let
         { records, withoutParens, withParens } =
             recordLeavesRanges record
     in
-    if isLet || (List.isEmpty withParens && List.isEmpty withoutParens) then
+    if List.isEmpty withParens && List.isEmpty withoutParens then
         [ let
             removalRange : Range
             removalRange =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1215,7 +1215,7 @@ expressionVisitorHelp node context =
                     onlyErrors (recordAccessChecks (Node.range node) (Just recordNameRange) (Node.value field) setters)
 
                 Expression.LetExpression { expression } ->
-                    onlyErrors [ injectRecordAccessIntoLetExpression "a let/in" (Node.range record) expression field ]
+                    onlyErrors [ injectRecordAccessIntoLetExpression (Node.range record) expression field ]
 
                 Expression.IfBlock _ thenBranch elseBranch ->
                     onlyErrors (distributeFieldAccess "an if/then/else" (Node.range record) [ thenBranch, elseBranch ] field)
@@ -1253,8 +1253,8 @@ distributeFieldAccess kind recordRange branches (Node fieldRange fieldName) =
             []
 
 
-injectRecordAccessIntoLetExpression : String -> Range -> Node Expression -> Node String -> Rule.Error {}
-injectRecordAccessIntoLetExpression kind recordRange letBody (Node fieldRange fieldName) =
+injectRecordAccessIntoLetExpression : Range -> Node Expression -> Node String -> Rule.Error {}
+injectRecordAccessIntoLetExpression recordRange letBody (Node fieldRange fieldName) =
     let
         removalRange : Range
         removalRange =
@@ -1262,7 +1262,7 @@ injectRecordAccessIntoLetExpression kind recordRange letBody (Node fieldRange fi
     in
     Rule.errorWithFix
         { message = "Field access can be simplified"
-        , details = [ "Accessing the field outside " ++ kind ++ " expression can be simplified to access the field inside it" ]
+        , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it" ]
         }
         removalRange
         (Fix.removeRange removalRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1248,16 +1248,7 @@ distributeFieldAccess kind ((Node recordRange _) as record) (Node fieldRange fie
             }
             removalRange
             (Fix.removeRange removalRange
-                :: List.map
-                    (\leafRange -> Fix.insertAt leafRange.end ("." ++ fieldName))
-                    (withoutParens ++ records)
-                ++ List.concatMap
-                    (\leafRange ->
-                        [ Fix.insertAt leafRange.start "("
-                        , Fix.insertAt leafRange.end (")." ++ fieldName)
-                        ]
-                    )
-                    withParens
+                :: List.map (\leafRange -> Fix.insertAt leafRange.end ("." ++ fieldName)) records
             )
         ]
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1283,8 +1283,8 @@ recordLeavesRangesHelp nodes foundRanges =
 
         (Node range expr) :: rest ->
             case expr of
-                Expression.IfBlock _ thenNode elseNode ->
-                    recordLeavesRangesHelp (thenNode :: elseNode :: rest) foundRanges
+                Expression.IfBlock _ thenBranch elseBranch ->
+                    recordLeavesRangesHelp (thenBranch :: elseBranch :: rest) foundRanges
 
                 Expression.LetExpression { expression } ->
                     recordLeavesRangesHelp (expression :: rest) foundRanges

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1234,10 +1234,7 @@ distributeFieldAccess : Bool -> String -> Node Expression -> Node String -> List
 distributeFieldAccess isLet kind ((Node recordRange _) as record) (Node fieldRange fieldName) =
     case recordLeavesRanges record of
         { records, withoutParens, withParens } ->
-            if not (List.isEmpty withParens && List.isEmpty withoutParens) && not isLet then
-                []
-
-            else
+            if isLet || (List.isEmpty withParens && List.isEmpty withoutParens) then
                 [ let
                     removalRange : Range
                     removalRange =
@@ -1261,6 +1258,9 @@ distributeFieldAccess isLet kind ((Node recordRange _) as record) (Node fieldRan
                             withParens
                     )
                 ]
+
+            else
+                []
 
 
 combineRecordLeavesRanges :


### PR DESCRIPTION
This will in my opinion be a bit easier to understand.
For the records part, it should also be slightly faster because there is less data creation, as well as shortcutting where we stop the exploration as soon as we see something that will prevent the simplification (and some tail-call optimization)

Can be reviewed commit by commit

cc @miniBill if you'd like to take a look