### PR TITLE
Add Result.mapError simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -389,6 +389,12 @@ Destructuring using case expressions
     Result.withDefault x (Ok y)
     --> y
 
+    Result.toMaybe (Ok x)
+    --> Just x
+
+    Result.toMaybe (Err e)
+    --> Nothing
+
 
 ### Lists
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3970,7 +3970,8 @@ resultMapChecks checkInfo =
                         checkInfo.fnRange
                         (if checkInfo.usingRightPizza then
                             [ Fix.removeRange { start = checkInfo.fnRange.start, end = (Node.range checkInfo.firstArg).start }
-                            , Fix.insertAt (Node.range checkInfo.firstArg).end " |> Ok"
+                            , Fix.insertAt (Node.range checkInfo.firstArg).end
+                                (" |> " ++ qualifiedToString (qualify ( [ "Result" ], "Ok" ) checkInfo))
                             ]
                                 ++ List.map Fix.removeRange okRanges
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5245,15 +5245,12 @@ listSortByChecks checkInfo =
         _ ->
             case getAlwaysResult checkInfo checkInfo.firstArg of
                 Just _ ->
-                    [ Rule.errorWithFix
-                        (toIdentityErrorInfo { toFix = "List.sortBy (always a)", lastArgName = "list" })
-                        checkInfo.fnRange
-                        (toIdentityFix
-                            { lastArg = secondArg checkInfo
-                            , parentRange = checkInfo.parentRange
-                            , qualifyResources = checkInfo
-                            }
-                        )
+                    [ identityError
+                        { toFix = "List.sortBy (always a)"
+                        , lastArgName = "list"
+                        , lastArg = secondArg checkInfo
+                        , resources = checkInfo
+                        }
                     ]
 
                 Nothing ->
@@ -5318,15 +5315,12 @@ listSortWithChecks checkInfo =
                     let
                         fixToIdentity : List (Error {})
                         fixToIdentity =
-                            [ Rule.errorWithFix
-                                (toIdentityErrorInfo { toFix = "List.sortWith (\\_ _ -> " ++ AstHelpers.orderToString order ++ ")", lastArgName = "list" })
-                                checkInfo.fnRange
-                                (toIdentityFix
-                                    { lastArg = secondArg checkInfo
-                                    , parentRange = checkInfo.parentRange
-                                    , qualifyResources = checkInfo
-                                    }
-                                )
+                            [ identityError
+                                { toFix = "List.sortWith (\\_ _ -> " ++ AstHelpers.orderToString order ++ ")"
+                                , lastArgName = "list"
+                                , lastArg = secondArg checkInfo
+                                , resources = checkInfo
+                                }
                             ]
                     in
                     case order of
@@ -7232,11 +7226,26 @@ replaceByBoolFix parentRange lastArg replacementValue qualifyResources =
     ]
 
 
-toIdentityErrorInfo : { toFix : String, lastArgName : String } -> { message : String, details : List String }
-toIdentityErrorInfo config =
-    { message = "Using " ++ config.toFix ++ " will always return the same " ++ config.lastArgName
-    , details = [ "You can replace this call by the " ++ config.lastArgName ++ " itself." ]
+identityError :
+    { toFix : String
+    , lastArgName : String
+    , lastArg : Maybe (Node lastArgument)
+    , resources : QualifyResources { a | fnRange : Range, parentRange : Range }
     }
+    -> Error {}
+identityError config =
+    Rule.errorWithFix
+        { message = "Using " ++ config.toFix ++ " will always return the same " ++ config.lastArgName
+        , details =
+            case config.lastArg of
+                Nothing ->
+                    [ "You can replace this call by identity." ]
+
+                Just _ ->
+                    [ "You can replace this call by the " ++ config.lastArgName ++ " itself." ]
+        }
+        config.resources.fnRange
+        (toIdentityFix { lastArg = config.lastArg, resources = config.resources })
 
 
 {-| identity if there's no second argument, else the second argument.
@@ -7248,21 +7257,24 @@ noopFix : CheckInfo -> List Fix
 noopFix checkInfo =
     toIdentityFix
         { lastArg = secondArg checkInfo
-        , parentRange = checkInfo.parentRange
-        , qualifyResources = checkInfo
+        , resources = checkInfo
         }
 
 
-toIdentityFix : { lastArg : Maybe (Node lastArgument), parentRange : Range, qualifyResources : QualifyResources a } -> List Fix
+toIdentityFix :
+    { lastArg : Maybe (Node lastArgument)
+    , resources : QualifyResources { a | parentRange : Range }
+    }
+    -> List Fix
 toIdentityFix config =
     case config.lastArg of
         Nothing ->
-            [ Fix.replaceRangeBy config.parentRange
-                (qualifiedToString (qualify ( [ "Basics" ], "identity" ) config.qualifyResources))
+            [ Fix.replaceRangeBy config.resources.parentRange
+                (qualifiedToString (qualify ( [ "Basics" ], "identity" ) config.resources))
             ]
 
         Just (Node lastArgRange _) ->
-            keepOnlyFix { parentRange = config.parentRange, keep = lastArgRange }
+            keepOnlyFix { parentRange = config.resources.parentRange, keep = lastArgRange }
 
 
 {-| Use in combination with

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7371,7 +7371,7 @@ identityError :
     -> Error {}
 identityError config =
     Rule.errorWithFix
-        { message = "Using " ++ config.toFix ++ " will always return the same " ++ config.lastArgName
+        { message = "Using " ++ config.toFix ++ " will always return the same given " ++ config.lastArgName
         , details =
             case config.lastArg of
                 Nothing ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -374,6 +374,15 @@ Destructuring using case expressions
     Result.map f (Ok x)
     --> Ok (f x)
 
+    Result.mapError identity x
+    --> x
+
+    Result.mapError f (Ok x)
+    --> Ok x
+
+    Result.mapError f (Err x)
+    --> Err (f x)
+
     Result.andThen f (Err x)
     --> Err x
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10814,7 +10814,7 @@ a = List.sortBy (always b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortBy (always a) will always return the same list"
+                            { message = "Using List.sortBy (always a) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortBy"
                             }
@@ -10830,7 +10830,7 @@ a = List.sortBy (always b) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortBy (always a) will always return the same list"
+                            { message = "Using List.sortBy (always a) will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.sortBy"
                             }
@@ -10846,7 +10846,7 @@ a = List.sortBy (\\_ -> b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortBy (always a) will always return the same list"
+                            { message = "Using List.sortBy (always a) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortBy"
                             }
@@ -10862,7 +10862,7 @@ a = List.sortBy (\\_ -> b) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortBy (always a) will always return the same list"
+                            { message = "Using List.sortBy (always a) will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.sortBy"
                             }
@@ -10998,7 +10998,7 @@ a = List.sortWith (always (always GT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -11014,7 +11014,7 @@ a = List.sortWith (always (always GT)) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.sortWith"
                             }
@@ -11030,7 +11030,7 @@ a = List.sortWith (\\_ -> (always GT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -11046,7 +11046,7 @@ a = List.sortWith (\\_ _ -> GT)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -11062,7 +11062,7 @@ a = List.sortWith (always (\\_ -> GT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> GT) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -11078,7 +11078,7 @@ a = List.sortWith (always (always EQ))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -11094,7 +11094,7 @@ a = List.sortWith (always (always EQ)) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.sortWith"
                             }
@@ -11110,7 +11110,7 @@ a = List.sortWith (\\_ -> (always EQ))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -11126,7 +11126,7 @@ a = List.sortWith (\\_ _ -> EQ)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -11142,7 +11142,7 @@ a = List.sortWith (always (\\_ -> EQ))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
+                            { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -13142,7 +13142,7 @@ a = Result.mapError identity x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using Result.mapError identity will always return the same result"
+                            { message = "Using Result.mapError identity will always return the same given result"
                             , details = [ "You can replace this call by the result itself." ]
                             , under = "Result.mapError"
                             }
@@ -13158,7 +13158,7 @@ a = Result.mapError identity <| x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using Result.mapError identity will always return the same result"
+                            { message = "Using Result.mapError identity will always return the same given result"
                             , details = [ "You can replace this call by the result itself." ]
                             , under = "Result.mapError"
                             }
@@ -13174,7 +13174,7 @@ a = x |> Result.mapError identity
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using Result.mapError identity will always return the same result"
+                            { message = "Using Result.mapError identity will always return the same given result"
                             , details = [ "You can replace this call by the result itself." ]
                             , under = "Result.mapError"
                             }
@@ -13190,7 +13190,7 @@ a = Result.mapError identity
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using Result.mapError identity will always return the same result"
+                            { message = "Using Result.mapError identity will always return the same given result"
                             , details = [ "You can replace this call by identity." ]
                             , under = "Result.mapError"
                             }
@@ -13206,7 +13206,7 @@ a = Result.mapError <| identity
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using Result.mapError identity will always return the same result"
+                            { message = "Using Result.mapError identity will always return the same given result"
                             , details = [ "You can replace this call by identity." ]
                             , under = "Result.mapError"
                             }
@@ -13222,7 +13222,7 @@ a = identity |> Result.mapError
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using Result.mapError identity will always return the same result"
+                            { message = "Using Result.mapError identity will always return the same given result"
                             , details = [ "You can replace this call by identity." ]
                             , under = "Result.mapError"
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -12751,6 +12751,7 @@ resultTests : Test
 resultTests =
     describe "Result"
         [ resultMapTests
+        , resultMapErrorTests
         , resultAndThenTests
         , resultWithDefaultTests
         ]
@@ -13068,6 +13069,325 @@ a = Ok >> Result.map f >> g
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = f >> Ok >> g
+"""
+                        ]
+        ]
+
+
+resultMapErrorTests : Test
+resultMapErrorTests =
+    describe "Result.mapError"
+        [ test "should not report Result.mapError used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError
+b = Result.mapError f
+c = Result.mapError f x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Result.mapError f (Ok z) by (Ok z)" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f (Ok z)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Calling Result.mapError on a value that is Ok will always return the Ok result value"
+                            , details = [ "You can remove the Result.mapError call." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (Ok z)
+"""
+                        ]
+        , test "should replace Result.mapError f <| Ok z by Ok z" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f <| Ok z
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Calling Result.mapError on a value that is Ok will always return the Ok result value"
+                            , details = [ "You can remove the Result.mapError call." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Ok z
+"""
+                        ]
+        , test "should replace Ok z |> Result.mapError f by Ok z" <|
+            \() ->
+                """module A exposing (..)
+a = Ok z |> Result.mapError f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Calling Result.mapError on a value that is Ok will always return the Ok result value"
+                            , details = [ "You can remove the Result.mapError call." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Ok z
+"""
+                        ]
+        , test "should replace Result.mapError identity x by x" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError identity x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError identity will always return the same result"
+                            , details = [ "You can replace this call by the result itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = x
+"""
+                        ]
+        , test "should replace Result.mapError identity <| x by x" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError identity <| x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError identity will always return the same result"
+                            , details = [ "You can replace this call by the result itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = x
+"""
+                        ]
+        , test "should replace x |> Result.mapError identity by x" <|
+            \() ->
+                """module A exposing (..)
+a = x |> Result.mapError identity
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError identity will always return the same result"
+                            , details = [ "You can replace this call by the result itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = x
+"""
+                        ]
+        , test "should replace Result.mapError identity by identity" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError identity
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError identity will always return the same result"
+                            , details = [ "You can replace this call by identity." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
+        , test "should replace Result.mapError <| identity by identity" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError <| identity
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError identity will always return the same result"
+                            , details = [ "You can replace this call by identity." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
+        , test "should replace identity |> Result.mapError by identity" <|
+            \() ->
+                """module A exposing (..)
+a = identity |> Result.mapError
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError identity will always return the same result"
+                            , details = [ "You can replace this call by identity." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
+        , test "should replace Result.mapError f (Err x) by Err (f x)" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f (Err x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err (f x)
+"""
+                        ]
+        , test "should replace Result.mapError f <| Err x by Err (f x)" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f <| Err x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err (f <| x)
+"""
+                        ]
+        , test "should replace Err x |> Result.mapError f by x |> f |> Err" <|
+            \() ->
+                """module A exposing (..)
+a = Err x |> Result.mapError f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = x |> f |> Err
+"""
+                        ]
+        , test "should replace x |> Err |> Result.mapError f by x |> f |> Err" <|
+            \() ->
+                """module A exposing (..)
+a = x |> Err |> Result.mapError f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = x |> f |> Err
+"""
+                        ]
+        , test "should replace Result.mapError f <| Err <| x by Err <| f <| x" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f <| Err <| x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err (f <| x)
+"""
+                        ]
+        , test "should replace Result.mapError f << Err by Err << f" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f << Err
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f
+"""
+                        ]
+        , test "should replace Err >> Result.mapError f by f >> Err" <|
+            \() ->
+                """module A exposing (..)
+a = Err >> Result.mapError f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = f >> Err
+"""
+                        ]
+        , test "should replace Result.mapError f << Err << a by Err << f << a" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f << Err << a
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f << a
+"""
+                        ]
+        , test "should replace g << Result.mapError f << Err by g << Err << f" <|
+            \() ->
+                """module A exposing (..)
+a = g << Result.mapError f << Err
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = g << Err << f
+"""
+                        ]
+        , test "should replace Err >> Result.mapError f >> g by f >> Err >> g" <|
+            \() ->
+                """module A exposing (..)
+a = Err >> Result.mapError f >> g
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = f >> Err >> g
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10815,7 +10815,7 @@ a = List.sortBy (always b)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortBy (always a) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortBy"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10847,7 +10847,7 @@ a = List.sortBy (\\_ -> b)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortBy (always a) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortBy"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -10999,7 +10999,7 @@ a = List.sortWith (always (always GT))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11031,7 +11031,7 @@ a = List.sortWith (\\_ -> (always GT))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11047,7 +11047,7 @@ a = List.sortWith (\\_ _ -> GT)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11063,7 +11063,7 @@ a = List.sortWith (always (\\_ -> GT))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortWith (\\_ _ -> GT) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11079,7 +11079,7 @@ a = List.sortWith (always (always EQ))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11111,7 +11111,7 @@ a = List.sortWith (\\_ -> (always EQ))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11127,7 +11127,7 @@ a = List.sortWith (\\_ _ -> EQ)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11143,7 +11143,7 @@ a = List.sortWith (always (\\_ -> EQ))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Using List.sortWith (\\_ _ -> EQ) will always return the same list"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)


### PR DESCRIPTION
```elm
Result.mapError identity x
--> x
Result.mapError f (Ok x)
--> Ok x
Result.mapError f (Err x)
--> Err (f x)
Result.mapError f << Ok
--> Ok
Result.mapError f << Err
--> Err << f
```
Only the first 3 are shown in the summary