### PR TITLE
Add tests for String.length simplifications

### DIFF
--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4735,6 +4735,23 @@ a = String.length "a\\t🚀b\\\\c🇲🇻\\u{000D}\\r"
 a = 13
 """
                         ]
+        , test "should replace String.length \"\"\"a\\t🚀b\\c🇲🇻\\u{000D}\\r\"\"\" by 13" <|
+            \() ->
+                """module A exposing (..)
+a = String.length \"\"\"a\\t🚀b\\\\c🇲🇻\\u{000D}\\r\"\"\"
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the string is 13"
+                            , details = [ "The length of the string can be determined by looking at the code." ]
+                            , under = "String.length"
+                            }
+                            |> Review.Test.whenFixed
+                                """module A exposing (..)
+a = 13
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4731,7 +4731,7 @@ a = String.length "a\\t🚀b\\\\c🇲🇻\\u{000D}\\r"
                             , under = "String.length"
                             }
                             |> Review.Test.whenFixed
-                                """module A exposing (..)"
+                                """module A exposing (..)
 a = 13
 """
                         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4615,6 +4615,7 @@ stringSimplificationTests : Test
 stringSimplificationTests =
     describe "String"
         [ stringIsEmptyTests
+        , stringLengthTests
         , concatTests
         , joinTests
         , stringRepeatTests
@@ -4669,6 +4670,69 @@ a = String.isEmpty "a"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = False
+"""
+                        ]
+        ]
+
+
+stringLengthTests : Test
+stringLengthTests =
+    describe "String.length"
+        [ test "should not report String.length that contains a variable or expression" <|
+            \() ->
+                """module A exposing (..)
+a = String.length
+b = String.length str
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test "should replace String.length \"\" by 0" <|
+            \() ->
+                """module A exposing (..)
+a = String.length ""
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the string is 0"
+                            , details = [ "The length of the string can be determined by looking at the code." ]
+                            , under = "String.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 0
+"""
+                        ]
+        , test "should replace String.length \"abc\" by 3" <|
+            \() ->
+                """module A exposing (..)
+a = String.length "abc"
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the string is 3"
+                            , details = [ "The length of the string can be determined by looking at the code." ]
+                            , under = "String.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 3
+"""
+                        ]
+        , test "should replace String.length \"a\\t🚀b\\c🇲🇻\\u{000D}\\r\" by 13" <|
+            \() ->
+                """module A exposing (..)
+a = String.length "a\\t🚀b\\\\c🇲🇻\\u{000D}\\r"
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the string is 13"
+                            , details = [ "The length of the string can be determined by looking at the code." ]
+                            , under = "String.length"
+                            }
+                            |> Review.Test.whenFixed
+                                """module A exposing (..)"
+a = 13
 """
                         ]
         ]


### PR DESCRIPTION
Couldn't find tests for `String.length` simplifications which I found spooky. Here are some.
[elm-syntax itself doesn't have many string parsing tests it seems](https://github.com/stil4m/elm-syntax/blob/master/tests/Elm/Parser/ExpressionTests.elm#L41-L60) (here [tokens](https://github.com/stil4m/elm-syntax/blob/master/tests/Elm/Parser/TokenTests.elm#L146-L173)); let's add other kinds of characters you can think of