### PR TITLE
Add Html.Attributes.classList simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5187,7 +5187,7 @@ htmlAttributesClassListChecks checkInfo =
             singleElementListChecks { element = single }
 
         Just nonSingletonList ->
-            case findMapSurrounding (getTupleWithSecond False) nonSingletonList of
+            case findMapNeighboring (getTupleWithSecond False) nonSingletonList of
                 Just classPart ->
                     let
                         fix : List Fix
@@ -5221,7 +5221,7 @@ htmlAttributesClassListChecks checkInfo =
         Nothing ->
             case getCollapsedCons listArg of
                 Just classParts ->
-                    case findMapSurrounding (getTupleWithSecond False) classParts.consed of
+                    case findMapNeighboring (getTupleWithSecond False) classParts.consed of
                         Just classPart ->
                             let
                                 fix : List Fix
@@ -7374,13 +7374,13 @@ findMap mapper nodes =
                     findMap mapper rest
 
 
-findMapSurrounding : (a -> Maybe b) -> List a -> Maybe { before : Maybe a, found : b, after : Maybe a }
-findMapSurrounding tryMap list =
-    findMapSurroundingAfter Nothing tryMap list
+findMapNeighboring : (a -> Maybe b) -> List a -> Maybe { before : Maybe a, found : b, after : Maybe a }
+findMapNeighboring tryMap list =
+    findMapNeighboringAfter Nothing tryMap list
 
 
-findMapSurroundingAfter : Maybe a -> (a -> Maybe b) -> List a -> Maybe { before : Maybe a, found : b, after : Maybe a }
-findMapSurroundingAfter before tryMap list =
+findMapNeighboringAfter : Maybe a -> (a -> Maybe b) -> List a -> Maybe { before : Maybe a, found : b, after : Maybe a }
+findMapNeighboringAfter before tryMap list =
     case list of
         [] ->
             Nothing
@@ -7391,4 +7391,4 @@ findMapSurroundingAfter before tryMap list =
                     Just { before = before, found = found, after = after |> List.head }
 
                 Nothing ->
-                    findMapSurroundingAfter (Just now) tryMap after
+                    findMapNeighboringAfter (Just now) tryMap after

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14509,6 +14509,24 @@ import Html.Attributes
 a = Html.Attributes.class x
 """
                         ]
+        , test "should replace Html.Attributes.classList [ ( x, True ) ] by Html.Attributes.class (f x)" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ ( f x, True ) ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Html.Attributes.classList with a single tuple paired with True can be replaced with Html.Attributes.class"
+                            , details = [ "You can replace this call by Html.Attributes.class with the String from the single tuple list element." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.class (f x)
+"""
+                        ]
         , test "should replace Html.Attributes.classList (List.singleton ( x, True )) by Html.Attributes.class x" <|
             \() ->
                 """module A exposing (..)
@@ -14525,6 +14543,24 @@ a = Html.Attributes.classList (List.singleton ( x, True ))
                             |> Review.Test.whenFixed """module A exposing (..)
 import Html.Attributes
 a = Html.Attributes.class x
+"""
+                        ]
+        , test "should replace Html.Attributes.classList (List.singleton ( f x, True )) by Html.Attributes.class (f x)" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (List.singleton ( f x, True ))
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Html.Attributes.classList with a single tuple paired with True can be replaced with Html.Attributes.class"
+                            , details = [ "You can replace this call by Html.Attributes.class with the String from the single tuple list element." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.class (f x)
 """
                         ]
         , test "should replace Html.Attributes.classList (List.singleton ( x, False )) by Html.Attributes.classList []" <|
@@ -14599,11 +14635,11 @@ import Html.Attributes
 a = Html.Attributes.classList [ y ]
 """
                         ]
-        , test "should replace Html.Attributes.classList [ ( x, False ) ] by Html.Attributes.classList []" <|
+        , test "should replace Html.Attributes.classList [( x, False )] by Html.Attributes.classList []" <|
             \() ->
                 """module A exposing (..)
 import Html.Attributes
-a = Html.Attributes.classList [ ( x, False ) ]
+a = Html.Attributes.classList [( x, False )]
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
@@ -14617,7 +14653,7 @@ import Html.Attributes
 a = Html.Attributes.classList []
 """
                         ]
-        , test "should replace Html.Attributes.classList (( x, False ) :: tail) by Html.Attributes.classList tail" <|
+        , test "should replace Html.Attributes.classList (( x, False ) :: tail) by Html.Attributes.classList (tail)" <|
             \() ->
                 """module A exposing (..)
 import Html.Attributes
@@ -14632,7 +14668,25 @@ a = Html.Attributes.classList (( x, False ) :: tail)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Html.Attributes
-a = Html.Attributes.classList tail
+a = Html.Attributes.classList (tail)
+"""
+                        ]
+        , test "should replace Html.Attributes.classList (( x, False ) :: f tail) by Html.Attributes.classList (f tail)" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (( x, False ) :: f tail)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (f tail)
 """
                         ]
         , test "should replace Html.Attributes.classList (x :: ( y, False ) :: tail) by Html.Attributes.classList (x :: tail)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -31,6 +31,7 @@ all =
         , subTests
         , parserTests
         , jsonDecodeTests
+        , htmlAttributesTests
         , recordAccessTests
         , letTests
         ]
@@ -14459,6 +14460,233 @@ a = Json.Decode.oneOf [ x ]
                             |> Review.Test.whenFixed """module A exposing (..)
 import Json.Decode
 a = x
+"""
+                        ]
+        ]
+
+
+
+-- Html.Attributes
+
+
+htmlAttributesTests : Test
+htmlAttributesTests =
+    describe "Html.Attributes"
+        [ htmlAttributesClassListTests ]
+
+
+htmlAttributesClassListTests : Test
+htmlAttributesClassListTests =
+    describe "Html.Attributes.classList"
+        [ test "should not report Html.Attributes.classList used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList
+b = Html.Attributes.classList x
+c = Html.Attributes.classList [ y, z ]
+c = Html.Attributes.classList [ y, ( z, True ) ]
+d = Html.Attributes.classList (x :: y :: z)
+d = Html.Attributes.classList (( y, True ) :: z)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
+        , test "should replace Html.Attributes.classList [ ( x, True ) ] by Html.Attributes.class x" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ ( x, True ) ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Html.Attributes.classList with a single tuple paired with True can be replaced with Html.Attributes.class"
+                            , details = [ "You can replace this call by Html.Attributes.class with the String from the single tuple list element." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.class x
+"""
+                        ]
+        , test "should replace Html.Attributes.classList (List.singleton ( x, True )) by Html.Attributes.class x" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (List.singleton ( x, True ))
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Html.Attributes.classList with a single tuple paired with True can be replaced with Html.Attributes.class"
+                            , details = [ "You can replace this call by Html.Attributes.class with the String from the single tuple list element." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.class x
+"""
+                        ]
+        , test "should replace Html.Attributes.classList (List.singleton ( x, False )) by Html.Attributes.classList []" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (List.singleton ( x, False ))
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList []
+"""
+                        ]
+        , test "should replace Html.Attributes.classList [ x, ( y, False ), z ] by Html.Attributes.classList [ x, y ]" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ x, ( y, False ), z ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ x, z ]
+"""
+                        ]
+        , test "should replace Html.Attributes.classList [ x, ( y, False ) ] by Html.Attributes.classList [ x ]" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ x, ( y, False ) ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ x ]
+"""
+                        ]
+        , test "should replace Html.Attributes.classList [ ( x, False ), y ] by Html.Attributes.classList [ y ]" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ ( x, False ), y ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ y ]
+"""
+                        ]
+        , test "should replace Html.Attributes.classList [ ( x, False ) ] by Html.Attributes.classList []" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList [ ( x, False ) ]
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList []
+"""
+                        ]
+        , test "should replace Html.Attributes.classList (( x, False ) :: tail) by Html.Attributes.classList tail" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (( x, False ) :: tail)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList tail
+"""
+                        ]
+        , test "should replace Html.Attributes.classList (x :: ( y, False ) :: tail) by Html.Attributes.classList (x :: tail)" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (x :: ( y, False ) :: tail)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (x :: tail)
+"""
+                        ]
+        , test "should replace Html.Attributes.classList (x :: ( y, False ) :: z :: tail) by Html.Attributes.classList (x :: tail)" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (x :: ( y, False ) :: z :: tail)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (x :: z :: tail)
+"""
+                        ]
+        , test "should replace Html.Attributes.classList (( x, False ) :: y :: tail) by Html.Attributes.classList (x :: tail)" <|
+            \() ->
+                """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (( x, False ) :: y :: tail)
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "In a Html.Attributes.classList, a tuple paired with False can be removed"
+                            , details = [ "You can remove the tuple list element where the second part is False." ]
+                            , under = "Html.Attributes.classList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Html.Attributes
+a = Html.Attributes.classList (y :: tail)
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14509,7 +14509,7 @@ import Html.Attributes
 a = Html.Attributes.class x
 """
                         ]
-        , test "should replace Html.Attributes.classList [ ( x, True ) ] by Html.Attributes.class (f x)" <|
+        , test "should replace Html.Attributes.classList [ ( f x, True ) ] by Html.Attributes.class (f x)" <|
             \() ->
                 """module A exposing (..)
 import Html.Attributes


### PR DESCRIPTION
```elm
Html.Attributes.classList [ x, y, ( z, False ) ]
--> Html.Attributes.classList [ x, y ]

Html.Attributes.classList (x :: ( y, False ) :: zs)
--> Html.Attributes.classList (x :: zs)

Html.Attributes.classList (List.singleton ( y, False ))
--> Html.Attributes.classList []

Html.Attributes.classList (List.singleton ( onlyOneThing, True ))
--> Html.Attributes.class onlyOneThing

Html.Attributes.classList [ ( onlyOneThing, True ) ]
--> Html.Attributes.class onlyOneThing
```
Only the first and last simplifications are shown in the summary.