### PR TITLE
Don't apply List.indexedMap's checks to List.intersperse

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1594,7 +1594,7 @@ functionCallChecks =
         , reportEmptyListFirstArgument ( ( [ "List" ], "concat" ), listConcatChecks )
         , reportEmptyListSecondArgument ( ( [ "List" ], "concatMap" ), listConcatMapChecks )
         , reportEmptyListSecondArgument ( ( [ "List" ], "indexedMap" ), listIndexedMapChecks )
-        , reportEmptyListSecondArgument ( ( [ "List" ], "intersperse" ), listIndexedMapChecks )
+        , reportEmptyListSecondArgument ( ( [ "List" ], "intersperse" ), \_ -> [] )
         , ( ( [ "List" ], "sum" ), listSumChecks )
         , ( ( [ "List" ], "product" ), listProductChecks )
         , ( ( [ "List" ], "minimum" ), listMinimumChecks )


### PR DESCRIPTION
Fixes #72

I went for a lambda rather than a separate function, because I can predict that looking at that function would confuse me as to why it exists :sweat_smile: 