### PR TITLE
Add Set fold via toList simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -606,7 +606,7 @@ Destructuring using case expressions
     --> ( [], [] )
 
 
-### Set
+### Sets
 
     Set.map fn Set.empty -- same for Set.filter, Set.remove...
     --> Set.empty

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -440,8 +440,8 @@ Destructuring using case expressions
     List.filterMap (always Nothing) list
     --> []
 
-    List.filterMap identity (List.map f x)
-    --> List.filterMap f x
+    List.filterMap identity (List.map f list)
+    --> List.filterMap f list
 
     List.filterMap identity [ Just x, Just y ]
     --> [ x, y ]
@@ -464,8 +464,8 @@ Destructuring using case expressions
     List.concatMap (always []) list
     --> []
 
-    List.concat (List.map f x)
-    --> List.concatMap f x
+    List.concat (List.map f list)
+    --> List.concatMap f list
 
     List.indexedMap (\_ value -> f value) list
     --> List.map (\value -> f value) list
@@ -564,14 +564,14 @@ Destructuring using case expressions
     List.partition (always True) list
     --> ( list, [] )
 
-    List.take 0 x
+    List.take 0 list
     --> []
 
-    List.drop 0 x
-    --> x
+    List.drop 0 list
+    --> list
 
-    List.reverse (List.reverse x)
-    --> x
+    List.reverse (List.reverse list)
+    --> list
 
     List.sortBy (\_ -> a) list
     --> list

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2697,23 +2697,51 @@ getFunctionCall baseNode =
                 , argsAfterFirst = argsAfterFirst
                 }
 
-        Expression.OperatorApplication "|>" _ firstArg (Node _ (Expression.Application ((Node fnRange (Expression.FunctionOrValue _ fnName)) :: argsAfterFirst))) ->
-            Just
-                { nodeRange = Node.range baseNode
-                , fnRange = fnRange
-                , fnName = fnName
-                , firstArg = firstArg
-                , argsAfterFirst = argsAfterFirst
-                }
+        Expression.OperatorApplication "|>" _ firstArg fedFunction ->
+            case fedFunction of
+                Node fnRange (Expression.FunctionOrValue _ fnName) ->
+                    Just
+                        { nodeRange = Node.range baseNode
+                        , fnRange = fnRange
+                        , fnName = fnName
+                        , firstArg = firstArg
+                        , argsAfterFirst = []
+                        }
 
-        Expression.OperatorApplication "<|" _ (Node _ (Expression.Application ((Node fnRange (Expression.FunctionOrValue _ fnName)) :: argsAfterFirst))) firstArg ->
-            Just
-                { nodeRange = Node.range baseNode
-                , fnRange = fnRange
-                , fnName = fnName
-                , firstArg = firstArg
-                , argsAfterFirst = argsAfterFirst
-                }
+                Node _ (Expression.Application ((Node fnRange (Expression.FunctionOrValue _ fnName)) :: argsAfterFirst)) ->
+                    Just
+                        { nodeRange = Node.range baseNode
+                        , fnRange = fnRange
+                        , fnName = fnName
+                        , firstArg = firstArg
+                        , argsAfterFirst = argsAfterFirst
+                        }
+
+                _ ->
+                    Nothing
+
+        Expression.OperatorApplication "<|" _ fedFunction firstArg ->
+            case fedFunction of
+                Node fnRange (Expression.FunctionOrValue _ fnName) ->
+                    Just
+                        { nodeRange = Node.range baseNode
+                        , fnRange = fnRange
+                        , fnName = fnName
+                        , firstArg = firstArg
+                        , argsAfterFirst = []
+                        }
+
+                Node _ (Expression.Application ((Node fnRange (Expression.FunctionOrValue _ fnName)) :: argsAfterFirst)) ->
+                    Just
+                        { nodeRange = Node.range baseNode
+                        , fnRange = fnRange
+                        , fnName = fnName
+                        , firstArg = firstArg
+                        , argsAfterFirst = argsAfterFirst
+                        }
+
+                _ ->
+                    Nothing
 
         _ ->
             Nothing

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7504,6 +7504,22 @@ a = List.foldl (always identity) x
 a = always x
 """
                         ]
+        , test "should replace List.foldl f x (Set.toList set) by Set.foldl f x set" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl f x (Set.toList set)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a set, you don't need to convert to a List"
+                            , details = [ "Using Set.foldl directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Set.foldl f x set
+"""
+                        ]
         , listFoldlSumTests
         , listFoldlProductTests
         , listFoldlAllTests
@@ -8315,6 +8331,22 @@ a = List.foldr (always identity) x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = always x
+"""
+                        ]
+        , test "should replace List.foldr f x (Set.toList set) by Set.foldl f x set" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr f x (Set.toList set)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a set, you don't need to convert to a List"
+                            , details = [ "Using Set.foldr directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Set.foldr f x set
 """
                         ]
         , listFoldrSumTests

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8269,6 +8269,16 @@ a = List.foldr (\\el soFar -> soFar - el) 20 list
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
+        , test "should not report List.foldr ... << Set.toList ... used with wrong amount of arguments" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr reduce init << Set.toList list
+a = List.foldr reduce init compileTimeError << Set.toList
+a = List.foldr reduce << Set.toList
+a = List.foldr << Set.toList
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
         , test "should replace List.foldr fn x [] by x" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7520,6 +7520,38 @@ a = List.foldl f x (Set.toList set)
 a = Set.foldl f x set
 """
                         ]
+        , test "should replace List.foldl f x << Set.toList by Set.foldl f x" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl f x << Set.toList
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a set, you don't need to convert to a List"
+                            , details = [ "Using Set.foldl directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Set.foldl f x
+"""
+                        ]
+        , test "should replace Set.toList >> List.foldl f x by Set.foldl f x" <|
+            \() ->
+                """module A exposing (..)
+a = Set.toList >> List.foldl f x
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a set, you don't need to convert to a List"
+                            , details = [ "Using Set.foldl directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Set.foldl f x
+"""
+                        ]
         , listFoldlSumTests
         , listFoldlProductTests
         , listFoldlAllTests
@@ -8347,6 +8379,38 @@ a = List.foldr f x (Set.toList set)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = Set.foldr f x set
+"""
+                        ]
+        , test "should replace List.foldr f x << Set.toList by Set.foldr f x" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr f x << Set.toList
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a set, you don't need to convert to a List"
+                            , details = [ "Using Set.foldr directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Set.foldr f x
+"""
+                        ]
+        , test "should replace Set.toList >> List.foldr f x by Set.foldr f x" <|
+            \() ->
+                """module A exposing (..)
+a = Set.toList >> List.foldr f x
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a set, you don't need to convert to a List"
+                            , details = [ "Using Set.foldr directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Set.foldr f x
 """
                         ]
         , listFoldrSumTests


### PR DESCRIPTION
```elm
-- same for foldr
List.foldl f x (Set.toList set)
--> Set.foldl f x set
```
Composition like `Set.foldl >> List.foldl f x` works as well.
I put this in the summary section `### Sets` but internally it's checked from `( [ "List" ], "fold..." )`