### PR TITLE
Add simplifications for Random.uniform, Random.weighted

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6476,7 +6476,7 @@ randomUniformChecks checkInfo =
                 in
                 [ Rule.errorWithFix
                     { message = "Random.uniform with only one possible value can be replaced by Random.constant"
-                    , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
+                    , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value." ]
                     }
                     checkInfo.fnRange
                     [ Fix.replaceRangeBy { start = checkInfo.parentRange.start, end = onlyValueRange.start }
@@ -6499,7 +6499,7 @@ randomWeightedChecks checkInfo =
             if AstHelpers.isEmptyList otherOptionsArg then
                 [ Rule.errorWithFix
                     { message = "Random.weighted with only one possible value can be replaced by Random.constant"
-                    , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                    , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value." ]
                     }
                     checkInfo.fnRange
                     (case Node.value checkInfo.firstArg of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6475,7 +6475,7 @@ randomUniformChecks checkInfo =
                         Node.range checkInfo.firstArg
                 in
                 [ Rule.errorWithFix
-                    { message = "uniform with only one possible value can be replaced by constant"
+                    { message = "Random.uniform with only one possible value can be replaced by Random.constant"
                     , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
                     }
                     checkInfo.fnRange
@@ -6498,7 +6498,7 @@ randomWeightedChecks checkInfo =
         Just otherOptionsArg ->
             if AstHelpers.isEmptyList otherOptionsArg then
                 [ Rule.errorWithFix
-                    { message = "weighted with only one possible value can be replaced by constant"
+                    { message = "Random.weighted with only one possible value can be replaced by Random.constant"
                     , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
                     }
                     checkInfo.fnRange

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -35,6 +35,7 @@ all =
         , parserTests
         , jsonDecodeTests
         , htmlAttributesTests
+        , randomTests
         , recordAccessTests
         , letTests
         , pipelineTests
@@ -17380,6 +17381,214 @@ a = Html.Attributes.classList (( x, False ) :: y :: tail)
                             |> Review.Test.whenFixed """module A exposing (..)
 import Html.Attributes
 a = Html.Attributes.classList (y :: tail)
+"""
+                        ]
+        ]
+
+
+
+-- Random
+
+
+randomTests : Test
+randomTests =
+    Test.describe "Random"
+        [ randomUniformTests
+        , randomWeightedChecks
+        ]
+
+
+randomUniformTests : Test
+randomUniformTests =
+    Test.describe "uniform"
+        [ test "should not report Random.uniform used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.uniform
+b = Random.uniform []
+c = Random.uniform first
+d = Random.uniform head tail
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Random.uniform a [] by Random.constant a" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.uniform a []
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "uniform with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.uniform"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant a
+"""
+                        ]
+        , test "should replace Random.uniform a <| [] by Random.constant a" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.uniform a <| []
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "uniform with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.uniform"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant a
+"""
+                        ]
+        , test "should replace [] |> Random.uniform a by Random.constant a" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = [] |> Random.uniform a
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "uniform with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.uniform"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant a
+"""
+                        ]
+        ]
+
+
+randomWeightedChecks : Test
+randomWeightedChecks =
+    Test.describe "weighted"
+        [ test "should not report Random.uniform used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.weighted
+b = Random.weighted []
+c = Random.weighted first
+d = Random.weighted head tail
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Random.weighted ( w, a ) [] by Random.constant a" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.weighted ( w, a ) []
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "weighted with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.weighted"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant a
+"""
+                        ]
+        , test "should replace Random.weighted ( w, a ) <| [] by Random.constant a" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.weighted ( w, a ) <| []
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "weighted with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.weighted"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant a
+"""
+                        ]
+        , test "should replace [] |> Random.weighted ( w, a ) by Random.constant a" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = [] |> Random.weighted ( w, a )
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "weighted with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.weighted"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant a
+"""
+                        ]
+        , test "should replace Random.weighted tuple [] by Random.constant (Tuple.first tuple)" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.weighted tuple []
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "weighted with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.weighted"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant (Tuple.first tuple)
+"""
+                        ]
+        , test "should replace Random.weighted tuple <| [] by Random.constant (Tuple.first tuple)" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.weighted tuple <| []
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "weighted with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.weighted"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant (Tuple.first tuple)
+"""
+                        ]
+        , test "should replace [] |> Random.weighted tuple by Random.constant (Tuple.first tuple)" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = [] |> Random.weighted tuple
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "weighted with only one possible value can be replaced by constant"
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , under = "Random.weighted"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = Random.constant (Tuple.first tuple)
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -17422,7 +17422,7 @@ a = Random.uniform a []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.uniform with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.uniform"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17440,7 +17440,7 @@ a = Random.uniform a <| []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.uniform with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.uniform"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17458,7 +17458,7 @@ a = [] |> Random.uniform a
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.uniform with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.uniform"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17493,7 +17493,7 @@ a = Random.weighted ( w, a ) []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.weighted with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.weighted"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17511,7 +17511,7 @@ a = Random.weighted ( w, a ) <| []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.weighted with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.weighted"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17529,7 +17529,7 @@ a = [] |> Random.weighted ( w, a )
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.weighted with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.weighted"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17547,7 +17547,7 @@ a = Random.weighted tuple []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.weighted with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.weighted"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17565,7 +17565,7 @@ a = Random.weighted tuple <| []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.weighted with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.weighted"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17583,7 +17583,7 @@ a = [] |> Random.weighted tuple
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Random.weighted with only one possible value can be replaced by Random.constant"
-                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
+                            , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value." ]
                             , under = "Random.weighted"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -17421,7 +17421,7 @@ a = Random.uniform a []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "uniform with only one possible value can be replaced by constant"
+                            { message = "Random.uniform with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.uniform"
                             }
@@ -17439,7 +17439,7 @@ a = Random.uniform a <| []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "uniform with only one possible value can be replaced by constant"
+                            { message = "Random.uniform with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.uniform"
                             }
@@ -17457,7 +17457,7 @@ a = [] |> Random.uniform a
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "uniform with only one possible value can be replaced by constant"
+                            { message = "Random.uniform with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.uniform call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.uniform"
                             }
@@ -17492,7 +17492,7 @@ a = Random.weighted ( w, a ) []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "weighted with only one possible value can be replaced by constant"
+                            { message = "Random.weighted with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.weighted"
                             }
@@ -17510,7 +17510,7 @@ a = Random.weighted ( w, a ) <| []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "weighted with only one possible value can be replaced by constant"
+                            { message = "Random.weighted with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.weighted"
                             }
@@ -17528,7 +17528,7 @@ a = [] |> Random.weighted ( w, a )
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "weighted with only one possible value can be replaced by constant"
+                            { message = "Random.weighted with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.weighted"
                             }
@@ -17546,7 +17546,7 @@ a = Random.weighted tuple []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "weighted with only one possible value can be replaced by constant"
+                            { message = "Random.weighted with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.weighted"
                             }
@@ -17564,7 +17564,7 @@ a = Random.weighted tuple <| []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "weighted with only one possible value can be replaced by constant"
+                            { message = "Random.weighted with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.weighted"
                             }
@@ -17582,7 +17582,7 @@ a = [] |> Random.weighted tuple
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "weighted with only one possible value can be replaced by constant"
+                            { message = "Random.weighted with only one possible value can be replaced by Random.constant"
                             , details = [ "Only a single value can be produced by this Random.weighted call. You can replace the call with Random.constant with the value" ]
                             , under = "Random.weighted"
                             }


### PR DESCRIPTION
```elm
Random.uniform a []
--> Random.constant a

Random.weighted ( weight, a ) []
--> Random.constant a

Random.weighted tuple []
--> Random.constant (Tuple.first tuple)
```
which are part of https://github.com/jfmengels/elm-review-simplify/issues/109