### PR TITLE
`List.fold l,r` checks added

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -513,6 +513,9 @@ Destructuring using case expressions
     List.foldl (*) 1 list
     --> List.product list
 
+    List.foldl (*) 0 list
+    --> 0
+
     List.foldl (*) initial list
     --> initial + List.product list
 
@@ -542,6 +545,9 @@ Destructuring using case expressions
 
     List.foldr (*) initial list
     --> initial + List.product list
+
+    List.foldr (*) 0 list
+    --> 0
 
     List.foldr (&&) True list
     --> List.all identity list
@@ -3860,7 +3866,18 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                 numberBinaryOperationChecks { two = "+", list = "sum", identity = 0 }
 
             else if isBinaryOperation "*" checkInfo checkInfo.firstArg then
-                numberBinaryOperationChecks { two = "*", list = "product", identity = 1 }
+                if getUncomputedNumberValue initialArgument == Just 0 then
+                    [ Rule.errorWithFix
+                        { message = "The call to List." ++ foldOperationName ++ " (*) 0 will result in 0."
+                        , details = [ "You can replace this call by 0." ]
+                        }
+                        checkInfo.fnRange
+                        (replaceByEmptyFix "0" checkInfo.parentRange checkInfo.thirdArg)
+                    ]
+
+                else
+                    -- getUncomputedNumberValue initialArgument /= Just 0
+                    numberBinaryOperationChecks { two = "*", list = "product", identity = 1 }
 
             else if isBinaryOperation "&&" checkInfo checkInfo.firstArg then
                 boolBinaryOperationChecks { two = "&&", list = "all", determining = False }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3737,9 +3737,9 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                 }
                 checkInfo.fnRange
                 [ Fix.removeRange
-                    { start = initialArgumentRange.end, end = checkInfo.parentRange.end }
-                , Fix.removeRange
                     { start = checkInfo.parentRange.start, end = initialArgumentRange.start }
+                , Fix.removeRange
+                    { start = initialArgumentRange.end, end = checkInfo.parentRange.end }
                 ]
             ]
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -507,11 +507,11 @@ Destructuring using case expressions
     List.foldl 0 (+) list
     --> List.sum list
 
-    List.foldl 1 (*) list
-    --> List.product list
-
     List.foldl initial (+) list
     --> initial + List.sum list
+
+    List.foldl 1 (*) list
+    --> List.product list
 
     List.foldl initial (*) list
     --> initial + List.product list
@@ -521,6 +521,12 @@ Destructuring using case expressions
 
     List.foldl False (&&) list
     --> False
+
+    List.foldl False (||) list
+    --> List.any identity list
+
+    List.foldl True (||) list
+    --> True
 
     List.foldl fn x []
     --> x
@@ -534,11 +540,11 @@ Destructuring using case expressions
     List.foldr 0 (+) list
     --> List.sum list
 
-    List.foldr 1 (*) list
-    --> List.product list
-
     List.foldr initial (+) list
     --> initial + List.sum list
+
+    List.foldr 1 (*) list
+    --> initial + List.product list
 
     List.foldr initial (*) list
     --> initial + List.product list
@@ -548,6 +554,12 @@ Destructuring using case expressions
 
     List.foldr False (&&) list
     --> False
+
+    List.foldr False (||) list
+    --> List.any identity list
+
+    List.foldr True (||) list
+    --> True
 
     List.foldr fn x []
     --> x

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3868,39 +3868,36 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                                        Maybe.andThen
                                         (\alwaysResult ->
                                             if isIdentity checkInfo.lookupTable alwaysResult then
-                                                Just ()
+                                                Just
+                                                    [ Rule.errorWithFix
+                                                        { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
+                                                        , details = [ "You can replace this call by the initial accumulator." ]
+                                                        }
+                                                        checkInfo.fnRange
+                                                        (case checkInfo.thirdArg of
+                                                            Nothing ->
+                                                                [ Fix.replaceRangeBy
+                                                                    { start = checkInfo.parentRange.start
+                                                                    , end = (Node.range checkInfo.firstArg).end
+                                                                    }
+                                                                    "always"
+                                                                ]
+
+                                                            Just _ ->
+                                                                [ Fix.removeRange
+                                                                    { start = (Node.range initialArgument).end
+                                                                    , end = checkInfo.parentRange.end
+                                                                    }
+                                                                , Fix.removeRange
+                                                                    { start = checkInfo.parentRange.start
+                                                                    , end = (Node.range initialArgument).start
+                                                                    }
+                                                                ]
+                                                        )
+                                                    ]
 
                                             else
                                                 Nothing
-                                        )
-                                    |> Maybe.map
-                                        (\() ->
-                                            [ Rule.errorWithFix
-                                                { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
-                                                , details = [ "You can replace this call by the initial accumulator." ]
-                                                }
-                                                checkInfo.fnRange
-                                                (case checkInfo.thirdArg of
-                                                    Nothing ->
-                                                        [ Fix.replaceRangeBy
-                                                            { start = checkInfo.parentRange.start
-                                                            , end = (Node.range checkInfo.firstArg).end
-                                                            }
-                                                            "always"
-                                                        ]
-
-                                                    Just _ ->
-                                                        [ Fix.removeRange
-                                                            { start = (Node.range initialArgument).end
-                                                            , end = checkInfo.parentRange.end
-                                                            }
-                                                        , Fix.removeRange
-                                                            { start = checkInfo.parentRange.start
-                                                            , end = (Node.range initialArgument).start
-                                                            }
-                                                        ]
-                                                )
-                                            ]
                                         )
                                 )
             )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -544,7 +544,7 @@ Destructuring using case expressions
     --> initial + List.sum list
 
     List.foldr 1 (*) list
-    --> initial + List.product list
+    --> List.product list
 
     List.foldr initial (*) list
     --> initial + List.product list

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -501,6 +501,7 @@ Destructuring using case expressions
     List.isEmpty (x :: xs)
     --> False
 
+    -- The following simplifications for List.foldl also work for List.foldr
     List.foldl reduce initial []
     --> initial
 
@@ -535,36 +536,6 @@ Destructuring using case expressions
     --> x
 
     List.foldl (\_ soFar -> soFar) x list
-    --> x
-
-    List.foldr reduce initial []
-    --> initial
-
-    List.foldr (+) initial list
-    --> initial + List.sum list
-
-    List.foldr (*) initial list
-    --> initial + List.product list
-
-    List.foldr (*) 0 list
-    --> 0
-
-    List.foldr (&&) True list
-    --> List.all identity list
-
-    List.foldr (&&) False list
-    --> False
-
-    List.foldr (||) False list
-    --> List.any identity list
-
-    List.foldr (||) True list
-    --> True
-
-    List.foldr fn x []
-    --> x
-
-    List.foldr (\_ soFar -> soFar) x list
     --> x
 
     List.all fn []

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -504,67 +504,61 @@ Destructuring using case expressions
     List.foldl reduce initial []
     --> initial
 
-    List.foldl 0 (+) list
+    List.foldl (+) 0 list
     --> List.sum list
 
-    List.foldl initial (+) list
+    List.foldl (+) initial list
     --> initial + List.sum list
 
-    List.foldl 1 (*) list
+    List.foldl (*) 1 list
     --> List.product list
 
-    List.foldl initial (*) list
+    List.foldl (*) initial list
     --> initial + List.product list
 
-    List.foldl True (&&) list
+    List.foldl (&&) True list
     --> List.all identity list
 
-    List.foldl False (&&) list
+    List.foldl (&&) False list
     --> False
 
-    List.foldl False (||) list
+    List.foldl (||) False list
     --> List.any identity list
 
-    List.foldl True (||) list
+    List.foldl (||) True list
     --> True
 
     List.foldl fn x []
     --> x
 
-    List.foldl (always identity) x list
+    List.foldl (\_ soFar -> soFar) x list
     --> x
 
     List.foldr reduce initial []
     --> initial
 
-    List.foldr 0 (+) list
-    --> List.sum list
-
-    List.foldr initial (+) list
+    List.foldr (+) initial list
     --> initial + List.sum list
 
-    List.foldr 1 (*) list
-    --> List.product list
-
-    List.foldr initial (*) list
+    List.foldr (*) initial list
     --> initial + List.product list
 
-    List.foldr True (&&) list
+    List.foldr (&&) True list
     --> List.all identity list
 
-    List.foldr False (&&) list
+    List.foldr (&&) False list
     --> False
 
-    List.foldr False (||) list
+    List.foldr (||) False list
     --> List.any identity list
 
-    List.foldr True (||) list
+    List.foldr (||) True list
     --> True
 
     List.foldr fn x []
     --> x
 
-    List.foldr (always identity) x list
+    List.foldr (\_ soFar -> soFar) x list
     --> x
 
     List.all fn []

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -694,8 +694,8 @@ import Review.ModuleNameLookupTable as ModuleNameLookupTable exposing (ModuleNam
 import Review.Project.Dependency as Dependency exposing (Dependency)
 import Review.Rule as Rule exposing (Error, Rule)
 import Set exposing (Set)
-import Simplify.AstHelpers as AstHelpers exposing (removeParens)
-import Simplify.Evaluate as Evaluate exposing (getBoolean)
+import Simplify.AstHelpers as AstHelpers
+import Simplify.Evaluate as Evaluate
 import Simplify.Infer as Infer
 import Simplify.Match as Match exposing (Match(..))
 import Simplify.Normalize as Normalize
@@ -3810,7 +3810,7 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                             Just (numberBinaryOperationChecks { two = "*", list = "product" })
 
                         else if isBinaryOperation "&&" checkInfo checkInfo.firstArg then
-                            Match.toDetermined (getBoolean checkInfo initialArgument)
+                            Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
                                 |> Maybe.map
                                     (\initialIsTrue ->
                                         if not initialIsTrue then
@@ -3837,7 +3837,7 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                                     )
 
                         else if isBinaryOperation "||" checkInfo checkInfo.firstArg then
-                            Match.toDetermined (getBoolean checkInfo initialArgument)
+                            Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
                                 |> Maybe.map
                                     (\initialIsTrue ->
                                         if initialIsTrue then
@@ -5854,7 +5854,7 @@ getBooleanPattern lookupTable node =
 
 getAlwaysResult : Infer.Resources a -> Node Expression -> Maybe (Node Expression)
 getAlwaysResult inferResources expressionNode =
-    case Node.value (removeParens expressionNode) of
+    case Node.value (AstHelpers.removeParens expressionNode) of
         Expression.Application ((Node alwaysRange (Expression.FunctionOrValue _ "always")) :: result :: []) ->
             case ModuleNameLookupTable.moduleNameAt inferResources.lookupTable alwaysRange of
                 Just [ "Basics" ] ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3729,171 +3729,160 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
     -- List.fold f x [ a ] --> f (a) x
     --     @jfmengels' comment: potentially quite ugly
     --     I'd say it looks fine
-    case ( checkInfo.secondArg, checkInfo.thirdArg ) of
-        ( Just (Node initialArgumentRange _), Just (Node _ (Expression.ListExpr [])) ) ->
-            [ Rule.errorWithFix
-                { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
-                , details = [ "You can replace this call by the initial accumulator." ]
-                }
-                checkInfo.fnRange
-                [ Fix.removeRange
-                    { start = checkInfo.parentRange.start, end = initialArgumentRange.start }
-                , Fix.removeRange
-                    { start = initialArgumentRange.end, end = checkInfo.parentRange.end }
-                ]
-            ]
+    case checkInfo.secondArg of
+        Just initialArgument ->
+            case checkInfo.thirdArg of
+                Just (Node _ (Expression.ListExpr [])) ->
+                    [ Rule.errorWithFix
+                        { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
+                        , details = [ "You can replace this call by the initial accumulator." ]
+                        }
+                        checkInfo.fnRange
+                        [ Fix.removeRange
+                            { start = checkInfo.parentRange.start, end = (Node.range initialArgument).start }
+                        , Fix.removeRange
+                            { start = (Node.range initialArgument).end, end = checkInfo.parentRange.end }
+                        ]
+                    ]
 
-        _ ->
-            checkInfo.secondArg
-                -- when there's no initial accumulator,
-                -- we could fix to like \init -> List.sum >> (+) init
-                --     but we would then have to check for argument name clashes etc.
-                -- a point-free alternative is (>>) List.sum << (+)
-                --     but don't expect anyone to call this as simpler (except hayleigh)
-                |> Maybe.andThen
-                    (\initialArgument ->
-                        let
-                            numberBinaryOperationChecks : { identity : Int, two : String, list : String } -> Maybe (List (Error {}))
-                            numberBinaryOperationChecks operation =
-                                Maybe.map
-                                    (\fixes ->
+                _ ->
+                    let
+                        numberBinaryOperationChecks : { identity : Int, two : String, list : String } -> Maybe (List (Error {}))
+                        numberBinaryOperationChecks operation =
+                            Maybe.map
+                                (\fixes ->
+                                    [ Rule.errorWithFix
+                                        { message = "Use List." ++ operation.list ++ " instead"
+                                        , details =
+                                            [ "Using List." ++ foldOperationName ++ " (" ++ operation.two ++ ") " ++ String.fromInt operation.identity ++ " is the same as using List." ++ operation.list ++ "." ]
+                                        }
+                                        checkInfo.fnRange
+                                        fixes
+                                    ]
+                                )
+                                (if getUncomputedNumberValue initialArgument == Just (Basics.toFloat operation.identity) then
+                                    Just
+                                        [ Fix.replaceRangeBy
+                                            { start = checkInfo.parentRange.start
+                                            , end = (Node.range initialArgument).end
+                                            }
+                                            ("List." ++ operation.list)
+                                        ]
+
+                                 else
+                                    checkInfo.thirdArg
+                                        |> Maybe.map
+                                            (\_ ->
+                                                if checkInfo.usingRightPizza then
+                                                    -- list |> fold op initial --> ((list |> List.op) op initial)
+                                                    [ Fix.insertAt (Node.range initialArgument).end ")"
+                                                    , Fix.insertAt (Node.range initialArgument).start (operation.two ++ " ")
+                                                    , Fix.replaceRangeBy
+                                                        { start = checkInfo.fnRange.start
+                                                        , end = (Node.range checkInfo.firstArg).end
+                                                        }
+                                                        ("List." ++ operation.list ++ ")")
+                                                    , Fix.insertAt checkInfo.parentRange.start "(("
+                                                    ]
+
+                                                else
+                                                    -- <| or application
+                                                    -- fold op initial list --> (initial op (List.op list))
+                                                    [ Fix.insertAt checkInfo.parentRange.end ")"
+                                                    , Fix.insertAt (Node.range initialArgument).end
+                                                        (" " ++ operation.two ++ " (List." ++ operation.list)
+                                                    , Fix.removeRange
+                                                        { start = checkInfo.parentRange.start
+                                                        , end = (Node.range initialArgument).start
+                                                        }
+                                                    ]
+                                            )
+                                )
+                    in
+                    (if isBinaryOperation "+" checkInfo checkInfo.firstArg then
+                        numberBinaryOperationChecks { identity = 0, two = "+", list = "sum" }
+
+                     else if isBinaryOperation "*" checkInfo checkInfo.firstArg then
+                        numberBinaryOperationChecks { identity = 1, two = "*", list = "product" }
+
+                     else if isBinaryOperation "&&" checkInfo checkInfo.firstArg then
+                        Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
+                            |> Maybe.map
+                                (\initialIsTrue ->
+                                    if not initialIsTrue then
                                         [ Rule.errorWithFix
-                                            { message = "Use List." ++ operation.list ++ " instead"
-                                            , details =
-                                                [ "Using List." ++ foldOperationName ++ " (" ++ operation.two ++ ") " ++ String.fromInt operation.identity ++ " is the same as using List." ++ operation.list ++ "." ]
+                                            { message = "The call to List." ++ foldOperationName ++ " will result in False"
+                                            , details = [ "You can replace this call by False." ]
                                             }
                                             checkInfo.fnRange
-                                            fixes
+                                            (replaceByEmptyFix "False" checkInfo.parentRange checkInfo.thirdArg)
                                         ]
-                                    )
-                                    (if getUncomputedNumberValue initialArgument == Just (Basics.toFloat operation.identity) then
-                                        Just
+
+                                    else
+                                        -- initialIsTrue
+                                        [ Rule.errorWithFix
+                                            { message = "Use List.all identity instead"
+                                            , details = [ "Using List." ++ foldOperationName ++ " (&&) True is the same as using List.all identity." ]
+                                            }
+                                            checkInfo.fnRange
                                             [ Fix.replaceRangeBy
-                                                { start = checkInfo.parentRange.start
-                                                , end = (Node.range initialArgument).end
-                                                }
-                                                ("List." ++ operation.list)
+                                                { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
+                                                "List.all identity"
                                             ]
+                                        ]
+                                )
 
-                                     else
-                                        checkInfo.thirdArg
-                                            |> Maybe.map
-                                                (\_ ->
-                                                    if checkInfo.usingRightPizza then
-                                                        -- list |> fold op initial --> ((list |> List.op) op initial)
-                                                        [ Fix.insertAt (Node.range initialArgument).end ")"
-                                                        , Fix.insertAt (Node.range initialArgument).start (operation.two ++ " ")
-                                                        , Fix.replaceRangeBy
-                                                            { start = checkInfo.fnRange.start
-                                                            , end = (Node.range checkInfo.firstArg).end
-                                                            }
-                                                            ("List." ++ operation.list ++ ")")
-                                                        , Fix.insertAt checkInfo.parentRange.start "(("
-                                                        ]
+                     else if isBinaryOperation "||" checkInfo checkInfo.firstArg then
+                        Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
+                            |> Maybe.map
+                                (\initialIsTrue ->
+                                    if initialIsTrue then
+                                        [ Rule.errorWithFix
+                                            { message = "The call to List." ++ foldOperationName ++ " will result in True"
+                                            , details = [ "You can replace this call by True." ]
+                                            }
+                                            checkInfo.fnRange
+                                            (replaceByEmptyFix "True" checkInfo.parentRange checkInfo.thirdArg)
+                                        ]
 
-                                                    else
-                                                        -- <| or application
-                                                        -- fold op initial list --> (initial op (List.op list))
-                                                        [ Fix.insertAt checkInfo.parentRange.end ")"
-                                                        , Fix.insertAt (Node.range initialArgument).end
-                                                            (" " ++ operation.two ++ " (List." ++ operation.list)
-                                                        , Fix.removeRange
-                                                            { start = checkInfo.parentRange.start
-                                                            , end = (Node.range initialArgument).start
-                                                            }
-                                                        ]
-                                                )
-                                    )
-                        in
-                        if isBinaryOperation "+" checkInfo checkInfo.firstArg then
-                            numberBinaryOperationChecks { identity = 0, two = "+", list = "sum" }
-
-                        else if isBinaryOperation "*" checkInfo checkInfo.firstArg then
-                            numberBinaryOperationChecks { identity = 1, two = "*", list = "product" }
-
-                        else if isBinaryOperation "&&" checkInfo checkInfo.firstArg then
-                            Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
-                                |> Maybe.map
-                                    (\initialIsTrue ->
-                                        if not initialIsTrue then
-                                            [ Rule.errorWithFix
-                                                { message = "The call to List." ++ foldOperationName ++ " will result in False"
-                                                , details = [ "You can replace this call by False." ]
-                                                }
-                                                checkInfo.fnRange
-                                                (replaceByEmptyFix "False" checkInfo.parentRange checkInfo.thirdArg)
+                                    else
+                                        -- not initialIsTrue
+                                        [ Rule.errorWithFix
+                                            { message = "Use List.any identity instead"
+                                            , details = [ "Using List." ++ foldOperationName ++ " (||) False is the same as using List.any identity." ]
+                                            }
+                                            checkInfo.fnRange
+                                            [ Fix.replaceRangeBy
+                                                { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
+                                                "List.any identity"
                                             ]
+                                        ]
+                                )
 
-                                        else
-                                            -- initialIsTrue
-                                            [ Rule.errorWithFix
-                                                { message = "Use List.all identity instead"
-                                                , details = [ "Using List." ++ foldOperationName ++ " (&&) True is the same as using List.all identity." ]
-                                                }
-                                                checkInfo.fnRange
-                                                [ Fix.replaceRangeBy
-                                                    { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
-                                                    "List.all identity"
-                                                ]
-                                            ]
-                                    )
-
-                        else if isBinaryOperation "||" checkInfo checkInfo.firstArg then
-                            Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
-                                |> Maybe.map
-                                    (\initialIsTrue ->
-                                        if initialIsTrue then
-                                            [ Rule.errorWithFix
-                                                { message = "The call to List." ++ foldOperationName ++ " will result in True"
-                                                , details = [ "You can replace this call by True." ]
-                                                }
-                                                checkInfo.fnRange
-                                                (replaceByEmptyFix "True" checkInfo.parentRange checkInfo.thirdArg)
-                                            ]
-
-                                        else
-                                            -- not initialIsTrue
-                                            [ Rule.errorWithFix
-                                                { message = "Use List.any identity instead"
-                                                , details = [ "Using List." ++ foldOperationName ++ " (||) False is the same as using List.any identity." ]
-                                                }
-                                                checkInfo.fnRange
-                                                [ Fix.replaceRangeBy
-                                                    { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
-                                                    "List.any identity"
-                                                ]
-                                            ]
-                                    )
-
-                        else
-                            Nothing
+                     else
+                        Nothing
                     )
-                -- orElse
-                |> Maybe.map Just
-                |> Maybe.withDefault
-                    (getAlwaysResult checkInfo checkInfo.firstArg
-                        |> -- filter
-                           Maybe.andThen
-                            (\alwaysResult ->
-                                if isIdentity checkInfo.lookupTable alwaysResult then
-                                    Just ()
+                        -- orElse
+                        |> Maybe.map Just
+                        |> Maybe.withDefault
+                            (getAlwaysResult checkInfo checkInfo.firstArg
+                                |> -- filter
+                                   Maybe.andThen
+                                    (\alwaysResult ->
+                                        if isIdentity checkInfo.lookupTable alwaysResult then
+                                            Just ()
 
-                                else
-                                    Nothing
-                            )
-                        |> Maybe.map
-                            (\() ->
-                                [ Rule.errorWithFix
-                                    { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
-                                    , details = [ "You can replace this call by the initial accumulator." ]
-                                    }
-                                    checkInfo.fnRange
-                                    (case checkInfo.secondArg of
-                                        Nothing ->
-                                            [ Fix.replaceRangeBy checkInfo.parentRange "(always >> identity)" ]
-
-                                        Just (Node initialArgumentRange _) ->
-                                            case checkInfo.thirdArg of
+                                        else
+                                            Nothing
+                                    )
+                                |> Maybe.map
+                                    (\() ->
+                                        [ Rule.errorWithFix
+                                            { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
+                                            , details = [ "You can replace this call by the initial accumulator." ]
+                                            }
+                                            checkInfo.fnRange
+                                            (case checkInfo.thirdArg of
                                                 Nothing ->
                                                     [ Fix.replaceRangeBy
                                                         { start = checkInfo.parentRange.start
@@ -3904,19 +3893,22 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
 
                                                 Just _ ->
                                                     [ Fix.removeRange
-                                                        { start = initialArgumentRange.end
+                                                        { start = (Node.range initialArgument).end
                                                         , end = checkInfo.parentRange.end
                                                         }
                                                     , Fix.removeRange
                                                         { start = checkInfo.parentRange.start
-                                                        , end = initialArgumentRange.start
+                                                        , end = (Node.range initialArgument).start
                                                         }
                                                     ]
+                                            )
+                                        ]
                                     )
-                                ]
                             )
-                    )
-                |> Maybe.withDefault []
+                        |> Maybe.withDefault []
+
+        _ ->
+            []
 
 
 listAllChecks : CheckInfo -> List (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3725,10 +3725,6 @@ listFoldrChecks checkInfo =
 
 listFoldAnyDirectionChecks : String -> CheckInfo -> List (Error {})
 listFoldAnyDirectionChecks foldOperationName checkInfo =
-    -- TODO discuss adding
-    -- List.fold f x [ a ] --> f (a) x
-    --     @jfmengels' comment: potentially quite ugly
-    --     I'd say it looks fine
     case checkInfo.secondArg of
         Just initialArgument ->
             case checkInfo.thirdArg of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3781,125 +3781,123 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                                         )
                             )
                 in
-                case checkInfo.thirdArg of
-                    Just (Node _ (Expression.ListExpr [])) ->
-                        Just
-                            [ Rule.errorWithFix
-                                { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
-                                , details = [ "You can replace this call by the initial accumulator." ]
-                                }
-                                checkInfo.fnRange
-                                [ Fix.removeRange
-                                    { start = checkInfo.parentRange.start, end = (Node.range initialArgument).start }
-                                , Fix.removeRange
-                                    { start = (Node.range initialArgument).end, end = checkInfo.parentRange.end }
-                                ]
+                (if Maybe.withDefault False (Maybe.map isEmptyList checkInfo.thirdArg) then
+                    Just
+                        [ Rule.errorWithFix
+                            { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
+                            , details = [ "You can replace this call by the initial accumulator." ]
+                            }
+                            checkInfo.fnRange
+                            [ Fix.removeRange
+                                { start = checkInfo.parentRange.start, end = (Node.range initialArgument).start }
+                            , Fix.removeRange
+                                { start = (Node.range initialArgument).end, end = checkInfo.parentRange.end }
                             ]
+                        ]
 
-                    _ ->
-                        (if isBinaryOperation "+" checkInfo checkInfo.firstArg then
-                            numberBinaryOperationChecks { identity = 0, two = "+", list = "sum" }
+                 else if isBinaryOperation "+" checkInfo checkInfo.firstArg then
+                    numberBinaryOperationChecks { identity = 0, two = "+", list = "sum" }
 
-                         else if isBinaryOperation "*" checkInfo checkInfo.firstArg then
-                            numberBinaryOperationChecks { identity = 1, two = "*", list = "product" }
+                 else if isBinaryOperation "*" checkInfo checkInfo.firstArg then
+                    numberBinaryOperationChecks { identity = 1, two = "*", list = "product" }
 
-                         else if isBinaryOperation "&&" checkInfo checkInfo.firstArg then
-                            Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
-                                |> Maybe.map
-                                    (\initialIsTrue ->
-                                        if not initialIsTrue then
+                 else if isBinaryOperation "&&" checkInfo checkInfo.firstArg then
+                    Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
+                        |> Maybe.map
+                            (\initialIsTrue ->
+                                if not initialIsTrue then
+                                    [ Rule.errorWithFix
+                                        { message = "The call to List." ++ foldOperationName ++ " will result in False"
+                                        , details = [ "You can replace this call by False." ]
+                                        }
+                                        checkInfo.fnRange
+                                        (replaceByEmptyFix "False" checkInfo.parentRange checkInfo.thirdArg)
+                                    ]
+
+                                else
+                                    -- initialIsTrue
+                                    [ Rule.errorWithFix
+                                        { message = "Use List.all identity instead"
+                                        , details = [ "Using List." ++ foldOperationName ++ " (&&) True is the same as using List.all identity." ]
+                                        }
+                                        checkInfo.fnRange
+                                        [ Fix.replaceRangeBy
+                                            { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
+                                            "List.all identity"
+                                        ]
+                                    ]
+                            )
+
+                 else if isBinaryOperation "||" checkInfo checkInfo.firstArg then
+                    Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
+                        |> Maybe.map
+                            (\initialIsTrue ->
+                                if initialIsTrue then
+                                    [ Rule.errorWithFix
+                                        { message = "The call to List." ++ foldOperationName ++ " will result in True"
+                                        , details = [ "You can replace this call by True." ]
+                                        }
+                                        checkInfo.fnRange
+                                        (replaceByEmptyFix "True" checkInfo.parentRange checkInfo.thirdArg)
+                                    ]
+
+                                else
+                                    -- not initialIsTrue
+                                    [ Rule.errorWithFix
+                                        { message = "Use List.any identity instead"
+                                        , details = [ "Using List." ++ foldOperationName ++ " (||) False is the same as using List.any identity." ]
+                                        }
+                                        checkInfo.fnRange
+                                        [ Fix.replaceRangeBy
+                                            { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
+                                            "List.any identity"
+                                        ]
+                                    ]
+                            )
+
+                 else
+                    Nothing
+                )
+                    -- orElse
+                    |> Maybe.map Just
+                    |> Maybe.withDefault
+                        (getAlwaysResult checkInfo checkInfo.firstArg
+                            |> -- filter
+                               Maybe.andThen
+                                (\alwaysResult ->
+                                    if isIdentity checkInfo.lookupTable alwaysResult then
+                                        Just
                                             [ Rule.errorWithFix
-                                                { message = "The call to List." ++ foldOperationName ++ " will result in False"
-                                                , details = [ "You can replace this call by False." ]
+                                                { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
+                                                , details = [ "You can replace this call by the initial accumulator." ]
                                                 }
                                                 checkInfo.fnRange
-                                                (replaceByEmptyFix "False" checkInfo.parentRange checkInfo.thirdArg)
+                                                (case checkInfo.thirdArg of
+                                                    Nothing ->
+                                                        [ Fix.replaceRangeBy
+                                                            { start = checkInfo.parentRange.start
+                                                            , end = (Node.range checkInfo.firstArg).end
+                                                            }
+                                                            "always"
+                                                        ]
+
+                                                    Just _ ->
+                                                        [ Fix.removeRange
+                                                            { start = (Node.range initialArgument).end
+                                                            , end = checkInfo.parentRange.end
+                                                            }
+                                                        , Fix.removeRange
+                                                            { start = checkInfo.parentRange.start
+                                                            , end = (Node.range initialArgument).start
+                                                            }
+                                                        ]
+                                                )
                                             ]
 
-                                        else
-                                            -- initialIsTrue
-                                            [ Rule.errorWithFix
-                                                { message = "Use List.all identity instead"
-                                                , details = [ "Using List." ++ foldOperationName ++ " (&&) True is the same as using List.all identity." ]
-                                                }
-                                                checkInfo.fnRange
-                                                [ Fix.replaceRangeBy
-                                                    { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
-                                                    "List.all identity"
-                                                ]
-                                            ]
-                                    )
-
-                         else if isBinaryOperation "||" checkInfo checkInfo.firstArg then
-                            Match.toDetermined (Evaluate.getBoolean checkInfo initialArgument)
-                                |> Maybe.map
-                                    (\initialIsTrue ->
-                                        if initialIsTrue then
-                                            [ Rule.errorWithFix
-                                                { message = "The call to List." ++ foldOperationName ++ " will result in True"
-                                                , details = [ "You can replace this call by True." ]
-                                                }
-                                                checkInfo.fnRange
-                                                (replaceByEmptyFix "True" checkInfo.parentRange checkInfo.thirdArg)
-                                            ]
-
-                                        else
-                                            -- not initialIsTrue
-                                            [ Rule.errorWithFix
-                                                { message = "Use List.any identity instead"
-                                                , details = [ "Using List." ++ foldOperationName ++ " (||) False is the same as using List.any identity." ]
-                                                }
-                                                checkInfo.fnRange
-                                                [ Fix.replaceRangeBy
-                                                    { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
-                                                    "List.any identity"
-                                                ]
-                                            ]
-                                    )
-
-                         else
-                            Nothing
-                        )
-                            -- orElse
-                            |> Maybe.map Just
-                            |> Maybe.withDefault
-                                (getAlwaysResult checkInfo checkInfo.firstArg
-                                    |> -- filter
-                                       Maybe.andThen
-                                        (\alwaysResult ->
-                                            if isIdentity checkInfo.lookupTable alwaysResult then
-                                                Just
-                                                    [ Rule.errorWithFix
-                                                        { message = "The call to List." ++ foldOperationName ++ " will result in the initial accumulator"
-                                                        , details = [ "You can replace this call by the initial accumulator." ]
-                                                        }
-                                                        checkInfo.fnRange
-                                                        (case checkInfo.thirdArg of
-                                                            Nothing ->
-                                                                [ Fix.replaceRangeBy
-                                                                    { start = checkInfo.parentRange.start
-                                                                    , end = (Node.range checkInfo.firstArg).end
-                                                                    }
-                                                                    "always"
-                                                                ]
-
-                                                            Just _ ->
-                                                                [ Fix.removeRange
-                                                                    { start = (Node.range initialArgument).end
-                                                                    , end = checkInfo.parentRange.end
-                                                                    }
-                                                                , Fix.removeRange
-                                                                    { start = checkInfo.parentRange.start
-                                                                    , end = (Node.range initialArgument).start
-                                                                    }
-                                                                ]
-                                                        )
-                                                    ]
-
-                                            else
-                                                Nothing
-                                        )
+                                    else
+                                        Nothing
                                 )
+                        )
             )
         |> Maybe.withDefault []
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -502,8 +502,11 @@ Destructuring using case expressions
     --> False
 
     -- The following simplifications for List.foldl also work for List.foldr
-    List.foldl reduce initial []
-    --> initial
+    List.foldl fn x []
+    --> x
+
+    List.foldl (\_ soFar -> soFar) x list
+    --> x
 
     List.foldl (+) 0 list
     --> List.sum list
@@ -518,7 +521,7 @@ Destructuring using case expressions
     --> 0
 
     List.foldl (*) initial list
-    --> initial + List.product list
+    --> initial * List.product list
 
     List.foldl (&&) True list
     --> List.all identity list
@@ -531,12 +534,6 @@ Destructuring using case expressions
 
     List.foldl (||) True list
     --> True
-
-    List.foldl fn x []
-    --> x
-
-    List.foldl (\_ soFar -> soFar) x list
-    --> x
 
     List.all fn []
     --> True

--- a/src/Simplify/Match.elm
+++ b/src/Simplify/Match.elm
@@ -2,7 +2,6 @@ module Simplify.Match exposing
     ( Match(..)
     , map
     , maybeAndThen
-    , toDetermined
     )
 
 {-|
@@ -10,7 +9,6 @@ module Simplify.Match exposing
 @docs Match
 @docs map
 @docs maybeAndThen
-@docs toDetermined
 
 -}
 
@@ -38,13 +36,3 @@ maybeAndThen fn maybe =
 
         Nothing ->
             Undetermined
-
-
-toDetermined : Match determined -> Maybe determined
-toDetermined match =
-    case match of
-        Undetermined ->
-            Nothing
-
-        Determined determined ->
-            Just determined

--- a/src/Simplify/Match.elm
+++ b/src/Simplify/Match.elm
@@ -2,6 +2,7 @@ module Simplify.Match exposing
     ( Match(..)
     , map
     , maybeAndThen
+    , toDetermined
     )
 
 {-|
@@ -9,6 +10,7 @@ module Simplify.Match exposing
 @docs Match
 @docs map
 @docs maybeAndThen
+@docs toDetermined
 
 -}
 
@@ -36,3 +38,13 @@ maybeAndThen fn maybe =
 
         Nothing ->
             Undetermined
+
+
+toDetermined : Match determined -> Maybe determined
+toDetermined match =
+    case match of
+        Undetermined ->
+            Nothing
+
+        Determined determined ->
+            Just determined

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7067,22 +7067,6 @@ a = List.foldl (always identity) x
 a = always x
 """
                         ]
-        , test "should replace List.foldl (always identity) by (always >> identity)" <|
-            \() ->
-                """module A exposing (..)
-a = List.foldl (always identity)
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "The call to List.foldl will result in the initial accumulator"
-                            , details = [ "You can replace this call by the initial accumulator." ]
-                            , under = "List.foldl"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = (always >> identity)
-"""
-                        ]
         , Test.concat listFoldlSumTests
         , Test.concat listFoldlProductTests
         , Test.concat listFoldlAllTests
@@ -7788,22 +7772,6 @@ a = List.foldr (always identity) x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = always x
-"""
-                        ]
-        , test "should replace List.foldr (always identity) by (always >> identity)" <|
-            \() ->
-                """module A exposing (..)
-a = List.foldr (always identity)
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "The call to List.foldr will result in the initial accumulator"
-                            , details = [ "You can replace this call by the initial accumulator." ]
-                            , under = "List.foldr"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = (always >> identity)
 """
                         ]
         , Test.concat listFoldrSumTests

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7067,639 +7067,643 @@ a = List.foldl (always identity) x
 a = always x
 """
                         ]
-        , Test.concat listFoldlSumTests
-        , Test.concat listFoldlProductTests
-        , Test.concat listFoldlAllTests
-        , Test.concat listFoldlAnyTests
+        , listFoldlSumTests
+        , listFoldlProductTests
+        , listFoldlAllTests
+        , listFoldlAnyTests
         ]
 
 
-listFoldlAnyTests : List Test
+listFoldlAnyTests : Test
 listFoldlAnyTests =
-    [ test "should replace List.foldl (||) True by always True" <|
-        \() ->
-            """module A exposing (..)
+    describe "any"
+        [ test "should replace List.foldl (||) True by always True" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (||) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldl will result in True"
-                        , details = [ "You can replace this call by True." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldl will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = always True
 """
-                    ]
-    , test "should replace List.foldl (||) True list by True" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (||) True list by True" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (||) True list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldl will result in True"
-                        , details = [ "You can replace this call by True." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldl will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = True
 """
-                    ]
-    , test "should replace List.foldl (||) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (||) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (||) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldl (||) False is the same as using List.any identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldl (\\x -> (||) x) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x -> (||) x) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x -> (||) x) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldl (||) False is the same as using List.any identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> x || y) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> x || y) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> x || y) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldl (||) False is the same as using List.any identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> y || x) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> y || x) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> y || x) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldl (||) False is the same as using List.any identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> x |> (||) y) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> x |> (||) y) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> x |> (||) y) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldl (||) False is the same as using List.any identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> y |> (||) x) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> y |> (||) x) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> y |> (||) x) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldl (||) False is the same as using List.any identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    ]
+                        ]
+        ]
 
 
-listFoldlAllTests : List Test
+listFoldlAllTests : Test
 listFoldlAllTests =
-    [ test "should replace List.foldl (&&) False by always False" <|
-        \() ->
-            """module A exposing (..)
+    describe "all"
+        [ test "should replace List.foldl (&&) False by always False" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (&&) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldl will result in False"
-                        , details = [ "You can replace this call by False." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldl will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = always False
 """
-                    ]
-    , test "should replace List.foldl (&&) False list by False" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (&&) False list by False" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (&&) False list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldl will result in False"
-                        , details = [ "You can replace this call by False." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldl will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = False
 """
-                    ]
-    , test "should replace List.foldl (&&) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (&&) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (&&) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldl (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldl (\\x -> (&&) x) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x -> (&&) x) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x -> (&&) x) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldl (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> x && y) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> x && y) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> x && y) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldl (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> y && x) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> y && x) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> y && x) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldl (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> x |> (&&) y) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> x |> (&&) y) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> x |> (&&) y) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldl (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> y |> (&&) x) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> y |> (&&) x) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> y |> (&&) x) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldl (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    ]
+                        ]
+        ]
 
 
-listFoldlSumTests : List Test
+listFoldlSumTests : Test
 listFoldlSumTests =
-    [ test "should replace List.foldl (+) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+    describe "sum"
+        [ test "should replace List.foldl (+) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (+) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldl (\\x -> (+) x) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x -> (+) x) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x -> (+) x) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> x + y) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> x + y) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> x + y) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> y + x) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> y + x) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> y + x) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> x |> (+) y) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> x |> (+) y) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> x |> (+) y) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> y |> (+) x) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> y |> (+) x) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> y |> (+) x) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldl (+) initial list by initial + (List.sum list)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (+) initial list by initial + (List.sum list)" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (+) initial list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = initial + (List.sum list)
 """
-                    ]
-    , test "should replace List.foldl (+) initial <| list by initial + (List.sum <| list)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (+) initial <| list by initial + (List.sum <| list)" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (+) initial <| list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = initial + (List.sum <| list)
 """
-                    ]
-    , test "should replace list |> List.foldl (+) initial by ((list |> List.sum) + initial)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace list |> List.foldl (+) initial by ((list |> List.sum) + initial)" <|
+            \() ->
+                """module A exposing (..)
 a = list |> List.foldl (+) initial
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = ((list |> List.sum) + initial)
 """
-                    ]
-    ]
+                        ]
+        ]
 
 
-listFoldlProductTests : List Test
+listFoldlProductTests : Test
 listFoldlProductTests =
-    [ test "should replace List.foldl (*) 0 by always 0" <|
-        \() ->
-            """module A exposing (..)
+    describe "product"
+        [ test "should replace List.foldl (*) 0 by always 0" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (*) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldl (*) 0 will result in 0."
-                        , details =
-                            [ "You can replace this call by 0." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldl (*) 0 will result in 0."
+                            , details =
+                                [ "You can replace this call by 0." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = always 0
 """
-                    ]
-    , test "should replace List.foldl (*) 0 list by 0" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (*) 0 list by 0" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (*) 0 list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldl (*) 0 will result in 0."
-                        , details =
-                            [ "You can replace this call by 0." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldl (*) 0 will result in 0."
+                            , details =
+                                [ "You can replace this call by 0." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = 0
 """
-                    ]
-    , test "should replace List.foldl (*) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (*) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (*) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldl (\\x -> (*) x) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x -> (*) x) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x -> (*) x) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> x * y) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> x * y) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> x * y) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> y * x) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> y * x) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> y * x) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> x |> (*) y) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> x |> (*) y) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> x |> (*) y) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldl (\\x y -> y |> (*) x) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (\\x y -> y |> (*) x) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (\\x y -> y |> (*) x) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldl (*) initial list by initial * (List.product list)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (*) initial list by initial * (List.product list)" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (*) initial list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = initial * (List.product list)
 """
-                    ]
-    , test "should replace List.foldl (*) initial <| list by initial * (List.product <| list)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldl (*) initial <| list by initial * (List.product <| list)" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldl (*) initial <| list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = initial * (List.product <| list)
 """
-                    ]
-    , test "should replace list |> List.foldl (*) initial by ((list |> List.product) * initial)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace list |> List.foldl (*) initial by ((list |> List.product) * initial)" <|
+            \() ->
+                """module A exposing (..)
 a = list |> List.foldl (*) initial
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = ((list |> List.product) * initial)
 """
-                    ]
-    ]
+                        ]
+        ]
 
 
 listFoldrTests : Test
@@ -7808,639 +7812,643 @@ a = List.foldr (always identity) x
 a = always x
 """
                         ]
-        , Test.concat listFoldrSumTests
-        , Test.concat listFoldrProductTests
-        , Test.concat listFoldrAllTests
-        , Test.concat listFoldrAnyTests
+        , listFoldrSumTests
+        , listFoldrProductTests
+        , listFoldrAllTests
+        , listFoldrAnyTests
         ]
 
 
-listFoldrAnyTests : List Test
+listFoldrAnyTests : Test
 listFoldrAnyTests =
-    [ test "should replace List.foldr (||) True by always True" <|
-        \() ->
-            """module A exposing (..)
+    describe "any"
+        [ test "should replace List.foldr (||) True by always True" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (||) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldr will result in True"
-                        , details = [ "You can replace this call by True." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldr will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = always True
 """
-                    ]
-    , test "should replace List.foldr (||) True list by True" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (||) True list by True" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (||) True list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldr will result in True"
-                        , details = [ "You can replace this call by True." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldr will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = True
 """
-                    ]
-    , test "should replace List.foldr (||) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (||) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (||) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldr (||) False is the same as using List.any identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldr (\\x -> (||) x) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x -> (||) x) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x -> (||) x) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldr (||) False is the same as using List.any identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> x || y) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> x || y) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> x || y) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldr (||) False is the same as using List.any identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> y || x) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> y || x) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> y || x) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldr (||) False is the same as using List.any identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> x |> (||) y) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> x |> (||) y) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> x |> (||) y) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldr (||) False is the same as using List.any identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> y |> (||) x) False by List.any identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> y |> (||) x) False by List.any identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> y |> (||) x) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.any identity instead"
-                        , details =
-                            [ "Using List.foldr (||) False is the same as using List.any identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.any identity
 """
-                    ]
-    ]
+                        ]
+        ]
 
 
-listFoldrAllTests : List Test
+listFoldrAllTests : Test
 listFoldrAllTests =
-    [ test "should replace List.foldr (&&) False by always False" <|
-        \() ->
-            """module A exposing (..)
+    describe "all"
+        [ test "should replace List.foldr (&&) False by always False" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (&&) False
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldr will result in False"
-                        , details = [ "You can replace this call by False." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldr will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = always False
 """
-                    ]
-    , test "should replace List.foldr (&&) False list by False" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (&&) False list by False" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (&&) False list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldr will result in False"
-                        , details = [ "You can replace this call by False." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldr will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = False
 """
-                    ]
-    , test "should replace List.foldr (&&) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (&&) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (&&) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldr (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldr (\\x -> (&&) x) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x -> (&&) x) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x -> (&&) x) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldr (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> x && y) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> x && y) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> x && y) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldr (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> y && x) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> y && x) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> y && x) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldr (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> x |> (&&) y) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> x |> (&&) y) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> x |> (&&) y) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldr (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> y |> (&&) x) True by List.all identity" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> y |> (&&) x) True by List.all identity" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> y |> (&&) x) True
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.all identity instead"
-                        , details =
-                            [ "Using List.foldr (&&) True is the same as using List.all identity." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
 """
-                    ]
-    ]
+                        ]
+        ]
 
 
-listFoldrSumTests : List Test
+listFoldrSumTests : Test
 listFoldrSumTests =
-    [ test "should replace List.foldr (+) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+    describe "sum"
+        [ test "should replace List.foldr (+) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (+) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldr (\\x -> (+) x) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x -> (+) x) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x -> (+) x) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> x + y) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> x + y) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> x + y) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> y + x) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> y + x) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> y + x) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> x |> (+) y) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> x |> (+) y) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> x |> (+) y) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> y |> (+) x) 0 by List.sum" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> y |> (+) x) 0 by List.sum" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> y |> (+) x) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
 """
-                    ]
-    , test "should replace List.foldr (+) initial list by initial + (List.sum list)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (+) initial list by initial + (List.sum list)" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (+) initial list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = initial + (List.sum list)
 """
-                    ]
-    , test "should replace List.foldr (+) initial <| list by initial + (List.sum <| list)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (+) initial <| list by initial + (List.sum <| list)" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (+) initial <| list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = initial + (List.sum <| list)
 """
-                    ]
-    , test "should replace list |> List.foldr (+) initial by ((list |> List.sum) + initial)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace list |> List.foldr (+) initial by ((list |> List.sum) + initial)" <|
+            \() ->
+                """module A exposing (..)
 a = list |> List.foldr (+) initial
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = ((list |> List.sum) + initial)
 """
-                    ]
-    ]
+                        ]
+        ]
 
 
-listFoldrProductTests : List Test
+listFoldrProductTests : Test
 listFoldrProductTests =
-    [ test "should replace List.foldr (*) 0 by always 0" <|
-        \() ->
-            """module A exposing (..)
+    describe "product"
+        [ test "should replace List.foldr (*) 0 by always 0" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (*) 0
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldr (*) 0 will result in 0."
-                        , details =
-                            [ "You can replace this call by 0." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldr (*) 0 will result in 0."
+                            , details =
+                                [ "You can replace this call by 0." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = always 0
 """
-                    ]
-    , test "should replace List.foldr (*) 0 list by 0" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (*) 0 list by 0" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (*) 0 list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "The call to List.foldr (*) 0 will result in 0."
-                        , details =
-                            [ "You can replace this call by 0." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The call to List.foldr (*) 0 will result in 0."
+                            , details =
+                                [ "You can replace this call by 0." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = 0
 """
-                    ]
-    , test "should replace List.foldr (*) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (*) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (*) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldr (\\x -> (*) x) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x -> (*) x) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x -> (*) x) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> x * y) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> x * y) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> x * y) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> y * x) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> y * x) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> y * x) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> x |> (*) y) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> x |> (*) y) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> x |> (*) y) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldr (\\x y -> y |> (*) x) 1 by List.product" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (\\x y -> y |> (*) x) 1 by List.product" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (\\x y -> y |> (*) x) 1
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
-                    ]
-    , test "should replace List.foldr (*) initial list by initial * (List.product list)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (*) initial list by initial * (List.product list)" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (*) initial list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = initial * (List.product list)
 """
-                    ]
-    , test "should replace List.foldr (*) initial <| list by initial * (List.product <| list)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.foldr (*) initial <| list by initial * (List.product <| list)" <|
+            \() ->
+                """module A exposing (..)
 a = List.foldr (*) initial <| list
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = initial * (List.product <| list)
 """
-                    ]
-    , test "should replace list |> List.foldr (*) initial by ((list |> List.product) * initial)" <|
-        \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace list |> List.foldr (*) initial by ((list |> List.product) * initial)" <|
+            \() ->
+                """module A exposing (..)
 a = list |> List.foldr (*) initial
 """
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = ((list |> List.product) * initial)
 """
-                    ]
-    ]
+                        ]
+        ]
 
 
 listAllTests : Test

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7472,23 +7472,6 @@ a = List.foldl (\\x y -> y |> (+) x) 0
 a = List.sum
 """
                     ]
-    , test "should replace List.foldl (+) initial by (List.sum >> (+) initial)" <|
-        \() ->
-            """module A exposing (..)
-a = List.foldl (+) initial
-"""
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldl (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
-a = (List.sum >> (+) initial)
-"""
-                    ]
     , test "should replace List.foldl (+) initial list by initial + (List.sum list)" <|
         \() ->
             """module A exposing (..)
@@ -7523,7 +7506,7 @@ a = List.foldl (+) initial <| list
 a = initial + (List.sum <| list)
 """
                     ]
-    , test "should replace list |> List.foldl (+) initial by (list |> List.sum) + initial" <|
+    , test "should replace list |> List.foldl (+) initial by ((list |> List.sum) + initial)" <|
         \() ->
             """module A exposing (..)
 a = list |> List.foldl (+) initial
@@ -7537,7 +7520,7 @@ a = list |> List.foldl (+) initial
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
-a = (list |> List.sum) + initial
+a = ((list |> List.sum) + initial)
 """
                     ]
     ]
@@ -7647,23 +7630,6 @@ a = List.foldl (\\x y -> y |> (*) x) 1
 a = List.product
 """
                     ]
-    , test "should replace List.foldl (*) initial by (List.product >> (*) initial)" <|
-        \() ->
-            """module A exposing (..)
-a = List.foldl (*) initial
-"""
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
-                        , under = "List.foldl"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
-a = (List.product >> (*) initial)
-"""
-                    ]
     , test "should replace List.foldl (*) initial list by initial * (List.product list)" <|
         \() ->
             """module A exposing (..)
@@ -7712,7 +7678,7 @@ a = list |> List.foldl (*) initial
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
-a = (list |> List.product) * initial
+a = ((list |> List.product) * initial)
 """
                     ]
     ]
@@ -8229,23 +8195,6 @@ a = List.foldr (\\x y -> y |> (+) x) 0
 a = List.sum
 """
                     ]
-    , test "should replace List.foldr (+) initial by (List.sum >> (+) initial)" <|
-        \() ->
-            """module A exposing (..)
-a = List.foldr (+) initial
-"""
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.sum instead"
-                        , details =
-                            [ "Using List.foldr (+) 0 is the same as using List.sum." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
-a = (List.sum >> (+) initial)
-"""
-                    ]
     , test "should replace List.foldr (+) initial list by initial + (List.sum list)" <|
         \() ->
             """module A exposing (..)
@@ -8280,7 +8229,7 @@ a = List.foldr (+) initial <| list
 a = initial + (List.sum <| list)
 """
                     ]
-    , test "should replace list |> List.foldr (+) initial by (list |> List.sum) + initial" <|
+    , test "should replace list |> List.foldr (+) initial by ((list |> List.sum) + initial)" <|
         \() ->
             """module A exposing (..)
 a = list |> List.foldr (+) initial
@@ -8294,7 +8243,7 @@ a = list |> List.foldr (+) initial
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
-a = (list |> List.sum) + initial
+a = ((list |> List.sum) + initial)
 """
                     ]
     ]
@@ -8404,23 +8353,6 @@ a = List.foldr (\\x y -> y |> (*) x) 1
 a = List.product
 """
                     ]
-    , test "should replace List.foldr (*) initial by (List.product >> (*) initial)" <|
-        \() ->
-            """module A exposing (..)
-a = List.foldr (*) initial
-"""
-                |> Review.Test.run (rule defaults)
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "Use List.product instead"
-                        , details =
-                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
-                        , under = "List.foldr"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
-a = (List.product >> (*) initial)
-"""
-                    ]
     , test "should replace List.foldr (*) initial list by initial * (List.product list)" <|
         \() ->
             """module A exposing (..)
@@ -8455,7 +8387,7 @@ a = List.foldr (*) initial <| list
 a = initial * (List.product <| list)
 """
                     ]
-    , test "should replace list |> List.foldr (*) initial by (list |> List.product) * initial" <|
+    , test "should replace list |> List.foldr (*) initial by ((list |> List.product) * initial)" <|
         \() ->
             """module A exposing (..)
 a = list |> List.foldr (*) initial
@@ -8469,7 +8401,7 @@ a = list |> List.foldr (*) initial
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
-a = (list |> List.product) * initial
+a = ((list |> List.product) * initial)
 """
                     ]
     ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7664,7 +7664,7 @@ a = List.foldl (*) initial <| list
 a = initial * (List.product <| list)
 """
                     ]
-    , test "should replace list |> List.foldl (*) initial by (list |> List.product) * initial" <|
+    , test "should replace list |> List.foldl (*) initial by ((list |> List.product) * initial)" <|
         \() ->
             """module A exposing (..)
 a = list |> List.foldl (*) initial

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7545,102 +7545,102 @@ a = (list |> List.sum) + initial
 
 listFoldlProductTests : List Test
 listFoldlProductTests =
-    [ test "should replace List.foldl (*) 0 by List.product" <|
+    [ test "should replace List.foldl (*) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldl (*) 0
+a = List.foldl (*) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldl (\\x -> (*) x) 0 by List.product" <|
+    , test "should replace List.foldl (\\x -> (*) x) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldl (\\x -> (*) x) 0
+a = List.foldl (\\x -> (*) x) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldl (\\x y -> x * y) 0 by List.product" <|
+    , test "should replace List.foldl (\\x y -> x * y) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldl (\\x y -> x * y) 0
+a = List.foldl (\\x y -> x * y) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldl (\\x y -> y * x) 0 by List.product" <|
+    , test "should replace List.foldl (\\x y -> y * x) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldl (\\x y -> y * x) 0
+a = List.foldl (\\x y -> y * x) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldl (\\x y -> x |> (*) y) 0 by List.product" <|
+    , test "should replace List.foldl (\\x y -> x |> (*) y) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldl (\\x y -> x |> (*) y) 0
+a = List.foldl (\\x y -> x |> (*) y) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldl (\\x y -> y |> (*) x) 0 by List.product" <|
+    , test "should replace List.foldl (\\x y -> y |> (*) x) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldl (\\x y -> y |> (*) x) 0
+a = List.foldl (\\x y -> y |> (*) x) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -7657,7 +7657,7 @@ a = List.foldl (*) initial
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -7674,7 +7674,7 @@ a = List.foldl (*) initial list
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -7691,7 +7691,7 @@ a = List.foldl (*) initial <| list
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -7708,7 +7708,7 @@ a = list |> List.foldl (*) initial
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldl (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldl (*) 1 is the same as using List.product." ]
                         , under = "List.foldl"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -8302,102 +8302,102 @@ a = (list |> List.sum) + initial
 
 listFoldrProductTests : List Test
 listFoldrProductTests =
-    [ test "should replace List.foldr (*) 0 by List.product" <|
+    [ test "should replace List.foldr (*) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldr (*) 0
+a = List.foldr (*) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldr (\\x -> (*) x) 0 by List.product" <|
+    , test "should replace List.foldr (\\x -> (*) x) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldr (\\x -> (*) x) 0
+a = List.foldr (\\x -> (*) x) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldr (\\x y -> x * y) 0 by List.product" <|
+    , test "should replace List.foldr (\\x y -> x * y) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldr (\\x y -> x * y) 0
+a = List.foldr (\\x y -> x * y) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldr (\\x y -> y * x) 0 by List.product" <|
+    , test "should replace List.foldr (\\x y -> y * x) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldr (\\x y -> y * x) 0
+a = List.foldr (\\x y -> y * x) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldr (\\x y -> x |> (*) y) 0 by List.product" <|
+    , test "should replace List.foldr (\\x y -> x |> (*) y) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldr (\\x y -> x |> (*) y) 0
+a = List.foldr (\\x y -> x |> (*) y) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
 """
                     ]
-    , test "should replace List.foldr (\\x y -> y |> (*) x) 0 by List.product" <|
+    , test "should replace List.foldr (\\x y -> y |> (*) x) 1 by List.product" <|
         \() ->
             """module A exposing (..)
-a = List.foldr (\\x y -> y |> (*) x) 0
+a = List.foldr (\\x y -> y |> (*) x) 1
 """
                 |> Review.Test.run (rule defaults)
                 |> Review.Test.expectErrors
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -8414,7 +8414,7 @@ a = List.foldr (*) initial
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -8431,7 +8431,7 @@ a = List.foldr (*) initial list
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -8448,7 +8448,7 @@ a = List.foldr (*) initial <| list
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)
@@ -8465,7 +8465,7 @@ a = list |> List.foldr (*) initial
                     [ Review.Test.error
                         { message = "Use List.product instead"
                         , details =
-                            [ "Using List.foldr (*) 0 is the same as using List.product." ]
+                            [ "Using List.foldr (*) 1 is the same as using List.product." ]
                         , under = "List.foldr"
                         }
                         |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7512,7 +7512,41 @@ a = ((list |> List.sum) + initial)
 
 listFoldlProductTests : List Test
 listFoldlProductTests =
-    [ test "should replace List.foldl (*) 1 by List.product" <|
+    [ test "should replace List.foldl (*) 0 by always 0" <|
+        \() ->
+            """module A exposing (..)
+a = List.foldl (*) 0
+"""
+                |> Review.Test.run (rule defaults)
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "The call to List.foldl (*) 0 will result in 0."
+                        , details =
+                            [ "You can replace this call by 0." ]
+                        , under = "List.foldl"
+                        }
+                        |> Review.Test.whenFixed """module A exposing (..)
+a = always 0
+"""
+                    ]
+    , test "should replace List.foldl (*) 0 list by 0" <|
+        \() ->
+            """module A exposing (..)
+a = List.foldl (*) 0 list
+"""
+                |> Review.Test.run (rule defaults)
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "The call to List.foldl (*) 0 will result in 0."
+                        , details =
+                            [ "You can replace this call by 0." ]
+                        , under = "List.foldl"
+                        }
+                        |> Review.Test.whenFixed """module A exposing (..)
+a = 0
+"""
+                    ]
+    , test "should replace List.foldl (*) 1 by List.product" <|
         \() ->
             """module A exposing (..)
 a = List.foldl (*) 1
@@ -8219,7 +8253,41 @@ a = ((list |> List.sum) + initial)
 
 listFoldrProductTests : List Test
 listFoldrProductTests =
-    [ test "should replace List.foldr (*) 1 by List.product" <|
+    [ test "should replace List.foldr (*) 0 by always 0" <|
+        \() ->
+            """module A exposing (..)
+a = List.foldr (*) 0
+"""
+                |> Review.Test.run (rule defaults)
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "The call to List.foldr (*) 0 will result in 0."
+                        , details =
+                            [ "You can replace this call by 0." ]
+                        , under = "List.foldr"
+                        }
+                        |> Review.Test.whenFixed """module A exposing (..)
+a = always 0
+"""
+                    ]
+    , test "should replace List.foldr (*) 0 list by 0" <|
+        \() ->
+            """module A exposing (..)
+a = List.foldr (*) 0 list
+"""
+                |> Review.Test.run (rule defaults)
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "The call to List.foldr (*) 0 will result in 0."
+                        , details =
+                            [ "You can replace this call by 0." ]
+                        , under = "List.foldr"
+                        }
+                        |> Review.Test.whenFixed """module A exposing (..)
+a = 0
+"""
+                    ]
+    , test "should replace List.foldr (*) 1 by List.product" <|
         \() ->
             """module A exposing (..)
 a = List.foldr (*) 1

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7126,6 +7126,23 @@ a = List.foldl (||) False
 a = List.any identity
 """
                         ]
+        , test "should replace List.foldl (||) False list by List.any identity list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (||) False list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.any identity list
+"""
+                        ]
         , test "should replace List.foldl (\\x -> (||) x) False by List.any identity" <|
             \() ->
                 """module A exposing (..)
@@ -7266,6 +7283,23 @@ a = List.foldl (&&) True
 a = List.all identity
 """
                         ]
+        , test "should replace List.foldl (&&) True list by List.all identity list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (&&) True list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.all identity list
+"""
+                        ]
         , test "should replace List.foldl (\\x -> (&&) x) True by List.all identity" <|
             \() ->
                 """module A exposing (..)
@@ -7372,6 +7406,23 @@ a = List.foldl (+) 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
+"""
+                        ]
+        , test "should replace List.foldl (+) 0 list by List.sum list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (+) 0 list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.sum list
 """
                         ]
         , test "should replace List.foldl (\\x -> (+) x) 0 by List.sum" <|
@@ -7567,6 +7618,23 @@ a = List.foldl (*) 1
 a = List.product
 """
                         ]
+        , test "should replace List.foldl (*) 1 list by List.product list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (*) 1 list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.product list
+"""
+                        ]
         , test "should replace List.foldl (\\x -> (*) x) 1 by List.product" <|
             \() ->
                 """module A exposing (..)
@@ -7716,10 +7784,10 @@ a = List.foldr (\\el soFar -> soFar - el) 20 list
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test "should replace List.foldr f x [] by x" <|
+        , test "should replace List.foldr fn x [] by x" <|
             \() ->
                 """module A exposing (..)
-a = List.foldr f x []
+a = List.foldr fn x []
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
@@ -7871,6 +7939,23 @@ a = List.foldr (||) False
 a = List.any identity
 """
                         ]
+        , test "should replace List.foldr (||) False list by List.any identity list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (||) False list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.any identity list
+"""
+                        ]
         , test "should replace List.foldr (\\x -> (||) x) False by List.any identity" <|
             \() ->
                 """module A exposing (..)
@@ -8011,6 +8096,23 @@ a = List.foldr (&&) True
 a = List.all identity
 """
                         ]
+        , test "should replace List.foldr (&&) True list by List.all identity" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (&&) True list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.all identity list
+"""
+                        ]
         , test "should replace List.foldr (\\x -> (&&) x) True by List.all identity" <|
             \() ->
                 """module A exposing (..)
@@ -8117,6 +8219,23 @@ a = List.foldr (+) 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum
+"""
+                        ]
+        , test "should replace List.foldr (+) 0 list by List.sum list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (+) 0 list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.sum list
 """
                         ]
         , test "should replace List.foldr (\\x -> (+) x) 0 by List.sum" <|
@@ -8310,6 +8429,23 @@ a = List.foldr (*) 1
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.product
+"""
+                        ]
+        , test "should replace List.foldr (*) 1 list by List.product list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (*) 1 list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.product list
 """
                         ]
         , test "should replace List.foldr (\\x -> (*) x) 1 by List.product" <|


### PR DESCRIPTION
Adds a couple `List.foldl` and `foldr` simplifications
```elm
List.foldl reduce initial []
--> initial

List.foldl 0 (+) list
--> List.sum list

List.foldl initial (+) list
--> initial + List.sum list

List.foldl 1 (*) list
--> List.product list

List.foldl initial (*) list
--> initial + List.product list

List.foldl True (&&) list
--> List.all identity list

List.foldl False (&&) list
--> False

List.foldl False (||) list
--> List.any identity list

List.foldl True (||) list
--> True

List.foldl fn x []
--> x

List.foldl (always identity) x list
--> x
```
same with `foldr`
```elm
List.foldr reduce initial []
--> initial

List.foldr 0 (+) list
--> List.sum list

List.foldr initial (+) list
--> initial + List.sum list

List.foldr 1 (*) list
--> List.product list

List.foldr initial (*) list
--> initial + List.product list

List.foldr True (&&) list
--> List.all identity list

List.foldr False (&&) list
--> False

List.foldr False (||) list
--> List.any identity list

List.foldr True (||) list
--> True

List.foldr fn x []
--> x

List.foldr (always identity) x list
--> x
```
There are places in the code marked TODO that we can discuss