### PR TITLE
Enable access to the operator Range

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2454,12 +2454,7 @@ findOperatorRange context =
 
 offsetInStringToLocation : { offset : Int, source : String, startLocation : Location } -> Location
 offsetInStringToLocation config =
-    let
-        before : List String
-        before =
-            config.source |> String.left config.offset |> String.lines
-    in
-    case before |> List.reverse of
+    case config.source |> String.left config.offset |> String.lines |> List.reverse of
         [] ->
             config.startLocation
 
@@ -2469,8 +2464,8 @@ offsetInStringToLocation config =
             }
 
         lineWithOffsetLocation :: _ :: linesBeforeBeforeWithOffsetLocation ->
-            { column = 1 + String.length lineWithOffsetLocation
-            , row = config.startLocation.row + 1 + List.length linesBeforeBeforeWithOffsetLocation
+            { row = config.startLocation.row + 1 + List.length linesBeforeBeforeWithOffsetLocation
+            , column = 1 + String.length lineWithOffsetLocation
             }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6640,6 +6640,7 @@ pipingIntoCompositionChecks context compositionDirection expressionNode =
 
                 Expression.OperatorApplication symbol _ left right ->
                     let
+                        continuedSearch : Maybe { opToReplaceRange : Range, fixes : List Fix }
                         continuedSearch =
                             case compositionDirection of
                                 LeftComposition ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2470,7 +2470,7 @@ offsetInStringToLocation config =
             , column = config.startLocation.column + String.length onlyLine
             }
 
-        lineWithOffsetLocation :: lineBeforeWithOffsetLocation :: linesBeforeBeforeWithOffsetLocation ->
+        lineWithOffsetLocation :: _ :: linesBeforeBeforeWithOffsetLocation ->
             { column = 1 + String.length lineWithOffsetLocation
             , row = config.startLocation.row + 1 + List.length linesBeforeBeforeWithOffsetLocation
             }
@@ -7893,6 +7893,7 @@ keepOnlyFix config =
 removeBoundariesFix : Node a -> List Fix
 removeBoundariesFix node =
     let
+        nodeRange : Range
         nodeRange =
             Node.range node
     in

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1746,9 +1746,11 @@ expressionVisitorHelp node context =
                 Just checkFn ->
                     { errors =
                         let
+                            leftRange : Range
                             leftRange =
                                 Node.range left
 
+                            rightRange : Range
                             rightRange =
                                 Node.range right
                         in
@@ -2458,6 +2460,7 @@ findOperatorRange checkInfo =
 offsetInStringToLocation : { offset : Int, source : String, startLocation : Location } -> Location
 offsetInStringToLocation config =
     let
+        before : List String
         before =
             config.source |> String.left config.offset |> String.lines
     in

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7760,13 +7760,6 @@ parenthesizeFix toSurround =
     ]
 
 
-removeParenthesesFix : Range -> Range -> List Fix -> List Fix
-removeParenthesesFix parentheses expr acc =
-    Fix.removeRange { start = parentheses.start, end = expr.start }
-        :: Fix.removeRange { start = expr.end, end = parentheses.end }
-        :: acc
-
-
 lastElementRange : List (Node a) -> Maybe Range
 lastElementRange nodes =
     case nodes of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2409,50 +2409,45 @@ findOperatorRange checkInfo =
             checkInfo.extractSourceCode
                 { start = checkInfo.leftRange.end, end = checkInfo.rightRange.start }
 
-        operatorRangeFound : Maybe Range
-        operatorRangeFound =
-            betweenOperands
-                |> String.indexes checkInfo.operator
-                |> List.map
+        operatorStartLocationFound : Maybe Location
+        operatorStartLocationFound =
+            String.indexes checkInfo.operator betweenOperands
+                |> findMap
                     (\operatorOffset ->
-                        offsetInStringToLocation
-                            { offset = operatorOffset
-                            , startLocation = checkInfo.leftRange.end
-                            , source = betweenOperands
-                            }
-                    )
-                |> List.foldl
-                    (\operatorStartLocation resultSoFar ->
-                        case resultSoFar of
-                            Just found ->
-                                Just found
+                        let
+                            operatorStartLocation : Location
+                            operatorStartLocation =
+                                offsetInStringToLocation
+                                    { offset = operatorOffset
+                                    , startLocation = checkInfo.leftRange.end
+                                    , source = betweenOperands
+                                    }
 
-                            Nothing ->
-                                let
-                                    isPartOfComment : Bool
-                                    isPartOfComment =
-                                        List.any
-                                            (\(Node commentRange _) ->
-                                                rangeContainsLocation operatorStartLocation commentRange
-                                            )
-                                            checkInfo.comments
-                                in
-                                if isPartOfComment then
-                                    Nothing
+                            isPartOfComment : Bool
+                            isPartOfComment =
+                                List.any
+                                    (\(Node commentRange _) ->
+                                        rangeContainsLocation operatorStartLocation commentRange
+                                    )
+                                    checkInfo.comments
+                        in
+                        if isPartOfComment then
+                            Nothing
 
-                                else
-                                    Just
-                                        { start = operatorStartLocation
-                                        , end =
-                                            { row = operatorStartLocation.row
-                                            , column = operatorStartLocation.column + String.length checkInfo.operator
-                                            }
-                                        }
+                        else
+                            Just operatorStartLocation
                     )
-                    Nothing
     in
-    operatorRangeFound
-        |> Maybe.withDefault
+    case operatorStartLocationFound of
+        Just operatorStartLocation ->
+            { start = operatorStartLocation
+            , end =
+                { row = operatorStartLocation.row
+                , column = operatorStartLocation.column + String.length checkInfo.operator
+                }
+            }
+
+        Nothing ->
             -- there's a bug somewhere
             Range.emptyRange
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6623,7 +6623,7 @@ pipingIntoCompositionChecks context compositionDirection expressionNode =
                 RightComposition ->
                     ( ">>", "|>" )
 
-        pipingIntoCompositionChecksHelp : Node Expression -> Maybe { opToReplaceRange : Range, fixes : List Fix }
+        pipingIntoCompositionChecksHelp : Node Expression -> Maybe { opToReplaceRange : Range, fixes : List Fix, firstStepIsComposition : Bool }
         pipingIntoCompositionChecksHelp subExpression =
             case Node.value subExpression of
                 Expression.ParenthesizedExpression inParens ->
@@ -6632,15 +6632,22 @@ pipingIntoCompositionChecks context compositionDirection expressionNode =
                             Nothing
 
                         Just error ->
-                            Just
-                                { error
-                                    | fixes =
-                                        removeBoundariesFix subExpression ++ error.fixes
-                                }
+                            if error.firstStepIsComposition then
+                                -- parens can safely be removed
+                                Just
+                                    { error
+                                        | fixes =
+                                            removeBoundariesFix subExpression ++ error.fixes
+                                    }
+
+                            else
+                                -- inside parenthesis is checked separately because
+                                -- the parens here can't safely be removed
+                                Nothing
 
                 Expression.OperatorApplication symbol _ left right ->
                     let
-                        continuedSearch : Maybe { opToReplaceRange : Range, fixes : List Fix }
+                        continuedSearch : Maybe { opToReplaceRange : Range, fixes : List Fix, firstStepIsComposition : Bool }
                         continuedSearch =
                             case compositionDirection of
                                 LeftComposition ->
@@ -6650,7 +6657,8 @@ pipingIntoCompositionChecks context compositionDirection expressionNode =
                                     pipingIntoCompositionChecksHelp right
                     in
                     if symbol == replacement then
-                        continuedSearch
+                        Maybe.map (\errors -> { errors | firstStepIsComposition = False })
+                            continuedSearch
 
                     else if symbol == opToFind then
                         let
@@ -6675,6 +6683,7 @@ pipingIntoCompositionChecks context compositionDirection expressionNode =
                                             Just additionalErrorsFound ->
                                                 additionalErrorsFound.fixes
                                        )
+                            , firstStepIsComposition = True
                             }
 
                     else
@@ -7775,26 +7784,13 @@ lastElementRange nodes =
 
 rangeBetweenExclusive : ( Range, Range ) -> Range
 rangeBetweenExclusive ( aRange, bRange ) =
-    case locationsCompare aRange.start bRange.start of
+    case Range.compareLocations aRange.start bRange.start of
         GT ->
             { start = bRange.end, end = aRange.start }
 
         -- EQ | LT
         _ ->
             { start = aRange.end, end = bRange.start }
-
-
-locationsCompare : Location -> Location -> Order
-locationsCompare aEnd bEnd =
-    case compare aEnd.row bEnd.row of
-        EQ ->
-            compare aEnd.column bEnd.column
-
-        LT ->
-            LT
-
-        GT ->
-            GT
 
 
 removeFunctionFromFunctionCall : { a | fnRange : Range, firstArg : Node b, usingRightPizza : Bool } -> Fix

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -17398,7 +17398,7 @@ a =
         |> h
 """
                         ]
-        , test "should replace >> when used directly in a |> pipeline (with parentheses)" <|
+        , test "should replace >> when used directly in a |> pipeline (right argument >> inside parentheses)" <|
             \() ->
                 """module A exposing (..)
 a =
@@ -17419,6 +17419,29 @@ a =
 a =
     b
         |> f |> g
+"""
+                        ]
+        , test "should replace >> when used directly in a |> pipeline (right argument |> >> inside parentheses)" <|
+            \() ->
+                """module A exposing (..)
+a =
+    b
+        |> (f |> g >> h)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use |> instead of >>"
+                            , details =
+                                [ "Because of the precedence of operators, using >> at this location is the same as using |>."
+                                , "Please use |> instead as that is more idiomatic in Elm and generally easier to read."
+                                ]
+                            , under = ">>"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a =
+    b
+        |> (f |> g |> h)
 """
                         ]
         , test "should replace << when used directly in a <| pipeline" <|
@@ -17466,6 +17489,52 @@ a =
                             |> Review.Test.whenFixed """module A exposing (..)
 a =
     h <| g <| f <| b
+"""
+                        ]
+        , test "should replace << when used directly in a <| pipeline (left argument << inside parentheses)" <|
+            \() ->
+                """module A exposing (..)
+a =
+    (f << g)
+        <| b
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use <| instead of <<"
+                            , details =
+                                [ "Because of the precedence of operators, using << at this location is the same as using <|."
+                                , "Please use <| instead as that is more idiomatic in Elm and generally easier to read."
+                                ]
+                            , under = "<<"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a =
+    f <| g
+        <| b
+"""
+                        ]
+        , test "should replace << when used directly in a <| pipeline (left argument << <| inside parentheses)" <|
+            \() ->
+                """module A exposing (..)
+a =
+    (f << g <| h) <|
+        b
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Use <| instead of <<"
+                            , details =
+                                [ "Because of the precedence of operators, using << at this location is the same as using <|."
+                                , "Please use <| instead as that is more idiomatic in Elm and generally easier to read."
+                                ]
+                            , under = "<<"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a =
+    (f <| g <| h) <|
+        b
 """
                         ]
         ]


### PR DESCRIPTION
`elm-syntax` only gives us the operator symbol String but having access to the operator Range as well is valuable:
- we can replace only the operator instead of replacing everything between the operands, preserving comments and whitespace. → fixes https://github.com/jfmengels/elm-review-simplify/issues/46
- we can have a better error Range for operation simplification. Error ranges can quickly go out of hand which is the reason all function simplifications put the error range on the `fnRange`, not one of the arguments. Now we can do the same with operations

It seems this will be part of `elm-syntax` v8 https://github.com/stil4m/elm-syntax/issues/74 but now we can patch things up in the meantime :white_flower:

If the PR's solution seems too unstable and you want to wait for v8, I'm happy to wait as well.

Now what's included in this PR?
  - finding the operator's range (skips searching in all comments) and saving it in the `OperatorCheckInfo`
  - a more conservative fix for `:: [ ... ]` as hinted at in https://github.com/jfmengels/elm-review-simplify/issues/46
  - tests

That means that if this PR would be merged, we still need to change the other error ranges to the operator ranges.