### PR TITLE
Avoid using always when we can replace directly by the value

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3910,13 +3910,7 @@ listTakeChecks { lookupTable, parentRange, fnRange, firstArg, secondArg } =
             , details = [ "You can replace this call by []." ]
             }
             fnRange
-            (case secondArg of
-                Just _ ->
-                    [ Fix.replaceRangeBy parentRange "[]" ]
-
-                Nothing ->
-                    [ Fix.replaceRangeBy parentRange "(always [])" ]
-            )
+            (replaceByEmptyFix "[]" parentRange secondArg)
         ]
 
     else
@@ -5443,7 +5437,7 @@ replaceByEmptyFix empty parentRange secondArg =
             Fix.replaceRangeBy parentRange empty
 
         Nothing ->
-            Fix.replaceRangeBy parentRange ("(always " ++ empty ++ ")")
+            Fix.replaceRangeBy parentRange ("always " ++ empty)
     ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3035,28 +3035,22 @@ stringRightChecks checkInfo =
                 [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
             ]
 
-        ( Node lengthArgumentRange (Expression.Integer 0), _ ) ->
+        ( Node _ (Expression.Integer 0), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.right with length 0 will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy
-                    { start = checkInfo.parentRange.start, end = lengthArgumentRange.end }
-                    "always \"\""
-                ]
+                (replaceByEmptyFix emptyStringAsString checkInfo.parentRange checkInfo.secondArg)
             ]
 
-        ( Node _ (Expression.Negation (Node lengthArgumentRange (Expression.Integer _))), _ ) ->
+        ( Node _ (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.right with negative length will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy
-                    { start = checkInfo.parentRange.start, end = lengthArgumentRange.end }
-                    "always \"\""
-                ]
+                (replaceByEmptyFix emptyStringAsString checkInfo.parentRange checkInfo.secondArg)
             ]
 
         _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2920,19 +2920,16 @@ stringSliceChecks checkInfo =
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
+                (replaceByEmptyFix emptyStringAsString checkInfo.parentRange checkInfo.thirdArg)
             ]
 
-        ( _, Just (Node endArgumentRange (Expression.Integer 0)), _ ) ->
+        ( _, Just (Node _ (Expression.Integer 0)), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.slice with end index 0 will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy
-                    { start = checkInfo.fnRange.start, end = endArgumentRange.end }
-                    "always \"\""
-                ]
+                (replaceByEmptyFix emptyStringAsString checkInfo.parentRange checkInfo.thirdArg)
             ]
 
         ( Node startArgumentRange (Expression.Integer 0), _, _ ) ->
@@ -2962,10 +2959,7 @@ stringSliceChecks checkInfo =
                             , details = [ "You can replace this slice operation by \"\"." ]
                             }
                             checkInfo.fnRange
-                            [ Fix.replaceRangeBy
-                                { start = checkInfo.parentRange.start, end = (Node.range end).end }
-                                "always \"\""
-                            ]
+                            (replaceByEmptyFix emptyStringAsString checkInfo.parentRange checkInfo.thirdArg)
                         ]
                             |> Just
 
@@ -2982,10 +2976,7 @@ stringSliceChecks checkInfo =
                             , details = [ "You can replace this call by an empty string." ]
                             }
                             checkInfo.fnRange
-                            [ Fix.replaceRangeBy
-                                { start = checkInfo.parentRange.start, end = (Node.range end).end }
-                                "always \"\""
-                            ]
+                            (replaceByEmptyFix emptyStringAsString checkInfo.parentRange checkInfo.thirdArg)
                         ]
                             |> Just
 
@@ -3010,28 +3001,22 @@ stringLeftChecks checkInfo =
                 [ Fix.replaceRangeBy checkInfo.parentRange "\"\"" ]
             ]
 
-        ( Node lengthArgumentRange (Expression.Integer 0), _ ) ->
+        ( Node _ (Expression.Integer 0), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.left with length 0 will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy
-                    { start = checkInfo.parentRange.start, end = lengthArgumentRange.end }
-                    "always \"\""
-                ]
+                (replaceByEmptyFix emptyStringAsString checkInfo.parentRange checkInfo.secondArg)
             ]
 
-        ( Node lengthArgumentRange (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
+        ( Node _ (Expression.Negation (Node _ (Expression.Integer _))), _ ) ->
             [ Rule.errorWithFix
                 { message = "Using String.left with negative length will result in an empty string"
                 , details = [ "You can replace this call by an empty string." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy
-                    { start = checkInfo.parentRange.start, end = lengthArgumentRange.end }
-                    "always \"\""
-                ]
+                (replaceByEmptyFix emptyStringAsString checkInfo.parentRange checkInfo.secondArg)
             ]
 
         _ ->
@@ -3158,7 +3143,7 @@ stringRepeatChecks ({ parentRange, fnRange, firstArg, secondArg } as checkInfo) 
                             , details = [ "Using String.repeat with a number less than 1 will result in an empty string. You can replace this call by an empty string." ]
                             }
                             fnRange
-                            (replaceByEmptyFix "\"\"" parentRange secondArg)
+                            (replaceByEmptyFix emptyStringAsString parentRange secondArg)
                         ]
 
                     else
@@ -5439,6 +5424,11 @@ replaceByEmptyFix empty parentRange secondArg =
         Nothing ->
             Fix.replaceRangeBy parentRange ("always " ++ empty)
     ]
+
+
+emptyStringAsString : String
+emptyStringAsString =
+    "\"\""
 
 
 replaceByBoolFix : Range -> Maybe a -> Bool -> List Fix

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5341,7 +5341,23 @@ a = String.right b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test "should replace String.right 0 by \"\"" <|
+        , test "should replace String.right 0 str by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.right 0 str
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.right with length 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.right"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
+        , test "should replace String.right 0 by always \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.right 0
@@ -5357,7 +5373,23 @@ a = String.right 0
 a = always ""
 """
                         ]
-        , test "should replace String.right -literal by \"\"" <|
+        , test "should replace String.right -literal str by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.right -1 str
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.right with negative length will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.right"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
+        , test "should replace String.right -literal by always \"\"" <|
             \() ->
                 """module A exposing (..)
 a = String.right -1

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4836,7 +4836,7 @@ a = String.repeat 0
                             , under = "String.repeat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always "")
+a = always ""
 """
                         ]
         , test "should replace String.repeat -5 str by \"\"" <|
@@ -5672,7 +5672,7 @@ a = List.concatMap (always [])
                             , under = "List.concatMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         , test "should replace List.concatMap (\\_ -> [a]) x by List.map (\\_ -> a) x" <|
@@ -6220,7 +6220,7 @@ a = List.filter (always False)
                             , under = "List.filter"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         , test "should replace List.filter <| (always False) by always []" <|
@@ -6236,7 +6236,7 @@ a = List.filter <| (always False)
                             , under = "List.filter"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         , test "should replace always False |> List.filter by always []" <|
@@ -6252,7 +6252,7 @@ a = always False |> List.filter
                             , under = "List.filter"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         ]
@@ -6377,7 +6377,7 @@ a = List.filterMap (always Nothing)
                             , under = "List.filterMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         , test "should replace List.filterMap <| always Nothing by always []" <|
@@ -6393,7 +6393,7 @@ a = List.filterMap <| always Nothing
                             , under = "List.filterMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         , test "should replace always Nothing |> List.filterMap by always []" <|
@@ -6409,7 +6409,7 @@ a = always Nothing |> List.filterMap
                             , under = "List.filterMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         , test "should replace List.filterMap Just x by x" <|
@@ -7158,7 +7158,7 @@ a = List.repeat 0
                             , under = "List.repeat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         , test "should replace List.repeat -5 list by []" <|
@@ -7289,7 +7289,7 @@ a = List.take 0
                             , under = "List.take"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always [])
+a = always []
 """
                         ]
         ]
@@ -9161,7 +9161,7 @@ a = Set.filter (always False)
                             , under = "Set.filter"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always Set.empty)
+a = always Set.empty
 """
                         ]
         , test "should replace Set.filter <| (always False) by always Set.empty" <|
@@ -9177,7 +9177,7 @@ a = Set.filter <| (always False)
                             , under = "Set.filter"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always Set.empty)
+a = always Set.empty
 """
                         ]
         , test "should replace always False |> Set.filter by always Set.empty" <|
@@ -9193,7 +9193,7 @@ a = always False |> Set.filter
                             , under = "Set.filter"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (always Set.empty)
+a = always Set.empty
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5091,6 +5091,22 @@ a = String.slice b 0
 a = always ""
 """
                         ]
+        , test "should replace String.slice b 0 str by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice b 0 str
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.slice with end index 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
         , test "should replace String.slice n n by always \"\"" <|
             \() ->
                 """module A exposing (..)
@@ -5105,6 +5121,22 @@ a = String.slice n n
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = always ""
+"""
+                        ]
+        , test "should replace String.slice n n str by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice n n str
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.slice with equal start and end index will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
 """
                         ]
         , test "should replace String.slice a z \"\" by \"\"" <|
@@ -5153,6 +5185,22 @@ a = String.slice 0 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = always ""
+"""
+                        ]
+        , test "should replace String.slice 0 0 str by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice 0 0 str
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.slice with end index 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
 """
                         ]
         , test "should replace String.slice with natural start >= natural end by always \"\"" <|
@@ -5216,6 +5264,22 @@ a = String.left b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
+        , test "should replace String.left 0 str by \"\"" <|
+            \() ->
+                """module A exposing (..)
+a = String.left 0 str
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using String.left with length 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            , under = "String.left"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ""
+"""
+                        ]
         , test "should replace String.left 0 by always \"\"" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
The idea is to have
```elm
String.slice 1 1 str
```
replaced by
```elm
""
```
instead of by
```elm
always "" str
```
and the same for similar replacements done in #55. The rule would eventually end up being `""` but this removes some step and eventual confusion for a user running single fixes at a time.

Can be reviewed commit by commit

cc @lue-bird if you'd like to review :smile: (no pressure!)