### PR TITLE
correctly fix List.concat of only list literals in pipeline

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4171,8 +4171,8 @@ listConcatChecks checkInfo =
                             , details = [ "Try moving all the elements into a single list." ]
                             }
                             checkInfo.parentRange
-                            (Fix.removeRange checkInfo.fnRange
-                                :: List.concatMap removeBoundariesFix args
+                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg }
+                                ++ List.concatMap removeBoundariesFix args
                             )
                         ]
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6582,7 +6582,39 @@ a = List.concat [ [ 1, 2, 3 ], [ 4, 5, 6] ]
                             , under = "List.concat [ [ 1, 2, 3 ], [ 4, 5, 6] ]"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a =  [  1, 2, 3 ,  4, 5, 6 ]
+a = [  1, 2, 3 ,  4, 5, 6 ]
+"""
+                        ]
+        , test "should report List.concat that only contains list literals, using (<|)" <|
+            \() ->
+                """module A exposing (..)
+a = List.concat <| [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Expression could be simplified to be a single List"
+                            , details = [ "Try moving all the elements into a single list." ]
+                            , under = "List.concat <| [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [  1, 2, 3 ,  4, 5, 6  ]
+"""
+                        ]
+        , test "should report List.concat that only contains list literals, using (|>)" <|
+            \() ->
+                """module A exposing (..)
+a = [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] |> List.concat
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Expression could be simplified to be a single List"
+                            , details = [ "Try moving all the elements into a single list." ]
+                            , under = "[ [ 1, 2, 3 ], [ 4, 5, 6 ] ] |> List.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [  1, 2, 3 ,  4, 5, 6  ]
 """
                         ]
         , test "should concatenate consecutive list literals in passed to List.concat" <|


### PR DESCRIPTION
Whenever we provided a fix for `List.concat [ [ ...], ..., [ ... ] ]`, we merged the elements and removed the `List.concat` function reference.

So whenever there was a pipeline like `List.concat <| [[1,2,3],[4,5,6]]`, the fix source code would not compile:

    I was unable to parse the source code after applying the fixes. Here is
    the result of the automatic fixing:
    
      ```
        module A exposing (..)
        a =  <| [1,2,3,4,5,6]
    
      ```
    
    This is problematic because fixes are meant to help the user, and applying
    this fix will give them more work to do. After the fix has been applied,
    the problem should be solved and the user should not have to think about it
    anymore. If a fix can not be applied fully, it should not be applied at
    all.

The fix in this PR uses `keepOnlyFix (range of first arg)` to solve this and adds tests to verify it now works.