### PR TITLE
Add all arguments to CheckInfo

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -689,7 +689,6 @@ All of these also apply for `Sub`.
 
 -}
 
-import Array exposing (Array)
 import Dict exposing (Dict)
 import Elm.Docs
 import Elm.Syntax.Expression as Expression exposing (Expression, RecordSetter)

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1013,14 +1013,14 @@ onlyErrors errors =
 expressionVisitorHelp : Node Expression -> ModuleContext -> { errors : List (Error {}), rangesToIgnore : List Range, rightSidesOfPlusPlus : List Range, inferredConstants : List ( Range, Infer.Inferred ) }
 expressionVisitorHelp node context =
     let
-        separateArgs :
+        toCheckInfo :
             { fnRange : Range
             , firstArg : Node Expression
             , argsAfterFirst : Array (Node Expression)
             , usingRightPizza : Bool
             }
             -> CheckInfo
-        separateArgs checkInfo =
+        toCheckInfo checkInfo =
             { lookupTable = context.lookupTable
             , inferredConstants = context.inferredConstants
             , parentRange = Node.range node
@@ -1042,7 +1042,7 @@ expressionVisitorHelp node context =
                 Just checkFn ->
                     onlyErrors
                         (checkFn
-                            (separateArgs
+                            (toCheckInfo
                                 { fnRange = fnRange
                                 , firstArg = firstArg
                                 , argsAfterFirst = Array.fromList restOfArguments
@@ -1164,7 +1164,7 @@ expressionVisitorHelp node context =
                 Just checkFn ->
                     onlyErrors
                         (checkFn
-                            (separateArgs
+                            (toCheckInfo
                                 { fnRange = fnRange
                                 , firstArg = firstArg
                                 , argsAfterFirst = Array.empty
@@ -1184,7 +1184,7 @@ expressionVisitorHelp node context =
                 Just checkFn ->
                     errorsAndRangesToIgnore
                         (checkFn
-                            (separateArgs
+                            (toCheckInfo
                                 { fnRange = fnRange
                                 , firstArg = firstArg
                                 , argsAfterFirst = Array.push lastArg (Array.fromList argsBetweenFirstAndLastArg)
@@ -1208,7 +1208,7 @@ expressionVisitorHelp node context =
                 Just checkFn ->
                     onlyErrors
                         (checkFn
-                            (separateArgs
+                            (toCheckInfo
                                 { fnRange = fnRange
                                 , firstArg = firstArg
                                 , argsAfterFirst = Array.empty
@@ -1228,7 +1228,7 @@ expressionVisitorHelp node context =
                 Just checkFn ->
                     errorsAndRangesToIgnore
                         (checkFn
-                            (separateArgs
+                            (toCheckInfo
                                 { fnRange = fnRange
                                 , firstArg = firstArg
                                 , argsAfterFirst = Array.push lastArg (Array.fromList argsBetweenFirstAndLast)

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6033,12 +6033,15 @@ toIdentityErrorInfo config =
     }
 
 
-{-| TODO replace uses with `toIdentityFix` to be more explicit
+{-| identity if there's no second argument, else the second argument.
+
+TODO replace uses with `toIdentityFix` to be more explicit
+
 -}
 noopFix : CheckInfo -> List Fix
 noopFix checkInfo =
     toIdentityFix
-        { lastArg = Array.get (Array.length checkInfo.argsAfterFirst - 1) checkInfo.argsAfterFirst
+        { lastArg = secondArg checkInfo
         , parentRange = checkInfo.parentRange
         }
 


### PR DESCRIPTION
Refactoring internals. Instead of checking for argument counts one to three, we collect all arguments.

What's the motivation?

```elm
listMapNChecks : { n : Int } -> CheckInfo -> List (Error {})
listMapNChecks { n } checkInfo =
    if ... any argument after the first is empty ... then ...
```
The new implementation also cleans up some `CheckInfo` creation code which is nice.

I tried not to change the check implementations in the process, like switching to `keepOnlyFix` where possible. Having all tests pass first try makes me confident this didn't change any behavior.