### PR TITLE
`String` operation simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2908,6 +2908,15 @@ stringReverseChecks ({ parentRange, fnRange, firstArg } as checkInfo) =
 stringSliceChecks : CheckInfo -> List (Error {})
 stringSliceChecks checkInfo =
     case ( checkInfo.firstArg, checkInfo.secondArg, checkInfo.thirdArg ) of
+        ( _, Just (Node _ (Expression.Integer 0)), _ ) ->
+            [ Rule.errorWithFix
+                { message = "Using String.slice with end index 0 will result in an empty string"
+                , details = [ "You can replace this call by an empty string." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+            ]
+
         ( Node _ (Expression.Integer 0), _, _ ) ->
             [ Rule.errorWithFix
                 { message = "Use String.left instead"
@@ -2920,15 +2929,6 @@ stringSliceChecks checkInfo =
                     }
                     "String.left"
                 ]
-            ]
-
-        ( _, Just (Node _ (Expression.Integer 0)), _ ) ->
-            [ Rule.errorWithFix
-                { message = "Using String.slice with end index 0 will result in an empty string"
-                , details = [ "You can replace this call by an empty string." ]
-                }
-                checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
             ]
 
         ( _, _, Just (Node _ (Expression.Literal "")) ) ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2907,31 +2907,8 @@ stringReverseChecks ({ parentRange, fnRange, firstArg } as checkInfo) =
 
 stringSliceChecks : CheckInfo -> List (Error {})
 stringSliceChecks checkInfo =
-    case ( checkInfo.firstArg, checkInfo.secondArg, checkInfo.thirdArg ) of
-        ( _, Just (Node _ (Expression.Integer 0)), _ ) ->
-            [ Rule.errorWithFix
-                { message = "Using String.slice with end index 0 will result in an empty string"
-                , details = [ "You can replace this call by an empty string." ]
-                }
-                checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
-            ]
-
-        ( Node _ (Expression.Integer 0), _, _ ) ->
-            [ Rule.errorWithFix
-                { message = "Use String.left instead"
-                , details = [ "Using String.slice with start index 0 is the same as using String.left." ]
-                }
-                checkInfo.fnRange
-                [ Fix.replaceRangeBy
-                    { start = checkInfo.fnRange.start
-                    , end = (Node.range checkInfo.firstArg).end
-                    }
-                    "String.left"
-                ]
-            ]
-
-        ( _, _, Just (Node _ (Expression.Literal "")) ) ->
+    case checkInfo.thirdArg of
+        Just (Node _ (Expression.Literal "")) ->
             [ Rule.errorWithFix
                 { message = "Using String.slice on an empty string will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
@@ -2940,21 +2917,46 @@ stringSliceChecks checkInfo =
                 [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
             ]
 
-        ( start, Just end, _ ) ->
-            if Normalize.areAllTheSame checkInfo start [ end ] then
-                [ Rule.errorWithFix
-                    { message = "Using String.slice with equal start and end index will result in an empty string"
-                    , details = [ "You can replace this call by an empty string." ]
-                    }
-                    checkInfo.fnRange
-                    [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
-                ]
+        _ ->
+            case ( checkInfo.firstArg, checkInfo.secondArg ) of
+                ( _, Just (Node _ (Expression.Integer 0)) ) ->
+                    [ Rule.errorWithFix
+                        { message = "Using String.slice with end index 0 will result in an empty string"
+                        , details = [ "You can replace this call by an empty string." ]
+                        }
+                        checkInfo.fnRange
+                        [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                    ]
 
-            else
-                []
+                ( Node _ (Expression.Integer 0), _ ) ->
+                    [ Rule.errorWithFix
+                        { message = "Use String.left instead"
+                        , details = [ "Using String.slice with start index 0 is the same as using String.left." ]
+                        }
+                        checkInfo.fnRange
+                        [ Fix.replaceRangeBy
+                            { start = checkInfo.fnRange.start
+                            , end = (Node.range checkInfo.firstArg).end
+                            }
+                            "String.left"
+                        ]
+                    ]
 
-        ( _, Nothing, _ ) ->
-            []
+                ( start, Just end ) ->
+                    if Normalize.areAllTheSame checkInfo start [ end ] then
+                        [ Rule.errorWithFix
+                            { message = "Using String.slice with equal start and end index will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            }
+                            checkInfo.fnRange
+                            [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                        ]
+
+                    else
+                        []
+
+                ( _, Nothing ) ->
+                    []
 
 
 stringLeftChecks : CheckInfo -> List (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3012,7 +3012,7 @@ stringRightChecks checkInfo =
                 [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
             ]
 
-        ( Node _ (Expression.Negation (Node _ (Expression.Integer length))), _ ) ->
+        ( Node _ (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.right with negative length will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2614,18 +2614,18 @@ basicsIdentityChecks checkInfo =
     ]
 
 
+identityCompositionErrorMessage : { message : String, details : List String }
+identityCompositionErrorMessage =
+    { message = "`identity` should be removed"
+    , details = [ "Composing a function with `identity` is the same as simplify referencing the function." ]
+    }
+
+
 identityCompositionCheck : CompositionCheckInfo -> List (Error {})
 identityCompositionCheck { lookupTable, left, right } =
-    let
-        errorInfo : () -> { message : String, details : List String }
-        errorInfo () =
-            { message = "`identity` should be removed"
-            , details = [ "Composing a function with `identity` is the same as simplify referencing the function." ]
-            }
-    in
     if isIdentity lookupTable right then
         [ Rule.errorWithFix
-            (errorInfo ())
+            identityCompositionErrorMessage
             (Node.range right)
             [ Fix.removeRange { start = (Node.range left).end, end = (Node.range right).end }
             ]
@@ -2633,7 +2633,7 @@ identityCompositionCheck { lookupTable, left, right } =
 
     else if isIdentity lookupTable left then
         [ Rule.errorWithFix
-            (errorInfo ())
+            identityCompositionErrorMessage
             (Node.range left)
             [ Fix.removeRange { start = (Node.range left).start, end = (Node.range right).start }
             ]
@@ -2667,19 +2667,19 @@ basicsAlwaysChecks ({ fnRange, firstArg, secondArg, usingRightPizza } as checkIn
             []
 
 
+alwaysCompositionErrorMessage : { message : String, details : List String }
+alwaysCompositionErrorMessage =
+    { message = "Function composed with always will be ignored"
+    , details = [ "`always` will swallow the function composed into it." ]
+    }
+
+
 alwaysCompositionCheck : CompositionCheckInfo -> List (Error {})
 alwaysCompositionCheck { lookupTable, fromLeftToRight, left, right, leftRange, rightRange } =
-    let
-        errorInfo : () -> { message : String, details : List String }
-        errorInfo () =
-            { message = "Function composed with always will be ignored"
-            , details = [ "`always` will swallow the function composed into it." ]
-            }
-    in
     if fromLeftToRight then
         if isAlwaysCall lookupTable right then
             [ Rule.errorWithFix
-                (errorInfo ())
+                alwaysCompositionErrorMessage
                 rightRange
                 [ Fix.removeRange { start = leftRange.start, end = rightRange.start } ]
             ]
@@ -2689,7 +2689,7 @@ alwaysCompositionCheck { lookupTable, fromLeftToRight, left, right, leftRange, r
 
     else if isAlwaysCall lookupTable left then
         [ Rule.errorWithFix
-            (errorInfo ())
+            alwaysCompositionErrorMessage
             leftRange
             [ Fix.removeRange { start = leftRange.end, end = rightRange.end } ]
         ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2613,11 +2613,16 @@ basicsIdentityChecks checkInfo =
 
 identityCompositionCheck : CompositionCheckInfo -> List (Error {})
 identityCompositionCheck { lookupTable, left, right } =
-    if isIdentity lookupTable right then
-        [ Rule.errorWithFix
+    let
+        errorInfo : () -> { message : String, details : List String }
+        errorInfo () =
             { message = "`identity` should be removed"
             , details = [ "Composing a function with `identity` is the same as simplify referencing the function." ]
             }
+    in
+    if isIdentity lookupTable right then
+        [ Rule.errorWithFix
+            (errorInfo ())
             (Node.range right)
             [ Fix.removeRange { start = (Node.range left).end, end = (Node.range right).end }
             ]
@@ -2625,9 +2630,7 @@ identityCompositionCheck { lookupTable, left, right } =
 
     else if isIdentity lookupTable left then
         [ Rule.errorWithFix
-            { message = "`identity` should be removed"
-            , details = [ "Composing a function with `identity` is the same as simplify referencing the function." ]
-            }
+            (errorInfo ())
             (Node.range left)
             [ Fix.removeRange { start = (Node.range left).start, end = (Node.range right).start }
             ]
@@ -2663,12 +2666,17 @@ basicsAlwaysChecks ({ fnRange, firstArg, secondArg, usingRightPizza } as checkIn
 
 alwaysCompositionCheck : CompositionCheckInfo -> List (Error {})
 alwaysCompositionCheck { lookupTable, fromLeftToRight, left, right, leftRange, rightRange } =
+    let
+        errorInfo : () -> { message : String, details : List String }
+        errorInfo () =
+            { message = "Function composed with always will be ignored"
+            , details = [ "`always` will swallow the function composed into it." ]
+            }
+    in
     if fromLeftToRight then
         if isAlwaysCall lookupTable right then
             [ Rule.errorWithFix
-                { message = "Function composed with always will be ignored"
-                , details = [ "`always` will swallow the function composed into it." ]
-                }
+                (errorInfo ())
                 rightRange
                 [ Fix.removeRange { start = leftRange.start, end = rightRange.start } ]
             ]
@@ -2678,9 +2686,7 @@ alwaysCompositionCheck { lookupTable, fromLeftToRight, left, right, leftRange, r
 
     else if isAlwaysCall lookupTable left then
         [ Rule.errorWithFix
-            { message = "Function composed with always will be ignored"
-            , details = [ "`always` will swallow the function composed into it." ]
-            }
+            (errorInfo ())
             leftRange
             [ Fix.removeRange { start = leftRange.end, end = rightRange.end } ]
         ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2923,25 +2923,26 @@ stringSliceChecks checkInfo =
                 [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
             ]
 
-        ( _, Just (Node _ (Expression.Integer 0)), _ ) ->
+        ( _, Just (Node endArgumentRange (Expression.Integer 0)), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.slice with end index 0 will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                [ Fix.replaceRangeBy
+                    { start = checkInfo.fnRange.start, end = endArgumentRange.end }
+                    "always \"\""
+                ]
             ]
 
-        ( Node _ (Expression.Integer 0), _, _ ) ->
+        ( Node startArgumentRange (Expression.Integer 0), _, _ ) ->
             [ Rule.errorWithFix
                 { message = "Use String.left instead"
                 , details = [ "Using String.slice with start index 0 is the same as using String.left." ]
                 }
                 checkInfo.fnRange
                 [ Fix.replaceRangeBy
-                    { start = checkInfo.fnRange.start
-                    , end = (Node.range checkInfo.firstArg).end
-                    }
+                    { start = checkInfo.fnRange.start, end = startArgumentRange.end }
                     "String.left"
                 ]
             ]
@@ -2978,7 +2979,10 @@ stringSliceChecks checkInfo =
                             , details = [ "You can replace this call by an empty string." ]
                             }
                             checkInfo.fnRange
-                            [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                            [ Fix.replaceRangeBy
+                                { start = checkInfo.parentRange.start, end = (Node.range end).end }
+                                "always \"\""
+                            ]
                         ]
                             |> Just
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1510,6 +1510,8 @@ functionCallChecks =
         , ( ( [ "String" ], "lines" ), stringLinesChecks )
         , ( ( [ "String" ], "reverse" ), stringReverseChecks )
         , ( ( [ "String" ], "slice" ), stringSliceChecks )
+        , ( ( [ "String" ], "left" ), stringLeftChecks )
+        , ( ( [ "String" ], "right" ), stringRightChecks )
         , ( ( [ "Platform", "Cmd" ], "batch" ), subAndCmdBatchChecks "Cmd" )
         , ( ( [ "Platform", "Cmd" ], "map" ), collectionMapChecks cmdCollection )
         , ( ( [ "Platform", "Sub" ], "batch" ), subAndCmdBatchChecks "Sub" )
@@ -2922,6 +2924,74 @@ stringSliceChecks checkInfo =
                 []
 
         ( _, Nothing, _ ) ->
+            []
+
+
+stringLeftChecks : CheckInfo -> List (Error {})
+stringLeftChecks checkInfo =
+    case ( checkInfo.firstArg, checkInfo.secondArg ) of
+        ( _, Just (Node _ (Expression.Literal "")) ) ->
+            [ Rule.errorWithFix
+                { message = "Using String.left on an empty string will result in an empty string"
+                , details = [ "You can replace this call by an empty string." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+            ]
+
+        ( Node _ (Expression.Integer 0), _ ) ->
+            [ Rule.errorWithFix
+                { message = "Using String.left with length 0 will result in an empty string"
+                , details = [ "You can replace this call by an empty string." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+            ]
+
+        ( Node _ (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
+            [ Rule.errorWithFix
+                { message = "Using String.left with negative length will result in an empty string"
+                , details = [ "You can replace this call by an empty string." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+            ]
+
+        _ ->
+            []
+
+
+stringRightChecks : CheckInfo -> List (Error {})
+stringRightChecks checkInfo =
+    case ( checkInfo.firstArg, checkInfo.secondArg ) of
+        ( _, Just (Node _ (Expression.Literal "")) ) ->
+            [ Rule.errorWithFix
+                { message = "Using String.right on an empty string will result in an empty string"
+                , details = [ "You can replace this call by an empty string." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+            ]
+
+        ( Node _ (Expression.Integer 0), _ ) ->
+            [ Rule.errorWithFix
+                { message = "Using String.right with length 0 will result in an empty string"
+                , details = [ "You can replace this call by an empty string." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+            ]
+
+        ( Node _ (Expression.Negation (Node _ (Expression.Integer length))), _ ) ->
+            [ Rule.errorWithFix
+                { message = "Using String.right with negative length will result in an empty string"
+                , details = [ "You can replace this call by an empty string." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+            ]
+
+        _ ->
             []
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2914,7 +2914,7 @@ stringSliceChecks checkInfo =
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
             ]
 
         ( Node _ (Expression.Integer 0), _, _ ) ->
@@ -2947,7 +2947,7 @@ stringSliceChecks checkInfo =
                     , details = [ "You can replace this call by an empty string." ]
                     }
                     checkInfo.fnRange
-                    [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+                    [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
                 ]
 
             else
@@ -2975,7 +2975,7 @@ stringLeftChecks checkInfo =
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
             ]
 
         ( Node _ (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
@@ -2984,7 +2984,7 @@ stringLeftChecks checkInfo =
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
             ]
 
         _ ->
@@ -3009,7 +3009,7 @@ stringRightChecks checkInfo =
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
             ]
 
         ( Node _ (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
@@ -3018,7 +3018,7 @@ stringRightChecks checkInfo =
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
             ]
 
         _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -299,31 +299,31 @@ Destructuring using case expressions
     String.reverse <| String.reverse x
     --> x
 
-    String.slice n n string
+    String.slice n n str
     --> ""
 
-    String.slice 0 n string
-    --> String.left n string
+    String.slice 0 n str
+    --> String.left n str
 
-    String.slice n 0 string
+    String.slice n 0 str
     --> ""
 
     String.slice a z ""
     --> ""
 
-    String.left 0 string
+    String.left 0 str
     --> ""
 
-    String.left -1 string
+    String.left -1 str
     --> ""
 
     String.left n ""
     --> ""
 
-    String.right 0 string
+    String.right 0 str
     --> ""
 
-    String.right -1 string
+    String.right -1 str
     --> ""
 
     String.right n ""

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -300,7 +300,7 @@ Destructuring using case expressions
     --> x
 
 
-### Maybe
+### Maybes
 
     Maybe.map identity x
     --> x

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2962,7 +2962,10 @@ stringSliceChecks checkInfo =
                             , details = [ "You can replace this slice operation by \"\"." ]
                             }
                             checkInfo.fnRange
-                            [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                            [ Fix.replaceRangeBy
+                                { start = checkInfo.parentRange.start, end = (Node.range end).end }
+                                "always \"\""
+                            ]
                         ]
                             |> Just
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3003,22 +3003,28 @@ stringLeftChecks checkInfo =
                 [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
             ]
 
-        ( Node _ (Expression.Integer 0), _ ) ->
+        ( Node lengthArgumentRange (Expression.Integer 0), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.left with length 0 will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                [ Fix.replaceRangeBy
+                    { start = checkInfo.parentRange.start, end = lengthArgumentRange.end }
+                    "always \"\""
+                ]
             ]
 
-        ( Node _ (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
+        ( Node lengthArgumentRange (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.left with negative length will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                [ Fix.replaceRangeBy
+                    { start = checkInfo.parentRange.start, end = lengthArgumentRange.end }
+                    "always \"\""
+                ]
             ]
 
         _ ->
@@ -3037,22 +3043,28 @@ stringRightChecks checkInfo =
                 [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
             ]
 
-        ( Node _ (Expression.Integer 0), _ ) ->
+        ( Node lengthArgumentRange (Expression.Integer 0), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.right with length 0 will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                [ Fix.replaceRangeBy
+                    { start = checkInfo.parentRange.start, end = lengthArgumentRange.end }
+                    "always \"\""
+                ]
             ]
 
-        ( Node _ (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
+        ( Node _ (Expression.Negation (Node lengthArgumentRange (Expression.Integer _))), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.right with negative length will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "always \"\"" ]
+                [ Fix.replaceRangeBy
+                    { start = checkInfo.parentRange.start, end = lengthArgumentRange.end }
+                    "always \"\""
+                ]
             ]
 
         _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2811,7 +2811,7 @@ stringConcatChecks { parentRange, fnRange, firstArg } =
     case Node.value firstArg of
         Expression.ListExpr [] ->
             [ Rule.errorWithFix
-                { message = "Using String.concat on an empty list will result in a empty string"
+                { message = "Using String.concat on an empty list will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 fnRange
@@ -2859,7 +2859,7 @@ stringReverseChecks ({ parentRange, fnRange, firstArg } as checkInfo) =
     case Node.value firstArg of
         Expression.Literal "" ->
             [ Rule.errorWithFix
-                { message = "Using String.reverse on an empty string will result in a empty string"
+                { message = "Using String.reverse on an empty string will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 fnRange
@@ -2892,7 +2892,7 @@ stringSliceChecks checkInfo =
 
         ( _, Just (Node _ (Expression.Integer 0)) ) ->
             [ Rule.errorWithFix
-                { message = "Using String.slice with end index 0 will result in a empty string"
+                { message = "Using String.slice with end index 0 will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
@@ -2902,7 +2902,7 @@ stringSliceChecks checkInfo =
         ( start, Just end ) ->
             if Normalize.areAllTheSame checkInfo start [ end ] then
                 [ Rule.errorWithFix
-                    { message = "Using String.slice with equal start and end index will result in a empty string"
+                    { message = "Using String.slice with equal start and end index will result in an empty string"
                     , details = [ "You can replace this call by an empty string." ]
                     }
                     checkInfo.fnRange
@@ -2928,7 +2928,7 @@ stringJoinChecks { parentRange, fnRange, firstArg, secondArg } =
     case secondArg of
         Just (Node _ (Expression.ListExpr [])) ->
             [ Rule.errorWithFix
-                { message = "Using String.join on an empty list will result in a empty string"
+                { message = "Using String.join on an empty list will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 fnRange
@@ -2971,7 +2971,7 @@ stringRepeatChecks ({ parentRange, fnRange, firstArg, secondArg } as checkInfo) 
     case secondArg of
         Just (Node _ (Expression.Literal "")) ->
             [ Rule.errorWithFix
-                { message = "Using String.repeat with an empty string will result in a empty string"
+                { message = "Using String.repeat with an empty string will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 fnRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -299,6 +299,36 @@ Destructuring using case expressions
     String.reverse <| String.reverse x
     --> x
 
+    String.slice n n string
+    --> ""
+
+    String.slice 0 n string
+    --> String.left n string
+
+    String.slice n 0 string
+    --> ""
+
+    String.slice a z ""
+    --> ""
+
+    String.left 0 string
+    --> ""
+
+    String.left -1 string
+    --> ""
+
+    String.left n ""
+    --> ""
+
+    String.right 0 string
+    --> ""
+
+    String.right -1 string
+    --> ""
+
+    String.right n ""
+    --> ""
+
 
 ### Maybes
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2479,17 +2479,7 @@ getNotCall lookupTable baseNode =
 
 getNotFunction : ModuleNameLookupTable -> Node Expression -> Maybe Range
 getNotFunction lookupTable baseNode =
-    case AstHelpers.removeParens baseNode of
-        Node notRange (Expression.FunctionOrValue _ "not") ->
-            case ModuleNameLookupTable.moduleNameAt lookupTable notRange of
-                Just [ "Basics" ] ->
-                    Just notRange
-
-                _ ->
-                    Nothing
-
-        _ ->
-            Nothing
+    getSpecificFunction ( [ "Basics" ], "not" ) lookupTable baseNode
 
 
 getSpecificFunction : ( ModuleName, String ) -> ModuleNameLookupTable -> Node Expression -> Maybe Range

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4684,7 +4684,7 @@ a = String.concat list
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test """should replace String.concat [] by \"\"""" <|
+        , test "should replace String.concat [] by \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.concat []
@@ -4713,7 +4713,7 @@ a = String.join b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test """should replace String.join b [] by \"\"""" <|
+        , test "should replace String.join b [] by \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.join b []
@@ -4807,7 +4807,7 @@ a = String.repeat n ""
 a = ""
 """
                         ]
-        , test """should replace String.repeat 0 str by \"\"""" <|
+        , test "should replace String.repeat 0 str by \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.repeat 0 str
@@ -4839,7 +4839,7 @@ a = String.repeat 0
 a = (always "")
 """
                         ]
-        , test """should replace String.repeat -5 str by \"\"""" <|
+        , test "should replace String.repeat -5 str by \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.repeat -5 str
@@ -5075,7 +5075,7 @@ a = String.slice b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test """should replace String.slice b 0 by \"\"""" <|
+        , test "should replace String.slice b 0 by \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.slice b 0
@@ -5123,7 +5123,7 @@ a = String.slice a z ""
 a = ""
 """
                         ]
-        , test """should replace String.slice 0 by String.left""" <|
+        , test "should replace String.slice 0 by String.left" <|
             \() ->
                 """module A exposing (..)
 a = String.slice 0
@@ -5152,7 +5152,7 @@ a = String.left b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test """should replace String.left 0 by always \"\"""" <|
+        , test "should replace String.left 0 by always \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.left 0
@@ -5168,7 +5168,7 @@ a = String.left 0
 a = always ""
 """
                         ]
-        , test """should replace String.left -literal by always \"\"""" <|
+        , test "should replace String.left -literal by always \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.left -1
@@ -5213,7 +5213,7 @@ a = String.right b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test """should replace String.right 0 by \"\"""" <|
+        , test "should replace String.right 0 by \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.right 0
@@ -5229,7 +5229,7 @@ a = String.right 0
 a = always ""
 """
                         ]
-        , test """should replace String.right -literal by \"\"""" <|
+        , test "should replace String.right -literal by \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.right -1

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4623,6 +4623,8 @@ stringSimplificationTests =
         , stringLinesTests
         , stringReverseTests
         , stringSliceTests
+        , stringRightTests
+        , stringLeftTests
         ]
 
 
@@ -5167,6 +5169,128 @@ a = str |> String.slice 0 n
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = str |> String.left n
+"""
+                        ]
+        ]
+
+
+stringLeftTests : Test
+stringLeftTests =
+    describe "String.left"
+        [ test "should not report String.left that contains variables or expressions" <|
+            \() ->
+                """module A exposing (..)
+a = String.left b c
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test """should replace String.left 0 by \"\"""" <|
+            \() ->
+                """module A exposing (..)
+a = String.left 0
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.left with length 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.left"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
+        , test """should replace String.left -literal by \"\"""" <|
+            \() ->
+                """module A exposing (..)
+a = String.left -1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.left with negative length will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.left"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
+        , test "should replace String.left n \"\" by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.left n ""
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.left on an empty string will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.left"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
+        ]
+
+
+stringRightTests : Test
+stringRightTests =
+    describe "String.right"
+        [ test "should not report String.right that contains variables or expressions" <|
+            \() ->
+                """module A exposing (..)
+a = String.right b c
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test """should replace String.right 0 by \"\"""" <|
+            \() ->
+                """module A exposing (..)
+a = String.right 0
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.right with length 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.right"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
+        , test """should replace String.right -literal by \"\"""" <|
+            \() ->
+                """module A exposing (..)
+a = String.right -1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.right with negative length will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.right"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
+        , test "should replace String.right n \"\" by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.right n ""
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.right on an empty string will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.right"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5088,29 +5088,13 @@ a = String.slice b 0
                             , under = "String.slice"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ""
+a = always ""
 """
                         ]
-        , test "should replace String.slice n 0 str by \"\"" <|
+        , test "should replace String.slice n n by always \"\"" <|
             \() ->
                 """module A exposing (..)
-a = String.slice n 0 str
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Using String.slice with end index 0 will result in an empty string"
-                            , details = [ "You can replace this call by an empty string." ]
-                            , under = "String.slice"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = ""
-"""
-                        ]
-        , test "should replace String.slice n n str by \"\"" <|
-            \() ->
-                """module A exposing (..)
-a = String.slice n n str
+a = String.slice n n
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
@@ -5120,7 +5104,7 @@ a = String.slice n n str
                             , under = "String.slice"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ""
+a = always ""
 """
                         ]
         , test "should replace String.slice a z \"\" by \"\"" <|
@@ -5139,10 +5123,10 @@ a = String.slice a z ""
 a = ""
 """
                         ]
-        , test """should replace String.slice 0 n str by String.left n str""" <|
+        , test """should replace String.slice 0 by String.left""" <|
             \() ->
                 """module A exposing (..)
-a = String.slice 0 n str
+a = String.slice 0
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
@@ -5152,23 +5136,7 @@ a = String.slice 0 n str
                             , under = "String.slice"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = String.left n str
-"""
-                        ]
-        , test """should replace str |> String.slice 0 n by str |> String.left n""" <|
-            \() ->
-                """module A exposing (..)
-a = str |> String.slice 0 n
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Use String.left instead"
-                            , details = [ "Using String.slice with start index 0 is the same as using String.left." ]
-                            , under = "String.slice"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = str |> String.left n
+a = String.left
 """
                         ]
         ]
@@ -5184,7 +5152,7 @@ a = String.left b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test """should replace String.left 0 by \"\"""" <|
+        , test """should replace String.left 0 by always \"\"""" <|
             \() ->
                 """module A exposing (..)
 a = String.left 0
@@ -5197,10 +5165,10 @@ a = String.left 0
                             , under = "String.left"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ""
+a = always ""
 """
                         ]
-        , test """should replace String.left -literal by \"\"""" <|
+        , test """should replace String.left -literal by always \"\"""" <|
             \() ->
                 """module A exposing (..)
 a = String.left -1
@@ -5213,7 +5181,7 @@ a = String.left -1
                             , under = "String.left"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ""
+a = always ""
 """
                         ]
         , test "should replace String.left n \"\" by \"\"" <|
@@ -5258,7 +5226,7 @@ a = String.right 0
                             , under = "String.right"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ""
+a = always ""
 """
                         ]
         , test """should replace String.right -literal by \"\"""" <|
@@ -5274,7 +5242,7 @@ a = String.right -1
                             , under = "String.right"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ""
+a = always ""
 """
                         ]
         , test "should replace String.right n \"\" by \"\"" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5155,22 +5155,54 @@ a = String.slice 0 0
 a = always ""
 """
                         ]
-        , test "should replace String.slice literal literal by the computed slice" <|
+        , test "should replace String.slice with natural start >= natural end by always \"\"" <|
             \() ->
                 """module A exposing (..)
-a = String.slice 1 2 "abc"
+a = String.slice 2 1
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The call to String.slice will result in \"b\""
-                            , details = [ "You can replace this slice operation by \"b\"." ]
+                            { message = "The call to String.slice will result in \"\""
+                            , details = [ "You can replace this slice operation by \"\"." ]
                             , under = "String.slice"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = "b"
+a = always ""
 """
                         ]
+        , test "should replace String.slice with negative start >= negative end by always \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice -1 -2
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to String.slice will result in \"\""
+                            , details = [ "You can replace this slice operation by \"\"." ]
+                            , under = "String.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always ""
+"""
+                        ]
+        , test "should not report String.slice with negative start, natural end" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice -1 2
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        []
+        , test "should not report String.slice with natural start, negative end" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice 1 -2
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        []
         ]
 
 
@@ -5232,22 +5264,6 @@ a = String.left n ""
 a = ""
 """
                         ]
-        , test "should replace String.left literal literal by the computed substring" <|
-            \() ->
-                """module A exposing (..)
-a = String.left 2 "abc"
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "The call to String.left will result in \"ab\""
-                            , details = [ "You can replace this left operation by \"ab\"." ]
-                            , under = "String.left"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = "ab"
-"""
-                        ]
         ]
 
 
@@ -5307,22 +5323,6 @@ a = String.right n ""
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = ""
-"""
-                        ]
-        , test "should replace String.right literal literal by the computed substring" <|
-            \() ->
-                """module A exposing (..)
-a = String.right 2 "abc"
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "The call to String.right will result in \"bc\""
-                            , details = [ "You can replace this right operation by \"bc\"." ]
-                            , under = "String.right"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = "bc"
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4689,7 +4689,7 @@ a = String.concat []
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using String.concat on an empty list will result in a empty string"
+                            { message = "Using String.concat on an empty list will result in an empty string"
                             , details = [ "You can replace this call by an empty string." ]
                             , under = "String.concat"
                             }
@@ -4718,7 +4718,7 @@ a = String.join b []
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using String.join on an empty list will result in a empty string"
+                            { message = "Using String.join on an empty list will result in an empty string"
                             , details = [ "You can replace this call by an empty string." ]
                             , under = "String.join"
                             }
@@ -4796,7 +4796,7 @@ a = String.repeat n ""
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using String.repeat with an empty string will result in a empty string"
+                            { message = "Using String.repeat with an empty string will result in an empty string"
                             , details = [ "You can replace this call by an empty string." ]
                             , under = "String.repeat"
                             }
@@ -5035,7 +5035,7 @@ a = String.reverse ""
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using String.reverse on an empty string will result in a empty string"
+                            { message = "Using String.reverse on an empty string will result in an empty string"
                             , details = [ "You can replace this call by an empty string." ]
                             , under = "String.reverse"
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4336,7 +4336,7 @@ a =
 appliedLambdaTests : Test
 appliedLambdaTests =
     describe "Applied lambda functions"
-        [ test "should not report a okay function/lambda calls" <|
+        [ test "should not report okay function/lambda calls" <|
             \() ->
                 """
 module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5075,7 +5075,7 @@ a = String.slice b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test "should replace String.slice b 0 by \"\"" <|
+        , test "should replace String.slice b 0 by always \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.slice b 0
@@ -5139,6 +5139,38 @@ a = String.slice 0
 a = String.left
 """
                         ]
+        , test "should replace String.slice 0 0 by always \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice 0 0
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.slice with end index 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always ""
+"""
+                        ]
+        , test "should replace String.slice literal literal by the computed slice" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice 1 2 "abc"
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to String.slice will result in \"b\""
+                            , details = [ "You can replace this slice operation by \"b\"." ]
+                            , under = "String.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = "b"
+"""
+                        ]
         ]
 
 
@@ -5200,6 +5232,22 @@ a = String.left n ""
 a = ""
 """
                         ]
+        , test "should replace String.left literal literal by the computed substring" <|
+            \() ->
+                """module A exposing (..)
+a = String.left 2 "abc"
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to String.left will result in \"ab\""
+                            , details = [ "You can replace this left operation by \"ab\"." ]
+                            , under = "String.left"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = "ab"
+"""
+                        ]
         ]
 
 
@@ -5259,6 +5307,22 @@ a = String.right n ""
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = ""
+"""
+                        ]
+        , test "should replace String.right literal literal by the computed substring" <|
+            \() ->
+                """module A exposing (..)
+a = String.right 2 "abc"
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to String.right will result in \"bc\""
+                            , details = [ "You can replace this right operation by \"bc\"." ]
+                            , under = "String.right"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = "bc"
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5121,6 +5121,22 @@ a = String.slice n n str
 a = ""
 """
                         ]
+        , test "should replace String.slice a z \"\" by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice a z ""
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.slice on an empty string will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
         , test """should replace String.slice 0 n str by String.left n str""" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
Adds `String` simplifications (and tests) suggested in #2
```elm
String.slice n n string
--> ""

String.slice 0 n string
--> String.left n string

String.slice n 0 string
--> ""

String.slice a z ""
--> ""

String.left 0 string
--> ""

String.left -1 string
--> ""

String.left n ""
--> ""

String.right 0 string
--> ""

String.right -1 string
--> ""

String.right n ""
--> ""

String.slice 1 2 "abc"
--> "b"

String.left 2 "abc"
--> "ab"

String.right 2 "abc"
--> "bc"
```
There rest is minor changes like "a empty" → "an empty"