### PR TITLE
Add more tests for List.append

### DIFF
--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6349,6 +6349,22 @@ a = List.append [b] [c,d,0]
 a = [b,c,d,0]
 """
                         ]
+        , test "should report List.append applied on two list literals (multiple elements)" <|
+            \() ->
+                """module A exposing (..)
+a = List.append [ b, z ] [c,d,0]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Appending literal lists could be simplified to be a single List"
+                            , details = [ "Try moving all the elements into a single list." ]
+                            , under = "List.append"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ b, z ,c,d,0]
+"""
+                        ]
         , test "should report List.append <| on two list literals" <|
             \() ->
                 """module A exposing (..)
@@ -6379,6 +6395,22 @@ a = [c,d,0] |> List.append [b]
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = [b,c,d,0]
+"""
+                        ]
+        , test "should report List.append |> on two list literals (multiple elements)" <|
+            \() ->
+                """module A exposing (..)
+a = [c,d,0] |> List.append [ b, z ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Appending literal lists could be simplified to be a single List"
+                            , details = [ "Try moving all the elements into a single list." ]
+                            , under = "List.append"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ b, z ,c,d,0]
 """
                         ]
         , test "should replace List.append [] ys by ys" <|


### PR DESCRIPTION
I was wondering whether List.append worked correctly, because with only a single element to append, there are multiple ways that the tests could pass without doing the right thing in practice. Not a big surprise, it worked well, but let's add the tests anyway :) 