### PR TITLE
Normalize >> and <<

### DIFF
--- a/src/Simplify/Normalize.elm
+++ b/src/Simplify/Normalize.elm
@@ -2,6 +2,7 @@ module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, comp
 
 import Dict
 import Elm.Syntax.Expression as Expression exposing (Expression)
+import Elm.Syntax.Infix as Infix
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern as Pattern exposing (Pattern)
 import Elm.Syntax.Range as Range
@@ -67,6 +68,9 @@ normalize resources node =
             addToFunctionCall
                 (normalize resources function)
                 (normalize resources extraArgument)
+
+        Expression.OperatorApplication "<<" _ left right ->
+            toNode (Expression.OperatorApplication ">>" Infix.Right (normalize resources right) (normalize resources left))
 
         Expression.OperatorApplication "::" infixDirection element list ->
             let

--- a/tests/Simplify/NormalizeTest.elm
+++ b/tests/Simplify/NormalizeTest.elm
@@ -621,6 +621,12 @@ normalizeWithInferredAndExpect moduleNames inferredList expected source =
 
 normalizeBase : List ( Range, ModuleName ) -> Infer.Inferred -> Expression -> String -> Expect.Expectation
 normalizeBase moduleNames inferred expected source =
+    normalizeSourceCode moduleNames inferred source
+        |> Expect.equal expected
+
+
+normalizeSourceCode : List ( Range, ModuleName ) -> Infer.Inferred -> String -> Expression
+normalizeSourceCode moduleNames inferred source =
     ("module A exposing (..)\nvalue = " ++ source)
         |> parse
         |> getValue
@@ -629,7 +635,6 @@ normalizeBase moduleNames inferred expected source =
             , inferredConstants = ( inferred, [] )
             }
         |> Node.value
-        |> Expect.equal expected
 
 
 {-| Parse source code into a AST.

--- a/tests/Simplify/NormalizeTest.elm
+++ b/tests/Simplify/NormalizeTest.elm
@@ -8,7 +8,7 @@ import Elm.Processing
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Expression exposing (Expression(..), LetDeclaration(..))
 import Elm.Syntax.File exposing (File)
-import Elm.Syntax.Infix as Infix
+import Elm.Syntax.Infix as Infix exposing (InfixDirection(..))
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern(..))
@@ -488,6 +488,31 @@ simpleNormalizationTests =
                             , expression = n (FunctionOrValue [] "x")
                             }
                         )
+        , test "should not change anything about >>" <|
+            \() ->
+                "a >> b >> c >> d"
+                    |> normalizeAndExpect
+                        (OperatorApplication ">>"
+                            Right
+                            (n (FunctionOrValue [] "a"))
+                            (n
+                                (OperatorApplication ">>"
+                                    Right
+                                    (n (FunctionOrValue [] "b"))
+                                    (n
+                                        (OperatorApplication ">>"
+                                            Right
+                                            (n (FunctionOrValue [] "c"))
+                                            (n (FunctionOrValue [] "d"))
+                                        )
+                                    )
+                                )
+                            )
+                        )
+        , test "should switch << to use >>" <|
+            \() ->
+                normalizeSourceCode [] Infer.empty "d << c << b << a"
+                    |> Expect.equal (normalizeSourceCode [] Infer.empty "a >> b >> c >> d")
         ]
 
 


### PR DESCRIPTION
This way we can detect that `(f >> g) a` and `(g << f) a` are the same.