### PR TITLE
Track bindings in scope

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1233,7 +1233,9 @@ expressionVisitor node context =
             | rangesToIgnore = RangeDict.union context.rangesToIgnore rangesToIgnore
             , rightSidesOfPlusPlus = RangeDict.union rightSidesOfPlusPlus context.rightSidesOfPlusPlus
             , inferredConstantsDict =
-                RangeDict.union context.inferredConstantsDict (RangeDict.fromList inferredConstants)
+                List.foldl (\( range, constants ) acc -> RangeDict.insert range constants acc)
+                    contextWithInferredConstants.inferredConstantsDict
+                    inferredConstants
           }
         )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1251,13 +1251,12 @@ expressionSurfaceRangesAfterPatterns expression =
 
 
 {-| Whenever you add ranges on expression enter, the same ranges should be removed on expression exit.
+Having one function finding unique ranges and a function for extracting bindings there ensures said consistency.
 
-Having one function presenting ranges and a function for extracting bindings ensures this works.
-
-An alternative idea would be to use some kind of tree structure
+An alternative approach would be to use some kind of tree structure
 with parent and sub ranges and bindings as leaves (maybe a "trie", tho I've not seen one as an elm package).
 
-Removing all bindings for an expression's range an leave would then be trivial
+Removing all bindings for an expression's range on leave would then be trivial
 
 -}
 expressionSurfaceBindingIntroductions : Node Expression -> RangeDict (() -> Set String)

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1050,7 +1050,7 @@ foldProjectContexts : ProjectContext -> ProjectContext -> ProjectContext
 foldProjectContexts =
     \a b ->
         { customTypesToReportInCases = Set.empty
-        , exposedVariants = Dict.union a.exposedVariants b.exposedVariants
+        , exposedVariants = Dict.union b.exposedVariants a.exposedVariants
         }
 
 
@@ -1117,7 +1117,7 @@ dependenciesVisitor typeNamesAsStrings dict context =
       else
         [ errorForUnknownIgnoredConstructor unknownTypesToIgnore ]
     , { customTypesToReportInCases = customTypesToReportInCases
-      , exposedVariants = Dict.union context.exposedVariants dependencyExposedVariants
+      , exposedVariants = Dict.union  dependencyExposedVariants context.exposedVariants
       }
     )
 
@@ -1170,7 +1170,7 @@ declarationVisitor declarationNode context =
                 in
                 { context
                     | exposedVariants =
-                        Set.union context.exposedVariants variantNames
+                        Set.union  variantNames context.exposedVariants
                 }
 
             else
@@ -1222,7 +1222,7 @@ expressionVisitor node context =
             contextWithInferredConstantsAndLocalBindings =
                 { contextWithInferredConstants
                     | localBindings =
-                        RangeDict.union context.localBindings (expressionSurfaceBindings node)
+                        RangeDict.union (expressionSurfaceBindings node) context.localBindings
                 }
 
             { errors, rangesToIgnore, rightSidesOfPlusPlus, inferredConstants } =
@@ -1230,7 +1230,7 @@ expressionVisitor node context =
         in
         ( errors
         , { contextWithInferredConstantsAndLocalBindings
-            | rangesToIgnore = RangeDict.union context.rangesToIgnore rangesToIgnore
+            | rangesToIgnore = RangeDict.union rangesToIgnore context.rangesToIgnore
             , rightSidesOfPlusPlus = RangeDict.union rightSidesOfPlusPlus context.rightSidesOfPlusPlus
             , inferredConstantsDict =
                 List.foldl (\( range, constants ) acc -> RangeDict.insert range constants acc)

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -941,7 +941,7 @@ fromProjectToModule =
                             in
                             insertImport importInfo.moduleName { alias = importInfo.alias, exposed = importInfo.exposed } importLookup
                         )
-                        Dict.empty
+                        implicitImports
                         fullAst.imports
             in
             { lookupTable = lookupTable
@@ -949,7 +949,7 @@ fromProjectToModule =
             , exposedVariantTypes = moduleExposedVariantTypes
             , importLookup =
                 createImportLookup
-                    { imports = Dict.union imports implicitImports
+                    { imports = imports
                     , importExposedVariants = projectContext.exposedVariants
                     }
             , moduleBindings = Set.empty

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1277,26 +1277,23 @@ expressionSurfaceBindingIntroductions expression =
 
         Expression.LetExpression letBlock ->
             let
-                letDeclarationBindingsForImplementation : Expression.LetDeclaration -> ( Range, () -> Set String )
+                letDeclarationBindingsForImplementation : Expression.LetDeclaration -> Set String
                 letDeclarationBindingsForImplementation letDeclaration =
                     case letDeclaration of
                         Expression.LetFunction letFunctionOrValueDeclaration ->
-                            ( Node.range letFunctionOrValueDeclaration.declaration
-                            , \() ->
-                                AstHelpers.patternListBindings
-                                    (Node.value letFunctionOrValueDeclaration.declaration).arguments
-                            )
+                            AstHelpers.patternListBindings
+                                (Node.value letFunctionOrValueDeclaration.declaration).arguments
 
-                        Expression.LetDestructuring (Node _ pattern) (Node implementationRange _) ->
-                            ( implementationRange
-                            , \() -> AstHelpers.patternBindings pattern
-                            )
+                        Expression.LetDestructuring (Node _ pattern) _ ->
+                            AstHelpers.patternBindings pattern
             in
             RangeDict.insert (Node.range expression)
                 (\() -> AstHelpers.letDeclarationListBindings letBlock.declarations)
                 (RangeDict.mapFromList
-                    (\(Node _ letDeclaration) ->
-                        letDeclarationBindingsForImplementation letDeclaration
+                    (\(Node letDeclarationRange letDeclaration) ->
+                        ( letDeclarationRange
+                        , \() -> letDeclarationBindingsForImplementation letDeclaration
+                        )
                     )
                     letBlock.declarations
                 )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4419,7 +4419,9 @@ listHeadChecks checkInfo =
                 , details = [ "You can replace this call by Nothing." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "Nothing" ]
+                [ Fix.replaceRangeBy checkInfo.parentRange
+                    (qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) checkInfo))
+                ]
             ]
 
         Expression.ListExpr ((Node headRange head) :: _) ->
@@ -4485,7 +4487,9 @@ listTailChecks checkInfo =
                         , details = [ "You can replace this call by Nothing." ]
                         }
                         checkInfo.fnRange
-                        [ Fix.replaceRangeBy checkInfo.parentRange "Nothing" ]
+                        [ Fix.replaceRangeBy checkInfo.parentRange
+                            (qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) checkInfo))
+                        ]
                     ]
 
                 _ :: [] ->
@@ -4724,7 +4728,9 @@ listMinimumChecks checkInfo =
                 , details = [ "You can replace this call by Nothing." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "Nothing" ]
+                [ Fix.replaceRangeBy checkInfo.parentRange
+                    (qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) checkInfo))
+                ]
             ]
 
         Expression.ListExpr ((Node elementRange _) :: []) ->
@@ -4756,7 +4762,9 @@ listMaximumChecks checkInfo =
                 , details = [ "You can replace this call by Nothing." ]
                 }
                 checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "Nothing" ]
+                [ Fix.replaceRangeBy checkInfo.parentRange
+                    (qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) checkInfo))
+                ]
             ]
 
         Expression.ListExpr ((Node elementRange _) :: []) ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1231,7 +1231,7 @@ expressionVisitor node context =
     else
         let
             { errors, rangesToIgnore, rightSidesOfPlusPlus, inferredConstants } =
-                expressionVisitorHelp node newContext context.importLookup
+                expressionVisitorHelp node newContext
         in
         ( errors
         , { newContext
@@ -1284,7 +1284,7 @@ expressionSurfaceBindings expression =
                             ( implementationRange, AstHelpers.patternBindings pattern )
             in
             RangeDict.insert (Node.range expression)
-                (AstHelpers.letDeclarationListBindings letBlock.declarations)
+                (Debug.log ("let bindings in " ++ Debug.toString (Node.range expression)) (AstHelpers.letDeclarationListBindings letBlock.declarations))
                 (RangeDict.mapFromList
                     (\(Node _ letDeclaration) ->
                         letDeclarationBindingsForImplementation letDeclaration
@@ -1367,8 +1367,8 @@ onlyErrors errors =
     }
 
 
-expressionVisitorHelp : Node Expression -> ModuleContext -> ImportLookup -> { errors : List (Error {}), rangesToIgnore : List Range, rightSidesOfPlusPlus : List Range, inferredConstants : List ( Range, Infer.Inferred ) }
-expressionVisitorHelp node context importLookup =
+expressionVisitorHelp : Node Expression -> ModuleContext -> { errors : List (Error {}), rangesToIgnore : List Range, rightSidesOfPlusPlus : List Range, inferredConstants : List ( Range, Infer.Inferred ) }
+expressionVisitorHelp node context =
     let
         toCheckInfo :
             { fnRange : Range
@@ -1379,7 +1379,7 @@ expressionVisitorHelp node context importLookup =
             -> CheckInfo
         toCheckInfo checkInfo =
             { lookupTable = context.lookupTable
-            , importLookup = importLookup
+            , importLookup = context.importLookup
             , moduleBindings = context.moduleBindings
             , localBindings = context.localBindings
             , inferredConstants = context.inferredConstants
@@ -1607,7 +1607,7 @@ expressionVisitorHelp node context importLookup =
             onlyErrors
                 (firstThatReportsError compositionChecks
                     { lookupTable = context.lookupTable
-                    , importLookup = importLookup
+                    , importLookup = context.importLookup
                     , moduleBindings = context.moduleBindings
                     , localBindings = context.localBindings
                     , fromLeftToRight = True
@@ -1623,7 +1623,7 @@ expressionVisitorHelp node context importLookup =
             onlyErrors
                 (firstThatReportsError compositionChecks
                     { lookupTable = context.lookupTable
-                    , importLookup = importLookup
+                    , importLookup = context.importLookup
                     , moduleBindings = context.moduleBindings
                     , localBindings = context.localBindings
                     , fromLeftToRight = True
@@ -1639,7 +1639,7 @@ expressionVisitorHelp node context importLookup =
             onlyErrors
                 (firstThatReportsError compositionChecks
                     { lookupTable = context.lookupTable
-                    , importLookup = importLookup
+                    , importLookup = context.importLookup
                     , moduleBindings = context.moduleBindings
                     , localBindings = context.localBindings
                     , fromLeftToRight = False
@@ -1655,7 +1655,7 @@ expressionVisitorHelp node context importLookup =
             onlyErrors
                 (firstThatReportsError compositionChecks
                     { lookupTable = context.lookupTable
-                    , importLookup = importLookup
+                    , importLookup = context.importLookup
                     , moduleBindings = context.moduleBindings
                     , localBindings = context.localBindings
                     , fromLeftToRight = False
@@ -1673,7 +1673,7 @@ expressionVisitorHelp node context importLookup =
                     { errors =
                         checkFn
                             { lookupTable = context.lookupTable
-                            , importLookup = importLookup
+                            , importLookup = context.importLookup
                             , moduleBindings = context.moduleBindings
                             , localBindings = context.localBindings
                             , inferredConstants = context.inferredConstants

--- a/src/Simplify/RangeDict.elm
+++ b/src/Simplify/RangeDict.elm
@@ -1,4 +1,4 @@
-module Simplify.RangeDict exposing (RangeDict, any, diff, empty, get, insert, map, mapFromList, member, singleton, union)
+module Simplify.RangeDict exposing (RangeDict, any, diff, empty, get, insert, map, mapFromList, member, remove, singleton, union)
 
 import Dict exposing (Dict)
 import Elm.Syntax.Range exposing (Range)
@@ -37,8 +37,13 @@ mapFromList toAssociation list =
 
 
 insert : Range -> v -> RangeDict v -> RangeDict v
-insert range rangeDict =
-    Dict.insert (rangeAsString range) rangeDict
+insert range value rangeDict =
+    Dict.insert (rangeAsString range) value rangeDict
+
+
+remove : Range -> RangeDict v -> RangeDict v
+remove range rangeDict =
+    Dict.remove (rangeAsString range) rangeDict
 
 
 get : Range -> RangeDict v -> Maybe v

--- a/src/Simplify/RangeDict.elm
+++ b/src/Simplify/RangeDict.elm
@@ -1,4 +1,4 @@
-module Simplify.RangeDict exposing (RangeDict, any, diff, empty, get, insert, map, mapFromList, member, remove, singleton, union)
+module Simplify.RangeDict exposing (RangeDict, any, empty, get, insert, mapFromList, member, remove, singleton, union)
 
 import Dict exposing (Dict)
 import Elm.Syntax.Range exposing (Range)
@@ -56,11 +56,6 @@ member range rangeDict =
     Dict.member (rangeAsString range) rangeDict
 
 
-map : (a -> b) -> RangeDict a -> RangeDict b
-map valueChange rangeDict =
-    Dict.map (\_ -> valueChange) rangeDict
-
-
 foldl : (v -> folded -> folded) -> folded -> RangeDict v -> folded
 foldl reduce initialFolded rangeDict =
     Dict.foldl (\_ -> reduce) initialFolded rangeDict
@@ -76,11 +71,6 @@ any isFound rangeDict =
 union : RangeDict v -> RangeDict v -> RangeDict v
 union aRangeDict bRangeDict =
     Dict.union aRangeDict bRangeDict
-
-
-diff : RangeDict a -> RangeDict b -> RangeDict a
-diff baseRangeDict exceptionsRangeDict =
-    Dict.diff baseRangeDict exceptionsRangeDict
 
 
 rangeAsString : Range -> String

--- a/src/Simplify/RangeDict.elm
+++ b/src/Simplify/RangeDict.elm
@@ -1,10 +1,11 @@
-module Simplify.RangeDict exposing (RangeDict, empty, get, insert, member)
+module Simplify.RangeDict exposing (RangeDict, any, diff, empty, fromList, get, insert, mapFromList, member, singleton, union)
 
 import Dict exposing (Dict)
 import Elm.Syntax.Range exposing (Range)
 
 
 type alias RangeDict v =
+    -- TODO: make opaque to disallow type confusion with other String dicts
     Dict String v
 
 
@@ -13,19 +14,76 @@ empty =
     Dict.empty
 
 
+singleton : Range -> v -> RangeDict v
+singleton range value =
+    Dict.singleton (rangeAsString range) value
+
+
+{-| Indirect [`fromList`](#fromList) to avoid successive List.map calls.
+-}
+mapFromList : (a -> ( Range, v )) -> List a -> RangeDict v
+mapFromList toAssociation list =
+    Dict.fromList
+        (List.map
+            (\element ->
+                let
+                    ( range, v ) =
+                        toAssociation element
+                in
+                ( rangeAsString range, v )
+            )
+            list
+        )
+
+
+{-| Use [`mapFromList`](#mapFromList) if you use List.map before.
+-}
+fromList : List ( Range, v ) -> RangeDict v
+fromList associations =
+    Dict.fromList
+        (List.map
+            (\( range, v ) ->
+                ( rangeAsString range, v )
+            )
+            associations
+        )
+
+
 insert : Range -> v -> RangeDict v -> RangeDict v
-insert range =
-    Dict.insert (rangeAsString range)
+insert range rangeDict =
+    Dict.insert (rangeAsString range) rangeDict
 
 
 get : Range -> RangeDict v -> Maybe v
-get range =
-    Dict.get (rangeAsString range)
+get range rangeDict =
+    Dict.get (rangeAsString range) rangeDict
 
 
 member : Range -> RangeDict v -> Bool
-member range =
-    Dict.member (rangeAsString range)
+member range rangeDict =
+    Dict.member (rangeAsString range) rangeDict
+
+
+foldl : (v -> folded -> folded) -> folded -> RangeDict v -> folded
+foldl reduce initialFolded rangeDict =
+    Dict.foldl (\_ -> reduce) initialFolded rangeDict
+
+
+any : (v -> Bool) -> RangeDict v -> Bool
+any isFound rangeDict =
+    foldl (\value soFar -> soFar || isFound value)
+        False
+        rangeDict
+
+
+union : RangeDict v -> RangeDict v -> RangeDict v
+union aRangeDict bRangeDict =
+    Dict.union aRangeDict bRangeDict
+
+
+diff : RangeDict a -> RangeDict b -> RangeDict a
+diff baseRangeDict exceptionsRangeDict =
+    Dict.diff baseRangeDict exceptionsRangeDict
 
 
 rangeAsString : Range -> String

--- a/src/Simplify/RangeDict.elm
+++ b/src/Simplify/RangeDict.elm
@@ -1,4 +1,4 @@
-module Simplify.RangeDict exposing (RangeDict, any, diff, empty, fromList, get, insert, map, mapFromList, member, singleton, union)
+module Simplify.RangeDict exposing (RangeDict, any, diff, empty, get, insert, map, mapFromList, member, singleton, union)
 
 import Dict exposing (Dict)
 import Elm.Syntax.Range exposing (Range)
@@ -19,7 +19,7 @@ singleton range value =
     Dict.singleton (rangeAsString range) value
 
 
-{-| Indirect [`fromList`](#fromList) to avoid successive List.map calls.
+{-| Indirect conversion from a list to key-value pairs to avoid successive List.map calls.
 -}
 mapFromList : (a -> ( Range, v )) -> List a -> RangeDict v
 mapFromList toAssociation list =
@@ -33,19 +33,6 @@ mapFromList toAssociation list =
                 ( rangeAsString range, v )
             )
             list
-        )
-
-
-{-| Use [`mapFromList`](#mapFromList) if you use List.map before.
--}
-fromList : List ( Range, v ) -> RangeDict v
-fromList associations =
-    Dict.fromList
-        (List.map
-            (\( range, v ) ->
-                ( rangeAsString range, v )
-            )
-            associations
         )
 
 

--- a/src/Simplify/RangeDict.elm
+++ b/src/Simplify/RangeDict.elm
@@ -4,60 +4,61 @@ import Dict exposing (Dict)
 import Elm.Syntax.Range exposing (Range)
 
 
-type alias RangeDict v =
-    -- TODO: make opaque to disallow type confusion with other String dicts
-    Dict String v
+type RangeDict v
+    = RangeDict (Dict String v)
 
 
 empty : RangeDict v
 empty =
-    Dict.empty
+    RangeDict Dict.empty
 
 
 singleton : Range -> v -> RangeDict v
 singleton range value =
-    Dict.singleton (rangeAsString range) value
+    RangeDict (Dict.singleton (rangeAsString range) value)
 
 
 {-| Indirect conversion from a list to key-value pairs to avoid successive List.map calls.
 -}
 mapFromList : (a -> ( Range, v )) -> List a -> RangeDict v
 mapFromList toAssociation list =
-    Dict.fromList
-        (List.map
-            (\element ->
-                let
-                    ( range, v ) =
-                        toAssociation element
-                in
-                ( rangeAsString range, v )
+    RangeDict
+        (Dict.fromList
+            (List.map
+                (\element ->
+                    let
+                        ( range, v ) =
+                            toAssociation element
+                    in
+                    ( rangeAsString range, v )
+                )
+                list
             )
-            list
         )
 
 
 insert : Range -> v -> RangeDict v -> RangeDict v
-insert range value rangeDict =
-    Dict.insert (rangeAsString range) value rangeDict
+insert range value (RangeDict rangeDict) =
+    RangeDict (Dict.insert (rangeAsString range) value rangeDict)
 
 
 remove : Range -> RangeDict v -> RangeDict v
-remove range rangeDict =
-    Dict.remove (rangeAsString range) rangeDict
+remove range (RangeDict rangeDict) =
+    RangeDict (Dict.remove (rangeAsString range) rangeDict)
 
 
 get : Range -> RangeDict v -> Maybe v
-get range rangeDict =
+get range (RangeDict rangeDict) =
     Dict.get (rangeAsString range) rangeDict
 
 
 member : Range -> RangeDict v -> Bool
-member range rangeDict =
+member range (RangeDict rangeDict) =
     Dict.member (rangeAsString range) rangeDict
 
 
 foldl : (v -> folded -> folded) -> folded -> RangeDict v -> folded
-foldl reduce initialFolded rangeDict =
+foldl reduce initialFolded (RangeDict rangeDict) =
     Dict.foldl (\_ -> reduce) initialFolded rangeDict
 
 
@@ -69,8 +70,8 @@ any isFound rangeDict =
 
 
 union : RangeDict v -> RangeDict v -> RangeDict v
-union aRangeDict bRangeDict =
-    Dict.union aRangeDict bRangeDict
+union (RangeDict aRangeDict) (RangeDict bRangeDict) =
+    RangeDict (Dict.union aRangeDict bRangeDict)
 
 
 rangeAsString : Range -> String

--- a/src/Simplify/RangeDict.elm
+++ b/src/Simplify/RangeDict.elm
@@ -1,4 +1,4 @@
-module Simplify.RangeDict exposing (RangeDict, any, diff, empty, fromList, get, insert, mapFromList, member, singleton, union)
+module Simplify.RangeDict exposing (RangeDict, any, diff, empty, fromList, get, insert, map, mapFromList, member, singleton, union)
 
 import Dict exposing (Dict)
 import Elm.Syntax.Range exposing (Range)
@@ -62,6 +62,11 @@ get range rangeDict =
 member : Range -> RangeDict v -> Bool
 member range rangeDict =
     Dict.member (rangeAsString range) rangeDict
+
+
+map : (a -> b) -> RangeDict a -> RangeDict b
+map valueChange rangeDict =
+    Dict.map (\_ -> valueChange) rangeDict
 
 
 foldl : (v -> folded -> folded) -> folded -> RangeDict v -> folded

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -543,7 +543,7 @@ a =
         doIt ( _, Node _ ({ foldl } :: _) ) =
             ()
     in
-    Set.foldl f x
+    foldl f x
 """
                         ]
         , test "should qualify if imported and exposed but shadowed by let destructured binding" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -513,7 +513,7 @@ a =
             ()
         
         doItBetter x =
-            Set.foldl f x
+            foldl f x
     in
     doItBetter
 """

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -481,7 +481,7 @@ a =
     case foldl f x of
         ( _, Node [] _ ) ->
             []
-
+    
         ( _, Node _ ({ foldl } :: _) ) ->
             []
 """


### PR DESCRIPTION
- [x] value, function declaration bindings
- [x] declaration argument list bindings
- [x] variant bindings
- [x] let declaration, destructuring bindings
- [x] let declaration argument list bindings
- [x] lambda argument list bindings
- [x] case argument bindings
- [x] reset local bindings on declaration visit
- [x] remove local ranges after patterns on expression exit visit
- [x] tests for all mentioned binding kinds

Nice to have the import shadowing edge cases covered