### PR TITLE
Add ability to reduce lambdas

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4094,35 +4094,36 @@ resultMapErrorCompositionChecks checkInfo =
             else
                 ( checkInfo.right, checkInfo.left )
     in
-    case getSpecificFunctionCall ( [ "Result" ], "mapError" ) checkInfo.lookupTable later of
+    case AstHelpers.getSpecificReducedFunctionCall ( [ "Result" ], "mapError" ) checkInfo.lookupTable later of
         Nothing ->
             []
 
         Just resultMapErrorCall ->
             firstThatReportsError
                 [ \() ->
-                    if AstHelpers.isSpecificValueOrFunction [ "Result" ] "Err" checkInfo.lookupTable earlier then
-                        [ Rule.errorWithFix
-                            resultMapErrorOnErrErrorInfo
-                            resultMapErrorCall.fnRange
-                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range resultMapErrorCall.firstArg }
-                                ++ [ if checkInfo.fromLeftToRight then
-                                        -- >>
-                                        Fix.insertAt checkInfo.parentRange.end
-                                            (" >> " ++ qualifiedToString (qualify ( [ "Result" ], "Err" ) checkInfo))
+                    case AstHelpers.getSpecificReducedFunction ( [ "Result" ], "Err" ) checkInfo.lookupTable earlier of
+                        Nothing ->
+                            []
 
-                                     else
-                                        -- <<
-                                        Fix.insertAt checkInfo.parentRange.start
-                                            (qualifiedToString (qualify ( [ "Result" ], "Err" ) checkInfo) ++ " << ")
-                                   ]
-                            )
-                        ]
+                        Just _ ->
+                            [ Rule.errorWithFix
+                                resultMapErrorOnErrErrorInfo
+                                resultMapErrorCall.fnRange
+                                (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range resultMapErrorCall.firstArg }
+                                    ++ [ if checkInfo.fromLeftToRight then
+                                            -- >>
+                                            Fix.insertAt checkInfo.parentRange.end
+                                                (" >> " ++ qualifiedToString (qualify ( [ "Result" ], "Err" ) checkInfo))
 
-                    else
-                        []
+                                         else
+                                            -- <<
+                                            Fix.insertAt checkInfo.parentRange.start
+                                                (qualifiedToString (qualify ( [ "Result" ], "Err" ) checkInfo) ++ " << ")
+                                       ]
+                                )
+                            ]
                 , \() ->
-                    case AstHelpers.getSpecificValueOrFunction ( [ "Result" ], "Ok" ) checkInfo.lookupTable earlier of
+                    case AstHelpers.getSpecificReducedFunction ( [ "Result" ], "Ok" ) checkInfo.lookupTable earlier of
                         Nothing ->
                             []
 

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -365,6 +365,27 @@ isIdentity lookupTable baseNode =
             False
 
 
+getCollapsedLambda : Node Expression -> Maybe { patterns : List (Node Pattern), expression : Node Expression }
+getCollapsedLambda expressionNode =
+    case Node.value (removeParens expressionNode) of
+        Expression.LambdaExpression lambda ->
+            case getCollapsedLambda lambda.expression of
+                Nothing ->
+                    Just
+                        { patterns = lambda.args
+                        , expression = lambda.expression
+                        }
+
+                Just innerCollapsedLambda ->
+                    Just
+                        { patterns = lambda.args ++ innerCollapsedLambda.patterns
+                        , expression = innerCollapsedLambda.expression
+                        }
+
+        _ ->
+            Nothing
+
+
 getVarPattern : Node Pattern -> Maybe String
 getVarPattern node =
     case Node.value node of

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -11,6 +11,7 @@ all =
     describe "Simplify"
         [ configurationTests
         , qualifyTests
+        , lambdaReduceTests
         , identityTests
         , alwaysTests
         , booleanTests
@@ -667,6 +668,132 @@ a =
         [ \\foldl -> doIt
         , (\\foldl -> doIt) >> (\\x -> foldl f x)
         ]
+"""
+                        ]
+        ]
+
+
+
+-- LAMBDA REDUCE
+
+
+lambdaReduceTests : Test
+lambdaReduceTests =
+    describe "lambda reduce"
+        [ test "should detect (\\error -> Err error) as Err function" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f << (\\error -> Err error)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f
+"""
+                        ]
+        , test "should detect (\\error -> error |> Err) as Err function" <|
+            \() ->
+                -- Err in practice only takes 1 argument; this is just for testing reducing functionality
+                """module A exposing (..)
+a = Result.mapError f << (\\error -> error |> Err)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f
+"""
+                        ]
+        , test "should detect (\\error -> Err <| error) as Err function" <|
+            \() ->
+                -- Err in practice only takes 1 argument; this is just for testing reducing functionality
+                """module A exposing (..)
+a = Result.mapError f << (\\error -> Err <| error)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f
+"""
+                        ]
+        , test "should detect (\\error sorry -> (error |> Err) <| sorry) as Err function" <|
+            \() ->
+                -- Err in practice only takes 1 argument; this is just for testing reducing functionality
+                """module A exposing (..)
+a = Result.mapError f << (\\error -> \\sorry -> (error |> Err) <| sorry)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f
+"""
+                        ]
+        , test "should detect (\\error -> \\sorry -> (error |> Err) <| sorry) as Err function" <|
+            \() ->
+                -- Err in practice only takes 1 argument; this is just for testing reducing functionality
+                """module A exposing (..)
+a = Result.mapError f << (\\error -> \\sorry -> (error |> Err) <| sorry)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f
+"""
+                        ]
+        , test "should detect (\\result -> Result.mapError f result) as Result.mapError f call" <|
+            \() ->
+                """module A exposing (..)
+a = (\\result -> Result.mapError f result) << Err
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f
+"""
+                        ]
+        , test "should detect (\\result -> \\sorry -> (result |> Result.mapError f) <| sorry) as Result.mapError f call" <|
+            \() ->
+                """module A exposing (..)
+a = (\\result -> \\sorry -> (result |> Result.mapError f) <| sorry) << Err
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Result.mapError on Err will result in Err with the function applied to the error"
+                            , details = [ "You can replace this call by Err with the function directly applied to the error itself." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Err << f
 """
                         ]
         ]


### PR DESCRIPTION
Adds a simple algorithm that tries to reduce
```elm
(\f -> List.map f) --> List.map
(\f -> \xs -> List.map f xs) --> List.map
(\f xs -> (f |> List.map) <| xs) --> List.map
```
This PR currently only uses these reducing function parsers for `Result.mapError`, but this should be useful in a lot of places.

Reducing only looks at lambdas, so it isn't "fully complete" since it doesn't reduce stuff like case-ofs or let blocks, e.g.
```elm
case unrelated of
    A -> \a -> f a
    B -> \b -> f b
```
or
```elm
case unrelated of
    A -> \a b -> function b
    B -> \a -> function
```
(_maybe_ that could be a separate check. Moving common arguments to an upper level might be too opinionated. A better place might be [`elm-review-reducible-lambdas`](https://package.elm-lang.org/packages/jsuder-xx/elm-review-reducible-lambdas/latest/NoEtaReducibleLambdas))