### PR TITLE
Don't simplify `String.slice 0` to `left`

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -299,9 +299,6 @@ Destructuring using case expressions
     String.slice n n str
     --> ""
 
-    String.slice 0 n str
-    --> String.left n str
-
     String.slice n 0 str
     --> ""
 
@@ -3176,18 +3173,6 @@ stringSliceChecks checkInfo =
                 }
                 checkInfo.fnRange
                 (replaceByEmptyFix emptyStringAsString checkInfo.parentRange (thirdArg checkInfo))
-            ]
-
-        ( Node startArgumentRange (Expression.Integer 0), _, _ ) ->
-            [ Rule.errorWithFix
-                { message = "Use String.left instead"
-                , details = [ "Using String.slice with start index 0 is the same as using String.left." ]
-                }
-                checkInfo.fnRange
-                [ Fix.replaceRangeBy
-                    { start = checkInfo.fnRange.start, end = startArgumentRange.end }
-                    "String.left"
-                ]
             ]
 
         ( start, Just end, _ ) ->

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5235,10 +5235,11 @@ a = String.slice b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
-        , test "should not report String.slice 0" <|
+        , test "should not report String.slice 0 n" <|
             \() ->
                 """module A exposing (..)
 a = String.slice 0
+b = String.slice 0 n
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5235,6 +5235,13 @@ a = String.slice b c
 """
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectNoErrors
+        , test "should not report String.slice 0" <|
+            \() ->
+                """module A exposing (..)
+a = String.slice 0
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectNoErrors
         , test "should replace String.slice b 0 by always \"\"" <|
             \() ->
                 """module A exposing (..)
@@ -5313,22 +5320,6 @@ a = String.slice a z ""
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = ""
-"""
-                        ]
-        , test "should replace String.slice 0 by String.left" <|
-            \() ->
-                """module A exposing (..)
-a = String.slice 0
-"""
-                    |> Review.Test.run (rule defaults)
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Use String.left instead"
-                            , details = [ "Using String.slice with start index 0 is the same as using String.left." ]
-                            , under = "String.slice"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = String.left
 """
                         ]
         , test "should replace String.slice 0 0 by always \"\"" <|


### PR DESCRIPTION
Removes
```elm
String.slice 0 n str --> String.left n str
```
because negative indices are accepted as end indices by `slice` but return `""` with `left`, so for example
```elm
"abcde" |> String.slice 0 -3 --> "ab"
"abcde" |> String.left -3 --> ""
```
> Reported by Décio Ferreira on slack