### PR TITLE
Add List.map2-5 simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4531,11 +4531,26 @@ listMapNChecks { n } checkInfo =
             , details = [ "You can replace this call by []." ]
             }
             checkInfo.fnRange
-            [ Fix.replaceRangeBy checkInfo.parentRange "[]" ]
+            [ Fix.replaceRangeBy checkInfo.parentRange
+                (multiAlways (n - List.length checkInfo.argsAfterFirst) "[]")
+            ]
         ]
 
     else
         []
+
+
+multiAlways : Int -> String -> String
+multiAlways alwaysCount alwaysResultExpressionAsString =
+    case alwaysCount of
+        0 ->
+            alwaysResultExpressionAsString
+
+        1 ->
+            "always " ++ alwaysResultExpressionAsString
+
+        alwaysCountPositive ->
+            "\\" ++ String.repeat alwaysCountPositive "_ " ++ "-> " ++ alwaysResultExpressionAsString
 
 
 listUnzipChecks : CheckInfo -> List (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4550,7 +4550,7 @@ multiAlways alwaysCount alwaysResultExpressionAsString =
             "always " ++ alwaysResultExpressionAsString
 
         alwaysCountPositive ->
-            "\\" ++ String.repeat alwaysCountPositive "_ " ++ "-> " ++ alwaysResultExpressionAsString
+            "(\\" ++ String.repeat alwaysCountPositive "_ " ++ "-> " ++ alwaysResultExpressionAsString ++ ")"
 
 
 listUnzipChecks : CheckInfo -> List (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4525,15 +4525,18 @@ listDropChecks checkInfo =
 
 listMapNChecks : { n : Int } -> CheckInfo -> List (Error {})
 listMapNChecks { n } checkInfo =
-    if List.any (\(Node _ expression) -> expression == Expression.ListExpr []) checkInfo.argsAfterFirst then
+    if List.any (\(Node _ list) -> list == Expression.ListExpr []) checkInfo.argsAfterFirst then
+        let
+            callReplacement : String
+            callReplacement =
+                multiAlways (n - List.length checkInfo.argsAfterFirst) "[]"
+        in
         [ Rule.errorWithFix
             { message = "Using List.map" ++ String.fromInt n ++ " with any list being [] will result in []"
-            , details = [ "You can replace this call by []." ]
+            , details = [ "You can replace this call by " ++ callReplacement ++ "." ]
             }
             checkInfo.fnRange
-            [ Fix.replaceRangeBy checkInfo.parentRange
-                (multiAlways (n - List.length checkInfo.argsAfterFirst) "[]")
-            ]
+            [ Fix.replaceRangeBy checkInfo.parentRange callReplacement ]
         ]
 
     else

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -589,6 +589,13 @@ Destructuring using case expressions
     List.sort [ a ]
     --> [ a ]
 
+    -- same for up to List.map5 when any list is empty
+    List.map2 fn xs []
+    --> []
+
+    List.map2 fn [] ys
+    --> []
+
     List.unzip []
     --> ( [], [] )
 
@@ -1601,6 +1608,10 @@ functionCallChecks =
         , ( ( [ "List" ], "take" ), listTakeChecks )
         , ( ( [ "List" ], "drop" ), listDropChecks )
         , ( ( [ "List" ], "member" ), collectionMemberChecks listCollection )
+        , ( ( [ "List" ], "map2" ), listMapNChecks { n = 2 } )
+        , ( ( [ "List" ], "map3" ), listMapNChecks { n = 3 } )
+        , ( ( [ "List" ], "map4" ), listMapNChecks { n = 4 } )
+        , ( ( [ "List" ], "map5" ), listMapNChecks { n = 5 } )
         , ( ( [ "List" ], "unzip" ), listUnzipChecks )
         , ( ( [ "Set" ], "map" ), collectionMapChecks setCollection )
         , ( ( [ "Set" ], "filter" ), collectionFilterChecks setCollection )
@@ -4510,6 +4521,21 @@ listDropChecks checkInfo =
 
             _ ->
                 []
+
+
+listMapNChecks : { n : Int } -> CheckInfo -> List (Error {})
+listMapNChecks { n } checkInfo =
+    if List.any (\(Node _ expression) -> expression == Expression.ListExpr []) checkInfo.argsAfterFirst then
+        [ Rule.errorWithFix
+            { message = "Using List.map" ++ String.fromInt n ++ " with any list being [] will result in []"
+            , details = [ "You can replace this call by []." ]
+            }
+            checkInfo.fnRange
+            [ Fix.replaceRangeBy checkInfo.parentRange "[]" ]
+        ]
+
+    else
+        []
 
 
 listUnzipChecks : CheckInfo -> List (Error {})

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5587,6 +5587,10 @@ listSimplificationTests =
         , listDropTests
         , listIntersperseTests
         , listMemberTests
+        , listMap2Tests
+        , listMap3Tests
+        , listMap4Tests
+        , listMap5Tests
         , listUnzipTests
         ]
 
@@ -10250,6 +10254,304 @@ a = List.unzip []
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = ( [], [] )
+"""
+                        ]
+        ]
+
+
+listMap2Tests : Test
+listMap2Tests =
+    describe "List.map2"
+        [ test "should not report List.map2 on a list argument containing a variable" <|
+            \() ->
+                """module A exposing (..)
+a = List.map2 f
+a = List.map2 f list0
+b = List.map2 f list0 list1
+c = List.map2 f [ h ] list1
+d = List.map2 f (h :: t) list1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test "should replace List.map2 f [] list1 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map2 f [] list1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map2 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map2"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map2 f list0 [] by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map2 f list0 []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map2 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map2"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        ]
+
+
+listMap3Tests : Test
+listMap3Tests =
+    describe "List.map3"
+        [ test "should not report List.map3 on a list argument containing a variable" <|
+            \() ->
+                """module A exposing (..)
+a = List.map3 f
+a = List.map3 f list0
+b = List.map3 f list0 list1
+b = List.map3 f list0 list1 list2
+c = List.map3 f [ h ] list1 list2
+d = List.map3 f (h :: t) list1 list2
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test "should replace List.map3 f [] list1 list2 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map3 f [] list1 list2
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map3 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map3 f list0 [] list2 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map3 f list0 [] list2
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map3 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map3 f list0 list1 [] by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map3 f list0 list1 []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map3 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        ]
+
+
+listMap4Tests : Test
+listMap4Tests =
+    describe "List.map4"
+        [ test "should not report List.map4 on a list argument containing a variable" <|
+            \() ->
+                """module A exposing (..)
+a = List.map4 f
+a = List.map4 f list0
+b = List.map4 f list0 list1
+b = List.map4 f list0 list1 list2
+b = List.map4 f list0 list1 list2 list3
+c = List.map4 f [ h ] list1 list2 list3
+d = List.map4 f (h :: t) list1 list2 list3
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test "should replace List.map4 f [] list1 list2 list3 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map4 f [] list1 list2 list3
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map4 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map4 f list0 [] list2 list3 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map4 f list0 [] list2 list3
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map4 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map4 f list0 list1 [] list3 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map4 f list0 list1 [] list3
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map4 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map4 f list0 list1 list2 [] by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map4 f list0 list1 list2 []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map4 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        ]
+
+
+listMap5Tests : Test
+listMap5Tests =
+    describe "List.map5"
+        [ test "should not report List.map5 on a list argument containing a variable" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f
+a = List.map5 f list0
+b = List.map5 f list0 list1
+b = List.map5 f list0 list1 list2
+b = List.map5 f list0 list1 list2 list3
+b = List.map5 f list0 list1 list2 list3 list4
+c = List.map5 f [ h ] list1 list2 list3 list4
+d = List.map5 f (h :: t) list1 list2 list3 list4
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test "should replace List.map5 f [] list1 list2 list3 list4 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f [] list1 list2 list3 list4
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map5 f list0 [] list2 list3 list4 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f list0 [] list2 list3 list4
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map5 f list0 list1 [] list3 list4 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f list0 list1 [] list3 list4
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map5 f list0 list1 list2 [] list4 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f list0 list1 list2 [] list4
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace List.map5 f list0 list1 list2 list3 [] by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f list0 list1 list2 list3 []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10289,6 +10289,22 @@ a = List.map2 f [] list1
 a = []
 """
                         ]
+        , test "should replace List.map2 f [] by always []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map2 f []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map2 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map2"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always []
+"""
+                        ]
         , test "should replace List.map2 f list0 [] by []" <|
             \() ->
                 """module A exposing (..)
@@ -10337,6 +10353,38 @@ a = List.map3 f [] list1 list2
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = []
+"""
+                        ]
+        , test "should replace List.map3 f [] list1 by always []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map3 f [] list1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map3 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always []
+"""
+                        ]
+        , test "should replace List.map3 f [] list1 by \\_ _ -> []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map3 f []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map3 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = \\_ _ -> []
 """
                         ]
         , test "should replace List.map3 f list0 [] list2 by []" <|
@@ -10404,6 +10452,54 @@ a = List.map4 f [] list1 list2 list3
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = []
+"""
+                        ]
+        , test "should replace List.map4 f [] list1 list2 by always []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map4 f [] list1 list2
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map4 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always []
+"""
+                        ]
+        , test "should replace List.map4 f [] list1 by \\_ _ -> []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map4 f [] list1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map4 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = \\_ _ -> []
+"""
+                        ]
+        , test "should replace List.map4 f [] by \\_ _ _ -> []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map4 f []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map4 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = \\_ _ _ -> []
 """
                         ]
         , test "should replace List.map4 f list0 [] list2 list3 by []" <|
@@ -10488,6 +10584,70 @@ a = List.map5 f [] list1 list2 list3 list4
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = []
+"""
+                        ]
+        , test "should replace List.map5 f [] list1 list2 list3 by always []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f [] list1 list2 list3
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always []
+"""
+                        ]
+        , test "should replace List.map5 f [] list1 list2 by \\_ _ -> []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f [] list1 list2
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = \\_ _ -> []
+"""
+                        ]
+        , test "should replace List.map5 f [] list1 by \\_ _ _ -> []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f [] list1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = \\_ _ _ -> []
+"""
+                        ]
+        , test "should replace List.map5 f [] by \\_ _ _ _ -> []" <|
+            \() ->
+                """module A exposing (..)
+a = List.map5 f []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.map5 with any list being [] will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.map5"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = \\_ _ _ _ -> []
 """
                         ]
         , test "should replace List.map5 f list0 [] list2 list3 list4 by []" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10298,7 +10298,7 @@ a = List.map2 f []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map2 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by always []." ]
                             , under = "List.map2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10364,7 +10364,7 @@ a = List.map3 f [] list1
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map3 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by always []." ]
                             , under = "List.map3"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10380,7 +10380,7 @@ a = List.map3 f []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map3 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by (\\_ _ -> [])." ]
                             , under = "List.map3"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10463,7 +10463,7 @@ a = List.map4 f [] list1 list2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map4 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by always []." ]
                             , under = "List.map4"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10479,7 +10479,7 @@ a = List.map4 f [] list1
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map4 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by (\\_ _ -> [])." ]
                             , under = "List.map4"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10495,7 +10495,7 @@ a = List.map4 f []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map4 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by (\\_ _ _ -> [])." ]
                             , under = "List.map4"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10595,7 +10595,7 @@ a = List.map5 f [] list1 list2 list3
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map5 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by always []." ]
                             , under = "List.map5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10611,7 +10611,7 @@ a = List.map5 f [] list1 list2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map5 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by (\\_ _ -> [])." ]
                             , under = "List.map5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10627,7 +10627,7 @@ a = List.map5 f [] list1
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map5 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by (\\_ _ _ -> [])." ]
                             , under = "List.map5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10643,7 +10643,7 @@ a = List.map5 f []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.map5 with any list being [] will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            , details = [ "You can replace this call by (\\_ _ _ _ -> [])." ]
                             , under = "List.map5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10371,7 +10371,7 @@ a = List.map3 f [] list1
 a = always []
 """
                         ]
-        , test "should replace List.map3 f [] list1 by \\_ _ -> []" <|
+        , test "should replace List.map3 f [] list1 by (\\_ _ -> [])" <|
             \() ->
                 """module A exposing (..)
 a = List.map3 f []
@@ -10384,7 +10384,7 @@ a = List.map3 f []
                             , under = "List.map3"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = \\_ _ -> []
+a = (\\_ _ -> [])
 """
                         ]
         , test "should replace List.map3 f list0 [] list2 by []" <|
@@ -10470,7 +10470,7 @@ a = List.map4 f [] list1 list2
 a = always []
 """
                         ]
-        , test "should replace List.map4 f [] list1 by \\_ _ -> []" <|
+        , test "should replace List.map4 f [] list1 by (\\_ _ -> [])" <|
             \() ->
                 """module A exposing (..)
 a = List.map4 f [] list1
@@ -10483,10 +10483,10 @@ a = List.map4 f [] list1
                             , under = "List.map4"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = \\_ _ -> []
+a = (\\_ _ -> [])
 """
                         ]
-        , test "should replace List.map4 f [] by \\_ _ _ -> []" <|
+        , test "should replace List.map4 f [] by (\\_ _ _ -> [])" <|
             \() ->
                 """module A exposing (..)
 a = List.map4 f []
@@ -10499,7 +10499,7 @@ a = List.map4 f []
                             , under = "List.map4"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = \\_ _ _ -> []
+a = (\\_ _ _ -> [])
 """
                         ]
         , test "should replace List.map4 f list0 [] list2 list3 by []" <|
@@ -10602,7 +10602,7 @@ a = List.map5 f [] list1 list2 list3
 a = always []
 """
                         ]
-        , test "should replace List.map5 f [] list1 list2 by \\_ _ -> []" <|
+        , test "should replace List.map5 f [] list1 list2 by (\\_ _ -> [])" <|
             \() ->
                 """module A exposing (..)
 a = List.map5 f [] list1 list2
@@ -10615,10 +10615,10 @@ a = List.map5 f [] list1 list2
                             , under = "List.map5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = \\_ _ -> []
+a = (\\_ _ -> [])
 """
                         ]
-        , test "should replace List.map5 f [] list1 by \\_ _ _ -> []" <|
+        , test "should replace List.map5 f [] list1 by (\\_ _ _ -> [])" <|
             \() ->
                 """module A exposing (..)
 a = List.map5 f [] list1
@@ -10631,10 +10631,10 @@ a = List.map5 f [] list1
                             , under = "List.map5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = \\_ _ _ -> []
+a = (\\_ _ _ -> [])
 """
                         ]
-        , test "should replace List.map5 f [] by \\_ _ _ _ -> []" <|
+        , test "should replace List.map5 f [] by (\\_ _ _ _ -> [])" <|
             \() ->
                 """module A exposing (..)
 a = List.map5 f []
@@ -10647,7 +10647,7 @@ a = List.map5 f []
                             , under = "List.map5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = \\_ _ _ _ -> []
+a = (\\_ _ _ _ -> [])
 """
                         ]
         , test "should replace List.map5 f list0 [] list2 list3 list4 by []" <|


### PR DESCRIPTION
```elm
-- same for up to List.map5 when any list is empty
List.map2 fn xs [] --> []
List.map2 fn [] ys --> []
```
Having #69, implementing this was easy