### PR TITLE
Add Random.map simplifications

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,7 +13,7 @@
         "elm/project-metadata-utils": "1.0.2 <= v < 2.0.0",
         "jfmengels/elm-review": "2.10.0 <= v < 3.0.0",
         "pzp1997/assoc-list": "1.0.0 <= v < 2.0.0",
-        "stil4m/elm-syntax": "7.2.9 <= v < 8.0.0"
+        "stil4m/elm-syntax": "7.3.1 <= v < 8.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "2.0.1 <= v < 3.0.0"

--- a/preview/elm.json
+++ b/preview/elm.json
@@ -11,7 +11,7 @@
             "elm/project-metadata-utils": "1.0.2",
             "jfmengels/elm-review": "2.13.1",
             "pzp1997/assoc-list": "1.0.0",
-            "stil4m/elm-syntax": "7.2.9"
+            "stil4m/elm-syntax": "7.3.1"
         },
         "indirect": {
             "elm/bytes": "1.0.8",

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -809,7 +809,7 @@ All of these also apply for `Sub`.
     Random.map identity generator
     --> generator
 
-    Random.map (always a)
+    Random.map (always a) generator
     --> Random.constant a
 
     Random.map f (Random.constant x)

--- a/src/Simplify/Match.elm
+++ b/src/Simplify/Match.elm
@@ -1,14 +1,12 @@
 module Simplify.Match exposing
     ( Match(..)
     , map
-    , maybeAndThen
     )
 
 {-|
 
 @docs Match
 @docs map
-@docs maybeAndThen
 
 -}
 
@@ -25,14 +23,4 @@ map mapper match =
             Determined (mapper a)
 
         Undetermined ->
-            Undetermined
-
-
-maybeAndThen : (a -> Match b) -> Maybe a -> Match b
-maybeAndThen fn maybe =
-    case maybe of
-        Just a ->
-            fn a
-
-        Nothing ->
             Undetermined

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -17771,8 +17771,6 @@ import Random
 a = always (Random.constant [])
 """
                         ]
-
-        ---
         , test "should replace Random.list -1 generator by Random.constant []" <|
             \() ->
                 """module A exposing (..)
@@ -18262,7 +18260,6 @@ a = Random.map (f x |> always) generator
 a = Random.constant (f x)
 """
                         ]
-
         , test "should replace Random.map (\\_ -> x) by always (Random.constant x)" <|
             \() ->
                 """module A exposing (..)
@@ -18503,8 +18500,38 @@ a = f x |> always |> Random.map
 a = always (Random.constant (f x))
 """
                         ]
-
-        --
+        , test "should replace always >> Random.map by Random.constant" <|
+            \() ->
+                """module A exposing (..)
+a = always >> Random.map
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Always mapping to the same value is equivalent to Random.constant"
+                            , details = [ "Since your Random.map call always produces the same value, you can replace the whole call by Random.constant that value." ]
+                            , under = "Random.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Random.constant
+"""
+                        ]
+        , test "should replace Random.map << always by Random.constant" <|
+            \() ->
+                """module A exposing (..)
+a = Random.map << always
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Always mapping to the same value is equivalent to Random.constant"
+                            , details = [ "Since your Random.map call always produces the same value, you can replace the whole call by Random.constant that value." ]
+                            , under = "Random.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Random.constant
+"""
+                        ]
         , test "should replace Random.map f (Random.constant x) by Random.constant (f x)" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
```elm
Random.map identity generator
--> generator

Random.map (always a) generator
--> Random.constant a

-- not in summary
Random.map << always
--> Random.map

Random.map f (Random.constant x)
--> Random.constant (f x)

-- not in summary
Random.map f << Random.constant
--> Random.constant << f
```
part of https://github.com/jfmengels/elm-review-simplify/issues/109

Some comments
- The generalized checks for `map f (pure x)` and `map identity` are also now re-used for existing `Maybe.map`, `Result.map`, ... checks
    - they are versatile and pretty: you can for example use them with `Ok` and `map` or with `Err` and `mapError`
- As an unrelated change, I upgraded `elm-syntax` to the latest version to make the local tests pass
- I feel like I could do another round of cleanups with better errors for error infos I marked TODO, more performant `compositionChecks` similar to `functionCallChecks,` changing `ModuleName -> String -> ...` to `( ModuleName, String ) -> ...` etc
- The amount of tests here kind of went out of hand (and the list isn't even complete). We could (from now on?) combine cases with equivalent/similar output to get a more focused file, slightly faster and less boring test creation, better performance (not that this has been a problem) but also a bit less clear errors. Thoughts?