### PR TITLE
Fix #86

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4333,7 +4333,7 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                             if initialNumber == Just (Basics.toFloat operation.identity) then
                                 fixWith
                                     [ Fix.replaceRangeBy
-                                        { start = checkInfo.parentRange.start
+                                        { start = checkInfo.fnRange.start
                                         , end = (Node.range initialArgument).end
                                         }
                                         ("List." ++ operation.list)
@@ -4366,7 +4366,7 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                                                 , Fix.insertAt (Node.range initialArgument).end
                                                     (" " ++ operation.two ++ " (List." ++ operation.list)
                                                 , Fix.removeRange
-                                                    { start = checkInfo.parentRange.start
+                                                    { start = checkInfo.fnRange.start
                                                     , end = (Node.range initialArgument).start
                                                     }
                                                 ]
@@ -4390,7 +4390,7 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                                     }
                                     checkInfo.fnRange
                                     [ Fix.replaceRangeBy
-                                        { start = checkInfo.parentRange.start, end = (Node.range initialArgument).end }
+                                        { start = checkInfo.fnRange.start, end = (Node.range initialArgument).end }
                                         ("List." ++ operation.list ++ " identity")
                                     ]
                                 ]
@@ -4401,11 +4401,7 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                             , details = [ "You can replace this call by the initial accumulator." ]
                             }
                             checkInfo.fnRange
-                            [ Fix.removeRange
-                                { start = checkInfo.parentRange.start, end = (Node.range initialArgument).start }
-                            , Fix.removeRange
-                                { start = (Node.range initialArgument).end, end = checkInfo.parentRange.end }
-                            ]
+                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range initialArgument })
                         ]
 
                     else if Maybe.withDefault False (Maybe.map (isIdentity checkInfo.lookupTable) (getAlwaysResult checkInfo checkInfo.firstArg)) then
@@ -4417,22 +4413,14 @@ listFoldAnyDirectionChecks foldOperationName checkInfo =
                             (case listArg of
                                 Nothing ->
                                     [ Fix.replaceRangeBy
-                                        { start = checkInfo.parentRange.start
+                                        { start = checkInfo.fnRange.start
                                         , end = (Node.range checkInfo.firstArg).end
                                         }
                                         "always"
                                     ]
 
                                 Just _ ->
-                                    [ Fix.removeRange
-                                        { start = (Node.range initialArgument).end
-                                        , end = checkInfo.parentRange.end
-                                        }
-                                    , Fix.removeRange
-                                        { start = checkInfo.parentRange.start
-                                        , end = (Node.range initialArgument).start
-                                        }
-                                    ]
+                                    keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range initialArgument }
                             )
                         ]
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8162,6 +8162,40 @@ a = List.foldl (||) False list
 a = List.any identity list
 """
                         ]
+        , test "should replace List.foldl (||) False <| list by List.any identity <| list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (||) False <| list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.any identity <| list
+"""
+                        ]
+        , test "should replace list |> List.foldl (||) False by list |> List.any identity" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.foldl (||) False
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldl (||) False is the same as using List.any identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list |> List.any identity
+"""
+                        ]
         , test "should replace List.foldl (\\x -> (||) x) False by List.any identity" <|
             \() ->
                 """module A exposing (..)
@@ -8300,6 +8334,40 @@ a = List.foldl (&&) True
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity
+"""
+                        ]
+        , test "should replace List.foldl (&&) True <| list by List.all identity <| list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (&&) True <| list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.all identity <| list
+"""
+                        ]
+        , test "should replace list |> List.foldl (&&) True by list |> List.all identity" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.foldl (&&) True
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldl (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list |> List.all identity
 """
                         ]
         , test "should replace List.foldl (&&) True list by List.all identity list" <|
@@ -8442,6 +8510,40 @@ a = List.foldl (+) 0 list
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum list
+"""
+                        ]
+        , test "should replace List.foldl (+) 0 <| list by List.sum <| list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (+) 0 <| list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.sum <| list
+"""
+                        ]
+        , test "should replace list |> List.foldl (+) 0 by list |> List.sum" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.foldl (+) 0
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldl (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list |> List.sum
 """
                         ]
         , test "should replace List.foldl (\\x -> (+) x) 0 by List.sum" <|
@@ -8618,6 +8720,40 @@ a = List.foldl (*) 1 list
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.product list
+"""
+                        ]
+        , test "should replace List.foldl (*) 1 <| list by List.product <| list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl (*) 1 <| list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.product <| list
+"""
+                        ]
+        , test "should replace list |> List.foldl (*) 1 by list |> List.product" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.foldl (*) 1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldl (*) 1 is the same as using List.product." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list |> List.product
 """
                         ]
         , test "should replace List.foldl (\\x -> (*) x) 1 by List.product" <|
@@ -8999,6 +9135,40 @@ a = List.foldr (||) False list
 a = List.any identity list
 """
                         ]
+        , test "should replace List.foldr (||) False <| list by List.any identity <| list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (||) False <| list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.any identity <| list
+"""
+                        ]
+        , test "should replace list |> List.foldr (||) False by list |> List.any identity" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.foldr (||) False
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.any identity instead"
+                            , details =
+                                [ "Using List.foldr (||) False is the same as using List.any identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list |> List.any identity
+"""
+                        ]
         , test "should replace List.foldr (\\x -> (||) x) False by List.any identity" <|
             \() ->
                 """module A exposing (..)
@@ -9139,7 +9309,7 @@ a = List.foldr (&&) True
 a = List.all identity
 """
                         ]
-        , test "should replace List.foldr (&&) True list by List.all identity" <|
+        , test "should replace List.foldr (&&) True list by List.all identity list" <|
             \() ->
                 """module A exposing (..)
 a = List.foldr (&&) True list
@@ -9154,6 +9324,40 @@ a = List.foldr (&&) True list
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.all identity list
+"""
+                        ]
+        , test "should replace List.foldr (&&) True <| list by List.all identity <| list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (&&) True <| list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.all identity <| list
+"""
+                        ]
+        , test "should replace list |> List.foldr (&&) True by list |> List.all identity" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.foldr (&&) True
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.all identity instead"
+                            , details =
+                                [ "Using List.foldr (&&) True is the same as using List.all identity." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list |> List.all identity
 """
                         ]
         , test "should replace List.foldr (\\x -> (&&) x) True by List.all identity" <|
@@ -9279,6 +9483,40 @@ a = List.foldr (+) 0 list
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.sum list
+"""
+                        ]
+        , test "should replace List.foldr (+) 0 <| list by List.sum <| list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (+) 0 <| list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.sum <| list
+"""
+                        ]
+        , test "should replace list |> List.foldr (+) 0 by list |> List.sum" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.foldr (+) 0
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.sum instead"
+                            , details =
+                                [ "Using List.foldr (+) 0 is the same as using List.sum." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list |> List.sum
 """
                         ]
         , test "should replace List.foldr (\\x -> (+) x) 0 by List.sum" <|
@@ -9455,6 +9693,40 @@ a = List.foldr (*) 1 list
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.product list
+"""
+                        ]
+        , test "should replace List.foldr (*) 1 <| list by List.product <| list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (*) 1 <| list
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.product <| list
+"""
+                        ]
+        , test "should replace list |> List.foldr (*) 1 by list |> List.product" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.foldr (*) 1
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use List.product instead"
+                            , details =
+                                [ "Using List.foldr (*) 1 is the same as using List.product." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list |> List.product
 """
                         ]
         , test "should replace List.foldr (\\x -> (*) x) 1 by List.product" <|


### PR DESCRIPTION
Corrects an error with pipelines and `List.fold` call simplifications: https://github.com/jfmengels/elm-review-simplify/issues/86
(tests included)

The fact that many issues are reported now is a sign at the quality of the rules before I added some I guess :balloon: 
Might be time for a PR adding some more tests and refactoring the old new rules