### PR TITLE
Compute import lookup once after imports have been visited

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -867,7 +867,7 @@ type alias ModuleContext =
              Set String
             )
     , exposedVariants : Set String
-    , cashedImportLookup : ImportLookup
+    , importLookup : ImportLookup
     }
 
 
@@ -947,7 +947,7 @@ fromProjectToModule =
             , extractSourceCode = extractSourceCode
             , importedExposedVariants = projectContext.exposedVariants
             , exposedVariants = Set.empty
-            , cashedImportLookup = Dict.empty
+            , importLookup = Dict.empty
             }
         )
         |> Rule.withModuleNameLookupTable
@@ -1104,7 +1104,7 @@ importVisitor importNode context =
 
 afterImportsVisitor : ModuleContext -> ModuleContext
 afterImportsVisitor context =
-    { context | cashedImportLookup = moduleContextToImportLookup context }
+    { context | importLookup = moduleContextToImportLookup context }
 
 
 
@@ -1173,7 +1173,7 @@ expressionVisitor node context =
     else
         let
             { errors, rangesToIgnore, rightSidesOfPlusPlus, inferredConstants } =
-                expressionVisitorHelp node newContext context.cashedImportLookup
+                expressionVisitorHelp node newContext context.importLookup
         in
         ( errors
         , { newContext


### PR DESCRIPTION
I think we can get rid of the "maybe cache".
It is possible that to support the `let` variables, we may need to touch that import lookup when switching scopes in the project and need to recompute the import lookup somewhat, but we should avoid to recompute the things I moved to `afterImportsVisitor` anyway.