### PR TITLE
Fix #104

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4421,20 +4421,24 @@ listAppendChecks checkInfo =
                 , details = [ "Try moving all the elements into a single list." ]
                 }
                 checkInfo.fnRange
-                (let
-                    betweenListArguments : Range
-                    betweenListArguments =
-                        rangeBetweenExclusive ( firstListRange, secondListRange )
-                 in
-                 Fix.replaceRangeBy
-                    { start = { row = betweenListArguments.start.row, column = betweenListArguments.start.column - 1 }
-                    , end = { row = betweenListArguments.end.row, column = betweenListArguments.end.column + 1 }
-                    }
-                    ","
-                    :: keepOnlyFix
-                        { parentRange = checkInfo.parentRange
-                        , keep = Range.combine [ firstListRange, secondListRange ]
+                (if checkInfo.usingRightPizza then
+                    []
+
+                 else
+                    let
+                        betweenListArguments : Range
+                        betweenListArguments =
+                            rangeBetweenExclusive ( firstListRange, secondListRange )
+                    in
+                    Fix.replaceRangeBy
+                        { start = { row = betweenListArguments.start.row, column = betweenListArguments.start.column - 1 }
+                        , end = { row = betweenListArguments.end.row, column = betweenListArguments.end.column + 1 }
                         }
+                        ","
+                        :: keepOnlyFix
+                            { parentRange = checkInfo.parentRange
+                            , keep = Range.combine [ firstListRange, secondListRange ]
+                            }
                 )
             ]
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7468,11 +7468,15 @@ rangeBetweenExclusive ( aRange, bRange ) =
 
 locationsCompare : ( Location, Location ) -> Order
 locationsCompare ( aEnd, bEnd ) =
-    if aEnd.column == bEnd.column then
-        compare aEnd.row bEnd.row
+    case compare aEnd.row bEnd.row of
+        EQ ->
+            compare aEnd.column bEnd.column
 
-    else
-        compare aEnd.column bEnd.column
+        LT ->
+            LT
+
+        GT ->
+            GT
 
 
 removeFunctionFromFunctionCall : { a | fnRange : Range, firstArg : Node b, usingRightPizza : Bool } -> Fix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4421,9 +4421,14 @@ listAppendChecks checkInfo =
                 , details = [ "Try moving all the elements into a single list." ]
                 }
                 checkInfo.fnRange
-                (Fix.replaceRangeBy
-                    { start = { row = firstListRange.end.row, column = firstListRange.end.column - 1 }
-                    , end = { row = secondListRange.start.row, column = secondListRange.start.column + 1 }
+                (let
+                    betweenListArguments : Range
+                    betweenListArguments =
+                        rangeBetweenExclusive ( firstListRange, secondListRange )
+                 in
+                 Fix.replaceRangeBy
+                    { start = { row = betweenListArguments.start.row, column = betweenListArguments.start.column - 1 }
+                    , end = { row = betweenListArguments.end.row, column = betweenListArguments.end.column + 1 }
                     }
                     ","
                     :: keepOnlyFix

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6333,7 +6333,7 @@ d = List.append xs [ 1 ]
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should report List.append on two list literals" <|
+        , test "should report List.append applied on two list literals" <|
             \() ->
                 """module A exposing (..)
 a = List.append [b] [c,d,0]
@@ -6349,10 +6349,71 @@ a = List.append [b] [c,d,0]
 a = [b,c,d,0]
 """
                         ]
+        , test "should report List.append <| on two list literals" <|
+            \() ->
+                """module A exposing (..)
+a = List.append [b] <| [c,d,0]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Appending literal lists could be simplified to be a single List"
+                            , details = [ "Try moving all the elements into a single list." ]
+                            , under = "List.append"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [b,c,d,0]
+"""
+                        ]
+        , test "should report List.append |> on two list literals" <|
+            \() ->
+                """module A exposing (..)
+a = [c,d,0] |> List.append [b]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Appending literal lists could be simplified to be a single List"
+                            , details = [ "Try moving all the elements into a single list." ]
+                            , under = "List.append"
+                            }
+                        ]
         , test "should replace List.append [] ys by ys" <|
             \() ->
                 """module A exposing (..)
 a = List.append [] ys
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Appending [] doesn't have any effect"
+                            , details = [ "You can remove the List.append function and the []." ]
+                            , under = "List.append"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ys
+"""
+                        ]
+        , test "should replace List.append [] <| ys by ys" <|
+            \() ->
+                """module A exposing (..)
+a = List.append [] <| ys
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Appending [] doesn't have any effect"
+                            , details = [ "You can remove the List.append function and the []." ]
+                            , under = "List.append"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = ys
+"""
+                        ]
+        , test "should replace ys |> List.append [] by ys" <|
+            \() ->
+                """module A exposing (..)
+a = ys |> List.append []
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -6385,6 +6446,38 @@ a = identity
             \() ->
                 """module A exposing (..)
 a = List.append xs []
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Appending [] doesn't have any effect"
+                            , details = [ "You can remove the List.append function and the []." ]
+                            , under = "List.append"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = xs
+"""
+                        ]
+        , test "should replace List.append xs <| [] by xs" <|
+            \() ->
+                """module A exposing (..)
+a = List.append xs <| []
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Appending [] doesn't have any effect"
+                            , details = [ "You can remove the List.append function and the []." ]
+                            , under = "List.append"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = xs
+"""
+                        ]
+        , test "should replace [] |> List.append xs by xs" <|
+            \() ->
+                """module A exposing (..)
+a = [] |> List.append xs
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors


### PR DESCRIPTION
Corrects #104 

The error was that I blindly copied the range replacing from `(++)` which was wrong because the order: "first, then second argument" cannot be guaranteed

There is no way however to fix this without being able to extract source code of the piped list, therefore no fixes will be provided.