### PR TITLE
Add List.head simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3916,22 +3916,21 @@ listHeadChecks checkInfo =
                 [ Fix.replaceRangeBy checkInfo.parentRange "Nothing" ]
             ]
 
-        Expression.ListExpr (head :: _) ->
-            let
-                headRange : Range
-                headRange =
-                    Node.range head
-            in
-            [ Rule.errorWithFix
-                listHeadExistsError
-                checkInfo.fnRange
-                (keepOnlyFix { parentRange = Node.range listArg, keep = headRange }
-                    ++ [ Fix.insertAt headRange.start "("
-                       , Fix.insertAt headRange.end ")"
-                       , Fix.replaceRangeBy checkInfo.fnRange "Just"
-                       ]
-                )
-            ]
+        Expression.ListExpr ((Node headRange head) :: _) ->
+            if needsParens head then
+                [ Rule.errorWithFix
+                    listHeadExistsError
+                    checkInfo.fnRange
+                    (keepOnlyFix { parentRange = Node.range listArg, keep = headRange }
+                        ++ [ Fix.insertAt headRange.start "("
+                           , Fix.insertAt headRange.end ")"
+                           , Fix.replaceRangeBy checkInfo.fnRange "Just"
+                           ]
+                    )
+                ]
+
+            else
+                justFirstElementError headRange
 
         Expression.OperatorApplication "::" _ head _ ->
             justFirstElementError (Node.range head)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6276,7 +6276,7 @@ a = List.singleton b |> List.head
 a = b |> Just
 """
                         ]
-        , test "should replace List.head [ a ] by Just (a)" <|
+        , test "should replace List.head [ a ] by Just a" <|
             \() ->
                 """module A exposing (..)
 a = List.head [ b ]
@@ -6289,10 +6289,26 @@ a = List.head [ b ]
                             , under = "List.head"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Just (b)
+a = Just b
 """
                         ]
-        , test "should replace List.head [ a, b, c ] by Just (a)" <|
+        , test "should replace List.head [ f a ] by Just (f a)" <|
+            \() ->
+                """module A exposing (..)
+a = List.head [ f b ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Just (f b)
+"""
+                        ]
+        , test "should replace List.head [ a, b, c ] by Just a" <|
             \() ->
                 """module A exposing (..)
 a = List.head [ b, c, d ]
@@ -6305,7 +6321,23 @@ a = List.head [ b, c, d ]
                             , under = "List.head"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Just (b)
+a = Just b
+"""
+                        ]
+        , test "should replace List.head [ f a, b, c ] by Just (f a)" <|
+            \() ->
+                """module A exposing (..)
+a = List.head [ f b, c, d ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Just (f b)
 """
                         ]
         , test "should replace List.head (a :: bToZ) by Just (a)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6276,7 +6276,7 @@ a = List.singleton b |> List.head
 a = b |> Just
 """
                         ]
-        , test "should replace List.head [ a ] by Just a" <|
+        , test "should replace List.head [ a ] by Just (a)" <|
             \() ->
                 """module A exposing (..)
 a = List.head [ b ]
@@ -6289,10 +6289,10 @@ a = List.head [ b ]
                             , under = "List.head"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Just b
+a = Just (b)
 """
                         ]
-        , test "should replace List.head [ a, b, c ] by Just a" <|
+        , test "should replace List.head [ a, b, c ] by Just (a)" <|
             \() ->
                 """module A exposing (..)
 a = List.head [ b, c, d ]
@@ -6305,7 +6305,7 @@ a = List.head [ b, c, d ]
                             , under = "List.head"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Just b
+a = Just (b)
 """
                         ]
         , test "should replace List.head (a :: bToZ) by Just (a)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5595,6 +5595,7 @@ listSimplificationTests =
         , listAppendTests
         , usingListConcatTests
         , listConcatMapTests
+        , listHeadTests
         , listMapTests
         , listFilterTests
         , listFilterMapTests
@@ -6194,6 +6195,133 @@ a = List.concat << List.map f
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.concatMap f
+"""
+                        ]
+        ]
+
+
+listHeadTests : Test
+listHeadTests =
+    describe "List.head"
+        [ test "should not report List.head used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a = List.head
+b = List.head list
+c = List.head (List.filter f list)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test "should replace List.head [] by Nothing" <|
+            \() ->
+                """module A exposing (..)
+a = List.head []
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on an empty list will result in Nothing"
+                            , details = [ "You can replace this call by Nothing." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Nothing
+"""
+                        ]
+        , test "should replace List.head (List.singleton a) by Just (a)" <|
+            \() ->
+                """module A exposing (..)
+a = List.head (List.singleton b)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Just (b)
+"""
+                        ]
+        , test "should replace List.head <| List.singleton a by Just <| a" <|
+            \() ->
+                """module A exposing (..)
+a = List.head <| List.singleton b
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Just <| b
+"""
+                        ]
+        , test "should replace List.singleton a |> List.head by a |> Just" <|
+            \() ->
+                """module A exposing (..)
+a = List.singleton b |> List.head
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b |> Just
+"""
+                        ]
+        , test "should replace List.head [ a ] by Just a" <|
+            \() ->
+                """module A exposing (..)
+a = List.head [ b ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Just b
+"""
+                        ]
+        , test "should replace List.head [ a, b, c ] by Just a" <|
+            \() ->
+                """module A exposing (..)
+a = List.head [ b, c, d ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Just b
+"""
+                        ]
+        , test "should replace List.head (a :: bToZ) by Just (a)" <|
+            \() ->
+                """module A exposing (..)
+a = List.head (b :: cToZ)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.head on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            , under = "List.head"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Just (b)
 """
                         ]
         ]


### PR DESCRIPTION
```elm
List.head [] --> Nothing
List.head (List.singleton a) --> Just a
List.head [ a, b, c ] --> Just a
List.head (a :: bToZ) --> Just a
```
(only the first and last simplifications are in the summary)