### PR TITLE
Add simplifications for Dict.toList, then List.map tuple part access

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -714,6 +714,12 @@ Destructuring using case expressions
     Dict.partition (always False) dict
     --> ( Dict.empty, dict )
 
+    List.map Tuple.first (Dict.toList dict)
+    --> Dict.keys x
+
+    List.map Tuple.second (Dict.toList dict)
+    --> Dict.values x
+
 
 ### Cmd / Sub
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -715,10 +715,10 @@ Destructuring using case expressions
     --> ( Dict.empty, dict )
 
     List.map Tuple.first (Dict.toList dict)
-    --> Dict.keys x
+    --> Dict.keys dict
 
     List.map Tuple.second (Dict.toList dict)
-    --> Dict.values x
+    --> Dict.values dict
 
 
 ### Cmd / Sub

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -334,11 +334,11 @@ isTupleFirstAccess lookupTable expressionNode =
 isTupleSecondAccess : ModuleNameLookupTable -> Node Expression -> Bool
 isTupleSecondAccess lookupTable expressionNode =
     case getSpecificReducedFunction ( [ "Tuple" ], "second" ) lookupTable expressionNode of
-        Nothing ->
-            isTupleSecondPatternLambda expressionNode
-
         Just _ ->
             True
+
+        Nothing ->
+            isTupleSecondPatternLambda expressionNode
 
 
 isTupleFirstPatternLambda : Node Expression -> Bool

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -346,7 +346,7 @@ isTupleFirstPatternLambda expressionNode =
     case Node.value (removeParens expressionNode) of
         Expression.LambdaExpression lambda ->
             case lambda.args of
-                [ Node _ (Pattern.TuplePattern [ Node _ (Pattern.VarPattern firstVariableName), Node _ Pattern.AllPattern ]) ] ->
+                [ Node _ (Pattern.TuplePattern [ Node _ (Pattern.VarPattern firstVariableName), _ ]) ] ->
                     case Node.value lambda.expression of
                         Expression.FunctionOrValue [] resultName ->
                             resultName == firstVariableName
@@ -366,7 +366,7 @@ isTupleSecondPatternLambda expressionNode =
     case Node.value (removeParens expressionNode) of
         Expression.LambdaExpression lambda ->
             case lambda.args of
-                [ Node _ (Pattern.TuplePattern [ Node _ Pattern.AllPattern, Node _ (Pattern.VarPattern firstVariableName) ]) ] ->
+                [ Node _ (Pattern.TuplePattern [ _, Node _ (Pattern.VarPattern firstVariableName) ]) ] ->
                     case Node.value lambda.expression of
                         Expression.FunctionOrValue [] resultName ->
                             resultName == firstVariableName

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -324,10 +324,10 @@ getNotFunction lookupTable baseNode =
 isTupleFirstAccess : ModuleNameLookupTable -> Node Expression -> Bool
 isTupleFirstAccess lookupTable expressionNode =
     case getSpecificReducedFunction ( [ "Tuple" ], "first" ) lookupTable expressionNode of
-        Nothing ->
-            False
-
         Just _ ->
+            True
+
+        Nothing ->
             isTupleFirstPatternLambda expressionNode
 
 
@@ -335,10 +335,10 @@ isTupleSecondAccess : ModuleNameLookupTable -> Node Expression -> Bool
 isTupleSecondAccess lookupTable expressionNode =
     case getSpecificReducedFunction ( [ "Tuple" ], "second" ) lookupTable expressionNode of
         Nothing ->
-            False
+            isTupleSecondPatternLambda expressionNode
 
         Just _ ->
-            isTupleSecondPatternLambda expressionNode
+            True
 
 
 isTupleFirstPatternLambda : Node Expression -> Bool

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7491,6 +7491,242 @@ a = identity |> List.map
 a = identity
 """
                         ]
+        , test "should replace Dict.toList >> List.map Tuple.first by Dict.keys" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.toList >> List.map Tuple.first
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys
+"""
+                        ]
+        , test "should replace Dict.toList >> List.map (\\( part0, _ ) -> part0) by Dict.keys" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.toList >> List.map (\\( part0, _ ) -> part0)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys
+"""
+                        ]
+        , test "should replace List.map Tuple.first << Dict.toList Tuple.first by Dict.keys" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = List.map Tuple.first << Dict.toList
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys
+"""
+                        ]
+        , test "should replace Dict.toList >> List.map Tuple.second by Dict.values" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.toList >> List.map Tuple.second
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.second is the same as using Dict.values"
+                            , details = [ "Using Dict.values directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.values
+"""
+                        ]
+        , test "should replace Dict.toList >> List.map (\\( _, part1 ) -> part1) by Dict.values" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.toList >> List.map (\\( _, part1 ) -> part1)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.second is the same as using Dict.values"
+                            , details = [ "Using Dict.values directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.values
+"""
+                        ]
+        , test "should replace List.map Tuple.second << Dict.toList Tuple.second by Dict.values" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = List.map Tuple.second << Dict.toList
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.second is the same as using Dict.values"
+                            , details = [ "Using Dict.values directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.values
+"""
+                        ]
+        , test "should replace List.map Tuple.first (Dict.toList dict) by Dict.keys dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = List.map Tuple.first (Dict.toList dict)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys dict
+"""
+                        ]
+        , test "should replace List.map Tuple.first (Dict.toList <| dict) by Dict.keys dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = List.map Tuple.first (Dict.toList <| dict)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys dict
+"""
+                        ]
+        , test "should replace List.map Tuple.first (dict |> Dict.toList) by Dict.keys dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = List.map Tuple.first (dict |> Dict.toList)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys dict
+"""
+                        ]
+        , test "should replace List.map Tuple.first <| Dict.toList dict by Dict.keys <| dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = List.map Tuple.first <| Dict.toList dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys <| dict
+"""
+                        ]
+        , test "should replace List.map Tuple.first <| (Dict.toList <| dict) by Dict.keys <| dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = List.map Tuple.first <| (Dict.toList <| dict)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys <| dict
+"""
+                        ]
+        , test "should replace List.map Tuple.first <| (dict |> Dict.toList) by Dict.keys <| dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = List.map Tuple.first <| (dict |> Dict.toList)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.keys <| dict
+"""
+                        ]
+
+        -- TODO
+        , test "should replace Dict.toList dict |> List.map Tuple.first by dict |> Dict.keys" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.toList dict |> List.map Tuple.first
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using Dict.toList, then List.map Tuple.first is the same as using Dict.keys"
+                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict |> Dict.keys
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7707,8 +7707,6 @@ import Dict
 a = Dict.keys <| dict
 """
                         ]
-
-        -- TODO
         , test "should replace Dict.toList dict |> List.map Tuple.first by dict |> Dict.keys" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7343,7 +7343,15 @@ listMapTests =
         [ test "should not report List.map used with okay arguments" <|
             \() ->
                 """module A exposing (..)
-a = List.map f x
+a = List.map
+b = List.map f
+c = List.map f x
+d = List.map f (Dict.fromList dict)
+e = List.map (\\( a, b ) -> a + b) (Dict.fromList dict)
+f = List.map (f >> Tuple.first) (Dict.fromList dict)
+d = List.map f << Dict.fromList
+e = List.map (\\( a, b ) -> a + b) << Dict.fromList
+f = List.map (f >> Tuple.first) << Dict.fromList
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors


### PR DESCRIPTION
As shown in the Dict section of https://github.com/jfmengels/elm-review-simplify/issues/2

```elm
List.map Tuple.first (Dict.toList dict)
--> Dict.keys dict
List.map Tuple.second (Dict.toList dict)
--> Dict.values dict

List.map (\( part0, _ ) -> part0) (Dict.toList dict)
--> Dict.keys dict
List.map (\( part1, _ ) -> part1) (Dict.toList dict)
--> Dict.values dict

List.map Tuple.first << Dict.toList
--> Dict.keys
List.map Tuple.second << Dict.toList
--> Dict.values
```
Only the first 2 are shown in the summary

What might be interesting to add is
```elm
List.map (Tuple.first >> f) (Dict.fromList dict)
--> List.map f (Dict.keys dict)
List.map (\( part0, _ ) -> f part0) (Dict.fromList dict)
--> List.map f (Dict.keys dict)
```
etc