### PR TITLE
fix #58 (* 0.0)

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1887,8 +1887,9 @@ multiplyChecks { leftRange, rightRange, left, right } =
                                     [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                     , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
                                     , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+by explicitly checking for `Basics.isNaN` and `Basics.isInfinite`."""
+                                    , """Basics.isNaN: https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN
+Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite"""
                                     ]
                                 }
                                 (getRange ())

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1870,33 +1870,43 @@ multiplyChecks : OperatorCheckInfo -> List (Error {})
 multiplyChecks { parentRange, leftRange, rightRange, left, right } =
     findMap
         (\( node, getRange ) ->
-            case getUncomputedNumberValue node of
-                Just value ->
-                    if value == 1 then
-                        Just
-                            [ Rule.errorWithFix
-                                { message = "Unnecessary multiplication by 1"
-                                , details = [ "Multiplying by 1 does not change the value of the number." ]
-                                }
-                                (getRange ())
-                                [ Fix.removeRange (getRange ()) ]
+            if getUncomputedNumberValue node == Just 1 then
+                Just
+                    [ Rule.errorWithFix
+                        { message = "Unnecessary multiplication by 1"
+                        , details = [ "Multiplying by 1 does not change the value of the number." ]
+                        }
+                        (getRange ())
+                        [ Fix.removeRange (getRange ()) ]
+                    ]
+
+            else if getUncomputedIntValue node == Just 0 then
+                Just
+                    [ Rule.errorWithFix
+                        { message = "Multiplying by 0 equals 0"
+                        , details = [ "You can replace this value by 0." ]
+                        }
+                        (getRange ())
+                        [ Fix.replaceRangeBy parentRange "0" ]
+                    ]
+
+            else if getUncomputedFloatValue node == Just 0 then
+                Just
+                    [ Rule.error
+                        { message = "Multiplication by 0.0 should be replaced"
+                        , details =
+                            [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                            , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
+                            , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
                             ]
+                        }
+                        (getRange ())
+                    ]
 
-                    else if value == 0 then
-                        Just
-                            [ Rule.errorWithFix
-                                { message = "Multiplying by 0 equals 0"
-                                , details = [ "You can replace this value by 0." ]
-                                }
-                                (getRange ())
-                                [ Fix.replaceRangeBy parentRange "0" ]
-                            ]
-
-                    else
-                        Nothing
-
-                _ ->
-                    Nothing
+            else
+                Nothing
         )
         [ ( right, \() -> { start = leftRange.end, end = rightRange.end } )
         , ( left, \() -> { start = leftRange.start, end = rightRange.start } )
@@ -4151,13 +4161,27 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                         ]
 
                     else if isBinaryOperation "*" checkInfo checkInfo.firstArg then
-                        if initialNumber == Just 0 then
+                        if getUncomputedIntValue initialArgument == Just 0 then
                             [ Rule.errorWithFix
                                 { message = "The call to List." ++ foldOperationName ++ " (*) 0 will result in 0."
                                 , details = [ "You can replace this call by 0." ]
                                 }
                                 checkInfo.fnRange
                                 (replaceByEmptyFix "0" checkInfo.parentRange (thirdArg checkInfo))
+                            ]
+
+                        else if getUncomputedFloatValue initialArgument == Just 0 then
+                            [ Rule.error
+                                { message = "Multiplication by 0.0 should be replaced"
+                                , details =
+                                    [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                    , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
+                                    , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                    ]
+                                }
+                                (Range.combine [ Node.range checkInfo.firstArg, Node.range initialArgument ])
                             ]
 
                         else
@@ -6149,6 +6173,35 @@ getUncomputedNumberValue node =
 
         Expression.Negation expr ->
             Maybe.map negate (getUncomputedNumberValue expr)
+
+        _ ->
+            Nothing
+
+
+getUncomputedIntValue : Node Expression -> Maybe Float
+getUncomputedIntValue node =
+    case Node.value (AstHelpers.removeParens node) of
+        Expression.Integer n ->
+            Just (toFloat n)
+
+        Expression.Hex n ->
+            Just (toFloat n)
+
+        Expression.Negation expr ->
+            Maybe.map negate (getUncomputedIntValue expr)
+
+        _ ->
+            Nothing
+
+
+getUncomputedFloatValue : Node Expression -> Maybe Float
+getUncomputedFloatValue node =
+    case Node.value (AstHelpers.removeParens node) of
+        Expression.Floatable n ->
+            Just n
+
+        Expression.Negation expr ->
+            Maybe.map negate (getUncomputedFloatValue expr)
 
         _ ->
             Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4153,23 +4153,7 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                         ]
 
                     else if isBinaryOperation "*" checkInfo checkInfo.firstArg then
-                        if initialNumber == Just 0 then
-                            [ Rule.error
-                                { message = "Multiplication by 0 should be replaced"
-                                , details =
-                                    [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
-                                    , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
-                                    , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
-                                    ]
-                                }
-                                (Range.combine [ Node.range checkInfo.firstArg, Node.range initialArgument ])
-                            ]
-
-                        else
-                            -- initialNumber /= Just 0
-                            numberBinaryOperationChecks { two = "*", list = "product", identity = 1 }
+                        numberBinaryOperationChecks { two = "*", list = "product", identity = 1 }
 
                     else if isBinaryOperation "+" checkInfo checkInfo.firstArg then
                         numberBinaryOperationChecks { two = "+", list = "sum", identity = 0 }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6161,35 +6161,6 @@ getUncomputedNumberValue node =
             Nothing
 
 
-getUncomputedIntValue : Node Expression -> Maybe Float
-getUncomputedIntValue node =
-    case Node.value (AstHelpers.removeParens node) of
-        Expression.Integer n ->
-            Just (toFloat n)
-
-        Expression.Hex n ->
-            Just (toFloat n)
-
-        Expression.Negation expr ->
-            Maybe.map negate (getUncomputedIntValue expr)
-
-        _ ->
-            Nothing
-
-
-getUncomputedFloatValue : Node Expression -> Maybe Float
-getUncomputedFloatValue node =
-    case Node.value (AstHelpers.removeParens node) of
-        Expression.Floatable n ->
-            Just n
-
-        Expression.Negation expr ->
-            Maybe.map negate (getUncomputedFloatValue expr)
-
-        _ ->
-            Nothing
-
-
 letInChecks : Expression.LetBlock -> List (Error {})
 letInChecks letBlock =
     case Node.value letBlock.expression of

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8080,64 +8080,7 @@ a = ((list |> List.sum) + initial)
 listFoldlProductTests : Test
 listFoldlProductTests =
     describe "product"
-        [ test "should report but not fix List.foldl (*) 0" <|
-            \() ->
-                """module A exposing (..)
-a = List.foldl (*) 0
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Multiplication by 0 should be replaced"
-                            , details =
-                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
-                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
-                                , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
-                                ]
-                            , under = "(*) 0"
-                            }
-                        ]
-        , test "should report but not fix List.foldl (*) 0 list" <|
-            \() ->
-                """module A exposing (..)
-a = List.foldl (*) 0 list
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Multiplication by 0 should be replaced"
-                            , details =
-                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
-                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
-                                , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
-                                ]
-                            , under = "(*) 0"
-                            }
-                        ]
-        , test "should report but not fix List.foldl (*) 0.0" <|
-            \() ->
-                """module A exposing (..)
-a = List.foldl (*) 0.0
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Multiplication by 0 should be replaced"
-                            , details =
-                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
-                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
-                                , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
-                                ]
-                            , under = "(*) 0.0"
-                            }
-                        ]
-        , test "should replace List.foldl (*) 1 by List.product" <|
+        [ test "should replace List.foldl (*) 1 by List.product" <|
             \() ->
                 """module A exposing (..)
 a = List.foldl (*) 1
@@ -8974,64 +8917,7 @@ a = ((list |> List.sum) + initial)
 listFoldrProductTests : Test
 listFoldrProductTests =
     describe "product"
-        [ test "should report but not fix List.foldr (*) 0" <|
-            \() ->
-                """module A exposing (..)
-a = List.foldr (*) 0
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Multiplication by 0 should be replaced"
-                            , details =
-                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
-                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
-                                , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
-                                ]
-                            , under = "(*) 0"
-                            }
-                        ]
-        , test "should report but not fix List.foldr (*) 0 list" <|
-            \() ->
-                """module A exposing (..)
-a = List.foldr (*) 0 list
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Multiplication by 0 should be replaced"
-                            , details =
-                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
-                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
-                                , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
-                                ]
-                            , under = "(*) 0"
-                            }
-                        ]
-        , test "should report but not fix List.foldr (*) 0.0" <|
-            \() ->
-                """module A exposing (..)
-a = List.foldr (*) 0.0
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Multiplication by 0 should be replaced"
-                            , details =
-                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
-                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
-                                , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
-                                ]
-                            , under = "(*) 0.0"
-                            }
-                        ]
-        , test "should replace List.foldr (*) 1 by List.product" <|
+        [ test "should replace List.foldr (*) 1 by List.product" <|
             \() ->
                 """module A exposing (..)
 a = List.foldr (*) 1

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1698,6 +1698,25 @@ a = 0 * n
 a = 0
 """
                         ]
+        , test "should report but not fix simplify 0.0 * n" <|
+            \() ->
+                """module A exposing (..)
+a = 0.0 * n
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Multiplication by 0.0 should be replaced"
+                            , details =
+                                [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
+                            , under = "0.0 * "
+                            }
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1663,7 +1663,7 @@ a = n * 0
 a = 0
 """
                         ]
-        , test "should simplify n * 0.0 to 0" <|
+        , test "should report but not fix simplify n * 0.0" <|
             \() ->
                 """module A exposing (..)
 a = n * 0.0
@@ -1671,13 +1671,16 @@ a = n * 0.0
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Multiplying by 0 equals 0"
-                            , details = [ "You can replace this value by 0." ]
+                            { message = "Multiplication by 0.0 should be replaced"
+                            , details =
+                                [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
                             , under = " * 0.0"
                             }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = 0
-"""
                         ]
         , test "should simplify 0 * n to 0" <|
             \() ->
@@ -8086,6 +8089,25 @@ a = List.foldl (*) 0 list
 a = 0
 """
                         ]
+        , test "should report but not fix List.foldl (*) 0.0" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (*) 0.0
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Multiplication by 0.0 should be replaced"
+                            , details =
+                                [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
+                            , under = "(*) 0.0"
+                            }
+                        ]
         , test "should replace List.foldl (*) 1 by List.product" <|
             \() ->
                 """module A exposing (..)
@@ -8956,6 +8978,25 @@ a = List.foldr (*) 0 list
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 0
 """
+                        ]
+        , test "should report but not fix List.foldr (*) 0" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (*) 0.0
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Multiplication by 0.0 should be replaced"
+                            , details =
+                                [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
+                            , under = "(*) 0.0"
+                            }
                         ]
         , test "should replace List.foldr (*) 1 by List.product" <|
             \() ->

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1660,8 +1660,9 @@ a = n * 0
                                 [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                 , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
                                 , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+by explicitly checking for `Basics.isNaN` and `Basics.isInfinite`."""
+                                , """Basics.isNaN: https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN
+Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite"""
                                 ]
                             , under = " * 0"
                             }
@@ -1679,8 +1680,9 @@ a = n * 0.0
                                 [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                 , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
                                 , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+by explicitly checking for `Basics.isNaN` and `Basics.isInfinite`."""
+                                , """Basics.isNaN: https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN
+Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite"""
                                 ]
                             , under = " * 0.0"
                             }
@@ -1698,8 +1700,9 @@ a = 0 * n
                                 [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                 , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
                                 , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+by explicitly checking for `Basics.isNaN` and `Basics.isInfinite`."""
+                                , """Basics.isNaN: https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN
+Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite"""
                                 ]
                             , under = "0 * "
                             }
@@ -1717,8 +1720,9 @@ a = 0.0 * n
                                 [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                 , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
                                 , """If you do want the described behavior, though, make your intention clear for the reader
-by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
-and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+by explicitly checking for `Basics.isNaN` and `Basics.isInfinite`."""
+                                , """Basics.isNaN: https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN
+Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite"""
                                 ]
                             , under = "0.0 * "
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1647,7 +1647,7 @@ a = 1 * n
 a = n
 """
                         ]
-        , test "should simplify n * 0 to 0" <|
+        , test "should report but not fix n * 0" <|
             \() ->
                 """module A exposing (..)
 a = n * 0
@@ -1655,13 +1655,16 @@ a = n * 0
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Multiplying by 0 equals 0"
-                            , details = [ "You can replace this value by 0." ]
+                            { message = "Multiplication by 0 should be replaced"
+                            , details =
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
                             , under = " * 0"
                             }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = 0
-"""
                         ]
         , test "should report but not fix simplify n * 0.0" <|
             \() ->
@@ -1671,9 +1674,9 @@ a = n * 0.0
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Multiplication by 0.0 should be replaced"
+                            { message = "Multiplication by 0 should be replaced"
                             , details =
-                                [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                 , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
                                 , """If you do want the described behavior, though, make your intention clear for the reader
 by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
@@ -1682,7 +1685,7 @@ and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/
                             , under = " * 0.0"
                             }
                         ]
-        , test "should simplify 0 * n to 0" <|
+        , test "should report but not fix 0 * n" <|
             \() ->
                 """module A exposing (..)
 a = 0 * n
@@ -1690,15 +1693,18 @@ a = 0 * n
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Multiplying by 0 equals 0"
-                            , details = [ "You can replace this value by 0." ]
+                            { message = "Multiplication by 0 should be replaced"
+                            , details =
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
                             , under = "0 * "
                             }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = 0
-"""
                         ]
-        , test "should report but not fix simplify 0.0 * n" <|
+        , test "should report but not fix 0.0 * n" <|
             \() ->
                 """module A exposing (..)
 a = 0.0 * n
@@ -1706,9 +1712,9 @@ a = 0.0 * n
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Multiplication by 0.0 should be replaced"
+                            { message = "Multiplication by 0 should be replaced"
                             , details =
-                                [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                 , "Most likely, multiplying by 0 was unintentional and you had a different factor in mind."
                                 , """If you do want the described behavior, though, make your intention clear for the reader
 by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
@@ -8074,7 +8080,7 @@ a = ((list |> List.sum) + initial)
 listFoldlProductTests : Test
 listFoldlProductTests =
     describe "product"
-        [ test "should replace List.foldl (*) 0 by always 0" <|
+        [ test "should report but not fix List.foldl (*) 0" <|
             \() ->
                 """module A exposing (..)
 a = List.foldl (*) 0
@@ -8082,16 +8088,18 @@ a = List.foldl (*) 0
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The call to List.foldl (*) 0 will result in 0."
+                            { message = "Multiplication by 0 should be replaced"
                             , details =
-                                [ "You can replace this call by 0." ]
-                            , under = "List.foldl"
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
+                            , under = "(*) 0"
                             }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = always 0
-"""
                         ]
-        , test "should replace List.foldl (*) 0 list by 0" <|
+        , test "should report but not fix List.foldl (*) 0 list" <|
             \() ->
                 """module A exposing (..)
 a = List.foldl (*) 0 list
@@ -8099,14 +8107,16 @@ a = List.foldl (*) 0 list
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The call to List.foldl (*) 0 will result in 0."
+                            { message = "Multiplication by 0 should be replaced"
                             , details =
-                                [ "You can replace this call by 0." ]
-                            , under = "List.foldl"
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
+                            , under = "(*) 0"
                             }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = 0
-"""
                         ]
         , test "should report but not fix List.foldl (*) 0.0" <|
             \() ->
@@ -8116,9 +8126,9 @@ a = List.foldl (*) 0.0
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Multiplication by 0.0 should be replaced"
+                            { message = "Multiplication by 0 should be replaced"
                             , details =
-                                [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                 , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
                                 , """If you do want the described behavior, though, make your intention clear for the reader
 by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
@@ -8964,7 +8974,7 @@ a = ((list |> List.sum) + initial)
 listFoldrProductTests : Test
 listFoldrProductTests =
     describe "product"
-        [ test "should replace List.foldr (*) 0 by always 0" <|
+        [ test "should report but not fix List.foldr (*) 0" <|
             \() ->
                 """module A exposing (..)
 a = List.foldr (*) 0
@@ -8972,16 +8982,18 @@ a = List.foldr (*) 0
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The call to List.foldr (*) 0 will result in 0."
+                            { message = "Multiplication by 0 should be replaced"
                             , details =
-                                [ "You can replace this call by 0." ]
-                            , under = "List.foldr"
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
+                            , under = "(*) 0"
                             }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = always 0
-"""
                         ]
-        , test "should replace List.foldr (*) 0 list by 0" <|
+        , test "should report but not fix List.foldr (*) 0 list" <|
             \() ->
                 """module A exposing (..)
 a = List.foldr (*) 0 list
@@ -8989,16 +9001,18 @@ a = List.foldr (*) 0 list
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The call to List.foldr (*) 0 will result in 0."
+                            { message = "Multiplication by 0 should be replaced"
                             , details =
-                                [ "You can replace this call by 0." ]
-                            , under = "List.foldr"
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
+                                , """If you do want the described behavior, though, make your intention clear for the reader
+by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)
+and [`Basics.isInfinite`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite)"""
+                                ]
+                            , under = "(*) 0"
                             }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = 0
-"""
                         ]
-        , test "should report but not fix List.foldr (*) 0" <|
+        , test "should report but not fix List.foldr (*) 0.0" <|
             \() ->
                 """module A exposing (..)
 a = List.foldr (*) 0.0
@@ -9006,9 +9020,9 @@ a = List.foldr (*) 0.0
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Multiplication by 0.0 should be replaced"
+                            { message = "Multiplication by 0 should be replaced"
                             , details =
-                                [ "Multiplying by Float 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
+                                [ "Multiplying by 0 will turn finite numbers into 0 and keep NaN and (-)Infinity"
                                 , "Most likely, multiplying by 0 was unintentional and you had a different factor like 1 in mind."
                                 , """If you do want the described behavior, though, make your intention clear for the reader
 by explicitly checking for [`Basics.isNaN`](https://package.elm-lang.org/packages/elm/core/latest/Basics#isNaN)


### PR DESCRIPTION
Multiplication by 0.0 now doesn't get any fixes as suggested in #58 and reports enough details to know how to proceed.
Let's tweak the error message and info further 🎈.

One thing I'm uncertain about: `0` always gets parsed as `Integer` (not `Floatable`) _but_ it satisfies `number`. `number` could be used as `Float` tho, which could again produce NaN, (-)Infinity but which would be fixed to `0` by elm-review-simplify.
My reaction would be to never fix to `0` unless we have type inference activated. WDYT?