### PR TITLE
correctly fix List.concat of only list literals in pipeline

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4208,8 +4208,8 @@ listConcatChecks checkInfo =
                                     , details = [ "Try moving all the elements into a single list." ]
                                     }
                                     checkInfo.parentRange
-                                    (Fix.removeRange checkInfo.fnRange
-                                        :: List.concatMap removeBoundariesFix args
+                                    (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg }
+                                        ++ List.concatMap removeBoundariesFix args
                                     )
                                 ]
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6651,7 +6651,39 @@ a = List.concat [ [ 1, 2, 3 ], [ 4, 5, 6] ]
                             , under = "List.concat [ [ 1, 2, 3 ], [ 4, 5, 6] ]"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a =  [  1, 2, 3 ,  4, 5, 6 ]
+a = [  1, 2, 3 ,  4, 5, 6 ]
+"""
+                        ]
+        , test "should report List.concat that only contains list literals, using (<|)" <|
+            \() ->
+                """module A exposing (..)
+a = List.concat <| [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Expression could be simplified to be a single List"
+                            , details = [ "Try moving all the elements into a single list." ]
+                            , under = "List.concat <| [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [  1, 2, 3 ,  4, 5, 6  ]
+"""
+                        ]
+        , test "should report List.concat that only contains list literals, using (|>)" <|
+            \() ->
+                """module A exposing (..)
+a = [ [ 1, 2, 3 ], [ 4, 5, 6 ] ] |> List.concat
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Expression could be simplified to be a single List"
+                            , details = [ "Try moving all the elements into a single list." ]
+                            , under = "[ [ 1, 2, 3 ], [ 4, 5, 6 ] ] |> List.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [  1, 2, 3 ,  4, 5, 6  ]
 """
                         ]
         , test "should concatenate consecutive list literals in passed to List.concat" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6988,6 +6988,38 @@ a = List.concatMap f [ a ]
 a =  f a
 """
                         ]
+        , test "should replace List.concatMap f [ b c ] by f (b c)" <|
+            \() ->
+                """module A exposing (..)
+a = List.concatMap f [ b c ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.concatMap on an element with a single item is the same as calling the function directly on that lone element."
+                            , details = [ "You can replace this call by a call to the function directly." ]
+                            , under = "List.concatMap"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a =  f (b c)
+"""
+                        ]
+        , test "should replace List.concatMap f <| [ a ] by f <| a" <|
+            \() ->
+                """module A exposing (..)
+a = List.concatMap f <| [ a ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.concatMap on an element with a single item is the same as calling the function directly on that lone element."
+                            , details = [ "You can replace this call by a call to the function directly." ]
+                            , under = "List.concatMap"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a =  f <| a
+"""
+                        ]
         , test "should replace List.concatMap f <| [ b c ] by f <| (b c)" <|
             \() ->
                 """module A exposing (..)
@@ -7004,7 +7036,7 @@ a = List.concatMap f <| [ b c ]
 a =  f <| (b c)
 """
                         ]
-        , test "should replace List.concatMap f <| [ c ] by c |> f" <|
+        , test "should replace [ c ] |> List.concatMap f by c |> f" <|
             \() ->
                 """module A exposing (..)
 a = [ c ] |> List.concatMap f
@@ -7020,7 +7052,7 @@ a = [ c ] |> List.concatMap f
 a = c |>  f
 """
                         ]
-        , test "should replace List.concatMap f <| [ b c ] by (b c) |> f" <|
+        , test "should replace [ b c ] |> List.concatMap f by (b c) |> f" <|
             \() ->
                 """module A exposing (..)
 a = [ b c ] |> List.concatMap f


### PR DESCRIPTION
Whenever we currently provide a fix for `List.concat [ [ ...], ..., [ ... ] ]`, we merge the elements and remove the `List.concat` function reference.

So whenever there was a pipeline like `List.concat <| [[1,2,3],[4,5,6]]`, the fix source code would not compile:

    I was unable to parse the source code after applying the fixes. Here is
    the result of the automatic fixing:
    
      ```
        module A exposing (..)
        a =  <| [1,2,3,4,5,6]
    
      ```
    
    This is problematic because fixes are meant to help the user, and applying
    this fix will give them more work to do. After the fix has been applied,
    the problem should be solved and the user should not have to think about it
    anymore. If a fix can not be applied fully, it should not be applied at
    all.

The fix in this PR uses `keepOnlyFix` with the range of list arg to solve this and adds tests to verify pipelines work correctly now.

One extra thing this PR contains which is only slighly related: For `concatMap f [ one ]` the tests had wrong names and were missing some cases. I couldn't let them sit there :)