### PR TITLE
Add List.member simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4061,10 +4061,6 @@ listMemberChecks checkInfo =
         needleArg =
             checkInfo.firstArg
 
-        needleRange : Range
-        needleRange =
-            Node.range needleArg
-
         needleArgNormalized : Node Expression
         needleArgNormalized =
             Normalize.normalize checkInfo needleArg
@@ -4079,6 +4075,10 @@ listMemberChecks checkInfo =
     case secondArg checkInfo of
         Just listArg ->
             let
+                needleRange : Range
+                needleRange =
+                    Node.range needleArg
+
                 listMemberExistsError : List (Error {})
                 listMemberExistsError =
                     [ Rule.errorWithFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4054,13 +4054,15 @@ listTailChecks checkInfo =
 listMemberChecks : CheckInfo -> List (Error {})
 listMemberChecks checkInfo =
     let
-        needleArg : Node Expression
-        needleArg =
-            checkInfo.firstArg
+        needleArgNormalized : Node Expression
+        needleArgNormalized =
+            Normalize.normalize checkInfo checkInfo.firstArg
 
         isNeedle : Node Expression -> Bool
         isNeedle element =
-            Normalize.compare checkInfo element needleArg
+            Normalize.compareWithoutNormalization
+                (Normalize.normalize checkInfo element)
+                needleArgNormalized
                 == Normalize.ConfirmedEquality
     in
     case secondArg checkInfo of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4162,42 +4162,6 @@ listMemberChecks checkInfo =
             []
 
 
-parenthesizeIfNeededFix : Node Expression -> List Fix
-parenthesizeIfNeededFix expressionNode =
-    if needsParens (Node.value expressionNode) then
-        parenthesizeFix (Node.range expressionNode)
-
-    else
-        []
-
-
-parenthesizeFix : Range -> List Fix
-parenthesizeFix toSurround =
-    [ Fix.insertAt toSurround.start "("
-    , Fix.insertAt toSurround.end ")"
-    ]
-
-
-rangeBetweenExclusive : ( Range, Range ) -> Range
-rangeBetweenExclusive ( aRange, bRange ) =
-    case locationsCompare ( aRange.start, bRange.start ) of
-        GT ->
-            { start = bRange.end, end = aRange.start }
-
-        -- EQ | LT
-        _ ->
-            { start = aRange.end, end = bRange.start }
-
-
-locationsCompare : ( Location, Location ) -> Order
-locationsCompare ( aEnd, bEnd ) =
-    if aEnd.column == bEnd.column then
-        compare aEnd.row bEnd.row
-
-    else
-        compare aEnd.column bEnd.column
-
-
 getBeforeLastCons : Node Expression -> List (Node Expression)
 getBeforeLastCons expressionNode =
     case Node.value expressionNode of
@@ -6528,6 +6492,42 @@ lastElementRange nodes =
 
 
 -- FIX HELPERS
+
+
+parenthesizeIfNeededFix : Node Expression -> List Fix
+parenthesizeIfNeededFix expressionNode =
+    if needsParens (Node.value expressionNode) then
+        parenthesizeFix (Node.range expressionNode)
+
+    else
+        []
+
+
+parenthesizeFix : Range -> List Fix
+parenthesizeFix toSurround =
+    [ Fix.insertAt toSurround.start "("
+    , Fix.insertAt toSurround.end ")"
+    ]
+
+
+rangeBetweenExclusive : ( Range, Range ) -> Range
+rangeBetweenExclusive ( aRange, bRange ) =
+    case locationsCompare ( aRange.start, bRange.start ) of
+        GT ->
+            { start = bRange.end, end = aRange.start }
+
+        -- EQ | LT
+        _ ->
+            { start = aRange.end, end = bRange.start }
+
+
+locationsCompare : ( Location, Location ) -> Order
+locationsCompare ( aEnd, bEnd ) =
+    if aEnd.column == bEnd.column then
+        compare aEnd.row bEnd.row
+
+    else
+        compare aEnd.column bEnd.column
 
 
 removeFunctionFromFunctionCall : { a | fnRange : Range, firstArg : Node b, usingRightPizza : Bool } -> Fix

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6532,13 +6532,22 @@ a = List.member b (List.singleton b)
 a = True
 """
                         ]
-        , test "should not report List.member b (List.singleton a)" <|
+        , test "should replace List.member b (List.singleton a) by b == a" <|
             \() ->
                 """module A exposing (..)
 a = List.member c (List.singleton b)
 """
                     |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectNoErrors
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.member on an list with a single element is equivalent to directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = c == b
+"""
+                        ]
         , test "should replace List.member a [ a ] by True" <|
             \() ->
                 """module A exposing (..)
@@ -6553,6 +6562,70 @@ a = List.member b [ b ]
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = True
+"""
+                        ]
+        , test "should replace List.member b [ a ] by b == a" <|
+            \() ->
+                """module A exposing (..)
+a = List.member c [ b ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.member on an list with a single element is equivalent to directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = c == b
+"""
+                        ]
+        , test "should replace List.member b <| [ a ] by b == a" <|
+            \() ->
+                """module A exposing (..)
+a = List.member c <| [ b ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.member on an list with a single element is equivalent to directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = c == b
+"""
+                        ]
+        , test "should replace List.member b [ f a ] by b == (f a)" <|
+            \() ->
+                """module A exposing (..)
+a = List.member c [ f b ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.member on an list with a single element is equivalent to directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = c == (f b)
+"""
+                        ]
+        , test "should replace [ a ] |> List.member b by a == b" <|
+            \() ->
+                """module A exposing (..)
+a = [ b ] |> List.member c
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.member on an list with a single element is equivalent to directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b == c
 """
                         ]
         , test "should replace List.member c [ a, b, c ] by True" <|


### PR DESCRIPTION
```elm
List.member a [] --> False
List.member a (List.singleton a) --> True
List.member c (a :: b :: c :: dToZ) --> True
List.member a [ a, b, c ] --> True
List.member a [ b ] --> a == b
List.member a (List.singleton b) --> a == b
```
Only the first and last 3 are shown in the summary.
Apparently `member a [] --> False` was already implemented (https://github.com/jfmengels/elm-review-simplify/issues/2 suggested otherwise)

The possibility of the needle being NaN is silently ignored. The most accurate fix would be
```elm
List.member a [ a, b, c ] --> a == a
```
This merge request doesn't do that because above would be simplified to `True` anyway (at least currently)