### PR TITLE
WIP: Error rework

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2862,8 +2862,8 @@ plusplusChecks checkInfo =
                 _ ->
                     Nothing
         , \() ->
-            case ( Node.value checkInfo.left, Node.value checkInfo.right ) of
-                ( Expression.ListExpr _, Expression.ListExpr _ ) ->
+            case ( AstHelpers.getListLiteral checkInfo.left, AstHelpers.getListLiteral checkInfo.right ) of
+                ( Just _, Just _ ) ->
                     Just
                         (Rule.errorWithFix
                             { message = "Expression could be simplified to be a single List"
@@ -2878,7 +2878,10 @@ plusplusChecks checkInfo =
                             ]
                         )
 
-                _ ->
+                ( Nothing, _ ) ->
+                    Nothing
+
+                ( _, Nothing ) ->
                     Nothing
         , \() ->
             case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.left of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8725,17 +8725,20 @@ recordAccessChecks :
 recordAccessChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case
-                findMap
-                    (\(Node _ ( Node _ setterField, setterValue )) ->
-                        if setterField == checkInfo.fieldName then
-                            Just setterValue
+            let
+                maybeMatchingSetterValue : Maybe (Node Expression)
+                maybeMatchingSetterValue =
+                    findMap
+                        (\(Node _ ( Node _ setterField, setterValue )) ->
+                            if setterField == checkInfo.fieldName then
+                                Just setterValue
 
-                        else
-                            Nothing
-                    )
-                    checkInfo.setters
-            of
+                            else
+                                Nothing
+                        )
+                        checkInfo.setters
+            in
+            case maybeMatchingSetterValue of
                 Just setter ->
                     Just
                         (Rule.errorWithFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3969,28 +3969,19 @@ stringRightChecks : CheckInfo -> Maybe (Error {})
 stringRightChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case checkInfo.firstArg of
-                Node _ (Expression.Integer 0) ->
-                    Just
-                        (Rule.errorWithFix
-                            { message = "Using String.right with length 0 will result in an empty string"
-                            , details = [ "You can replace this call by an empty string." ]
-                            }
-                            checkInfo.fnRange
-                            (replaceByEmptyFix emptyStringAsString checkInfo.parentRange (secondArg checkInfo) checkInfo)
-                        )
+            case Evaluate.getInt checkInfo checkInfo.firstArg of
+                Just length ->
+                    callWithNonPositiveIntCanBeReplacedByCheck
+                        { fn = ( [ "String" ], "right" )
+                        , int = length
+                        , intDescription = "length"
+                        , replacementDescription = "an empty string"
+                        , replacement = emptyStringAsString
+                        , lastArg = secondArg checkInfo
+                        }
+                        checkInfo
 
-                Node _ (Expression.Negation (Node _ (Expression.Integer _))) ->
-                    Just
-                        (Rule.errorWithFix
-                            { message = "Using String.right with negative length will result in an empty string"
-                            , details = [ "You can replace this call by an empty string." ]
-                            }
-                            checkInfo.fnRange
-                            (replaceByEmptyFix emptyStringAsString checkInfo.parentRange (secondArg checkInfo) checkInfo)
-                        )
-
-                _ ->
+                Nothing ->
                     Nothing
         , \() ->
             case secondArg checkInfo of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8702,7 +8702,7 @@ letKeyWordRange range =
 
 
 recordAccessChecks : Range -> Maybe Range -> String -> List (Node Expression.RecordSetter) -> Maybe (Error {})
-recordAccessChecks nodeRange recordNameRange fieldName setters =
+recordAccessChecks nodeRange maybeRecordNameRange fieldName setters =
     case
         findMap
             (\(Node _ ( Node _ setterField, setterValue )) ->
@@ -8725,16 +8725,16 @@ recordAccessChecks nodeRange recordNameRange fieldName setters =
                 )
 
         Nothing ->
-            case recordNameRange of
-                Just rnr ->
+            case maybeRecordNameRange of
+                Just recordNameRange ->
                     Just
                         (Rule.errorWithFix
                             { message = "Field access can be simplified"
                             , details = [ "Accessing the field of an unrelated record update can be simplified to just the original field's value" ]
                             }
                             nodeRange
-                            [ Fix.replaceRangeBy { start = nodeRange.start, end = rnr.start } ""
-                            , Fix.replaceRangeBy { start = rnr.end, end = nodeRange.end } ("." ++ fieldName)
+                            [ Fix.replaceRangeBy { start = nodeRange.start, end = recordNameRange.start } ""
+                            , Fix.replaceRangeBy { start = recordNameRange.end, end = nodeRange.end } ("." ++ fieldName)
                             ]
                         )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2802,10 +2802,7 @@ plusplusChecks checkInfo =
                                 { start = checkInfo.leftRange.start
                                 , end = checkInfo.rightRange.start
                                 }
-                            , error =
-                                { start = checkInfo.leftRange.start
-                                , end = checkInfo.operatorRange.end
-                                }
+                            , error = checkInfo.operatorRange
                             }
                         )
 
@@ -2816,10 +2813,7 @@ plusplusChecks checkInfo =
                                 { start = checkInfo.leftRange.end
                                 , end = checkInfo.rightRange.end
                                 }
-                            , error =
-                                { start = checkInfo.operatorRange.start
-                                , end = checkInfo.rightRange.end
-                                }
+                            , error = checkInfo.operatorRange
                             }
                         )
 
@@ -2834,10 +2828,7 @@ plusplusChecks checkInfo =
                                 { start = checkInfo.leftRange.start
                                 , end = checkInfo.rightRange.start
                                 }
-                            , error =
-                                { start = checkInfo.leftRange.start
-                                , end = checkInfo.operatorRange.end
-                                }
+                            , error = checkInfo.operatorRange
                             }
                         )
 
@@ -2852,10 +2843,7 @@ plusplusChecks checkInfo =
                                 { start = checkInfo.leftRange.end
                                 , end = checkInfo.rightRange.end
                                 }
-                            , error =
-                                { start = checkInfo.operatorRange.start
-                                , end = checkInfo.rightRange.end
-                                }
+                            , error = checkInfo.operatorRange
                             }
                         )
 
@@ -2869,7 +2857,7 @@ plusplusChecks checkInfo =
                             { message = "Expression could be simplified to be a single List"
                             , details = [ "Try moving all the elements into a single list." ]
                             }
-                            checkInfo.parentRange
+                            checkInfo.operatorRange
                             [ Fix.replaceRangeBy
                                 { start = endWithoutBoundary checkInfo.leftRange
                                 , end = startWithoutBoundary checkInfo.rightRange
@@ -2895,7 +2883,7 @@ plusplusChecks checkInfo =
                                 { message = "Should use (::) instead of (++)"
                                 , details = [ "Concatenating a list with a single value is the same as using (::) on the list with the value." ]
                                 }
-                                checkInfo.parentRange
+                                checkInfo.operatorRange
                                 (Fix.replaceRangeBy checkInfo.operatorRange
                                     "::"
                                     :: replaceBySubExpressionFix checkInfo.leftRange leftListSingleton.element

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2881,8 +2881,8 @@ plusplusChecks checkInfo =
                 _ ->
                     Nothing
         , \() ->
-            case Node.value checkInfo.left of
-                Expression.ListExpr (listElement :: []) ->
+            case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.left of
+                Just leftListSingleton ->
                     if checkInfo.isOnTheRightSideOfPlusPlus then
                         Nothing
 
@@ -2895,11 +2895,11 @@ plusplusChecks checkInfo =
                                 checkInfo.parentRange
                                 (Fix.replaceRangeBy checkInfo.operatorRange
                                     "::"
-                                    :: replaceBySubExpressionFix checkInfo.leftRange listElement
+                                    :: replaceBySubExpressionFix checkInfo.leftRange leftListSingleton.element
                                 )
                             )
 
-                _ ->
+                Nothing ->
                     Nothing
         ]
         ()

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5460,7 +5460,7 @@ listAnyChecks checkInfo =
                 Just equatedTo ->
                     [ Rule.errorWithFix
                         { message = "Use " ++ qualifiedToString ( [ "List" ], "member" ) ++ " instead"
-                        , details = [ "This call to " ++ qualifiedToString ( [ "List" ], "any" ) ++ " checks for the presence of a value, which what " ++ qualifiedToString ( [ "List" ], "member" ) ++ " is for." ]
+                        , details = [ "This call to " ++ qualifiedToString ( [ "List" ], "any" ) ++ " checks for the presence of a value. " ++ qualifiedToString ( [ "List" ], "member" ) ++ " is meant for this exact purpose." ]
                         }
                         checkInfo.fnRange
                         (Fix.replaceRangeBy checkInfo.fnRange (qualifiedToString (qualify ( [ "List" ], "member" ) checkInfo))

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3695,9 +3695,9 @@ callWithEmptyListArgReturnsEmptyListCheck config checkInfo =
         Just [] ->
             Just
                 (Rule.errorWithFix
-                    { message = "Using " ++ qualifiedToString config.fn ++ " on an empty list will result in an empty list"
-                    , details = [ "You can replace this call by an empty list." ]
-                    }
+                    (operationDoesNotChangeSpecificLastArgErrorInfo
+                        { fn = config.fn, replacementDescription = "an empty list" }
+                    )
                     checkInfo.fnRange
                     [ Fix.replaceRangeBy checkInfo.parentRange "[]" ]
                 )
@@ -3830,9 +3830,9 @@ stringReverseChecks checkInfo =
         Expression.Literal "" ->
             Just
                 (Rule.errorWithFix
-                    { message = "Using String.reverse on an empty string will result in an empty string"
-                    , details = [ "You can replace this call by an empty string." ]
-                    }
+                    (operationDoesNotChangeSpecificLastArgErrorInfo
+                        { fn = ( [ "String" ], "reverse" ), replacementDescription = "an empty string" }
+                    )
                     checkInfo.fnRange
                     [ Fix.replaceRangeBy checkInfo.parentRange emptyStringAsString ]
                 )
@@ -3852,9 +3852,9 @@ stringSliceChecks checkInfo =
                 Just (Node _ (Expression.Literal "")) ->
                     Just
                         (Rule.errorWithFix
-                            { message = "Using String.slice on an empty string will result in an empty string"
-                            , details = [ "You can replace this call by an empty string." ]
-                            }
+                            (operationDoesNotChangeSpecificLastArgErrorInfo
+                                { fn = ( [ "String" ], "slice" ), replacementDescription = "an empty string" }
+                            )
                             checkInfo.fnRange
                             [ Fix.replaceRangeBy checkInfo.parentRange emptyStringAsString ]
                         )
@@ -3956,9 +3956,9 @@ stringLeftChecks checkInfo =
                 Just (Node _ (Expression.Literal "")) ->
                     Just
                         (Rule.errorWithFix
-                            { message = "Using String.left on an empty string will result in an empty string"
-                            , details = [ "You can replace this call by an empty string." ]
-                            }
+                            (operationDoesNotChangeSpecificLastArgErrorInfo
+                                { fn = ( [ "String" ], "left" ), replacementDescription = "an empty string" }
+                            )
                             checkInfo.fnRange
                             [ Fix.replaceRangeBy checkInfo.parentRange emptyStringAsString ]
                         )
@@ -4026,9 +4026,9 @@ stringRightChecks checkInfo =
                 Just (Node _ (Expression.Literal "")) ->
                     Just
                         (Rule.errorWithFix
-                            { message = "Using String.right on an empty string will result in an empty string"
-                            , details = [ "You can replace this call by an empty string." ]
-                            }
+                            (operationDoesNotChangeSpecificLastArgErrorInfo
+                                { fn = ( [ "String" ], "right" ), replacementDescription = "an empty string" }
+                            )
                             checkInfo.fnRange
                             [ Fix.replaceRangeBy checkInfo.parentRange emptyStringAsString ]
                         )
@@ -7020,10 +7020,7 @@ collectionMapChecks collection checkInfo =
                     if collection.isEmpty checkInfo.lookupTable collectionArg then
                         Just
                             (Rule.errorWithFix
-                                -- TODO rework error info
-                                { message = "Using " ++ qualifiedToString ( collection.moduleName, "map" ) ++ " on " ++ collection.emptyDescription ++ " will result in " ++ collection.emptyDescription
-                                , details = [ "You can replace this call by " ++ collection.emptyDescription ++ "." ]
-                                }
+                                (operationDoesNotChangeSpecificLastArgErrorInfo { fn = ( collection.moduleName, "map" ), replacementDescription = collection.emptyDescription })
                                 checkInfo.fnRange
                                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range collectionArg })
                             )
@@ -7035,6 +7032,13 @@ collectionMapChecks collection checkInfo =
                     Nothing
         ]
         ()
+
+
+operationDoesNotChangeSpecificLastArgErrorInfo : { fn : ( ModuleName, String ), replacementDescription : String } -> { message : String, details : List String }
+operationDoesNotChangeSpecificLastArgErrorInfo config =
+    { message = "Using " ++ qualifiedToString config.fn ++ " on " ++ config.replacementDescription ++ " will result in " ++ config.replacementDescription
+    , details = [ "You can replace this call by " ++ config.replacementDescription ++ "." ]
+    }
 
 
 {-| TODO merge with identityError
@@ -7199,9 +7203,9 @@ maybeAndThenChecks checkInfo =
                             Determined _ ->
                                 Just
                                     (Rule.errorWithFix
-                                        { message = "Using " ++ qualifiedToString ( maybeCollection.moduleName, "andThen" ) ++ " on " ++ maybeEmptyAsString ++ " will result in " ++ maybeEmptyAsString
-                                        , details = [ "You can replace this call by " ++ maybeEmptyAsString ++ "." ]
-                                        }
+                                        (operationDoesNotChangeSpecificLastArgErrorInfo
+                                            { fn = ( maybeCollection.moduleName, "andThen" ), replacementDescription = maybeEmptyAsString }
+                                        )
                                         checkInfo.fnRange
                                         (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range maybeArg })
                                     )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3900,21 +3900,20 @@ stringLeftChecks checkInfo =
     firstThatReportsError
         [ \() ->
             case Evaluate.getInt checkInfo checkInfo.firstArg of
-                Just 0 ->
-                    Just
-                        (Rule.errorWithFix
-                            { message = "Using String.left with length 0 will result in an empty string"
-                            , details = [ "You can replace this call by an empty string." ]
-                            }
-                            checkInfo.fnRange
-                            (replaceByEmptyFix emptyStringAsString checkInfo.parentRange (secondArg checkInfo) checkInfo)
-                        )
+                Just length ->
+                    if length <= 0 then
+                        let
+                            lengthDescription : String
+                            lengthDescription =
+                                if length <= -1 then
+                                    "negative length"
 
-                Just lengthNon0 ->
-                    if lengthNon0 <= -1 then
+                                else
+                                    "length 0"
+                        in
                         Just
                             (Rule.errorWithFix
-                                { message = "Using String.left with negative length will result in an empty string"
+                                { message = "Using String.left with " ++ lengthDescription ++ " will result in an empty string"
                                 , details = [ "You can replace this call by an empty string." ]
                                 }
                                 checkInfo.fnRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6114,17 +6114,18 @@ listTakeChecks checkInfo =
     firstThatReportsError
         [ \() ->
             case Evaluate.getInt checkInfo checkInfo.firstArg of
-                Just 0 ->
-                    Just
-                        (Rule.errorWithFix
-                            { message = "Taking 0 items from a list will result in []"
-                            , details = [ "You can replace this call by []." ]
-                            }
-                            checkInfo.fnRange
-                            (replaceByEmptyFix "[]" checkInfo.parentRange maybeListArg checkInfo)
-                        )
+                Just length ->
+                    callWithNonPositiveIntCanBeReplacedByCheck
+                        { fn = ( [ "List" ], "take" )
+                        , int = length
+                        , intDescription = "length"
+                        , replacement = "[]"
+                        , replacementDescription = "an empty list"
+                        , lastArg = maybeListArg
+                        }
+                        checkInfo
 
-                _ ->
+                Nothing ->
                     Nothing
         , \() ->
             case maybeListArg of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4130,18 +4130,16 @@ stringRepeatChecks checkInfo =
                                 [ Fix.removeRange { start = checkInfo.fnRange.start, end = (Node.range checkInfo.firstArg).end } ]
                             )
 
-                    else if intValue < 1 then
-                        Just
-                            (Rule.errorWithFix
-                                { message = "String.repeat will result in an empty string"
-                                , details = [ "Using String.repeat with a number less than 1 will result in an empty string. You can replace this call by an empty string." ]
-                                }
-                                checkInfo.fnRange
-                                (replaceByEmptyFix emptyStringAsString checkInfo.parentRange (secondArg checkInfo) checkInfo)
-                            )
-
                     else
-                        Nothing
+                        callWithNonPositiveIntCanBeReplacedByCheck
+                            { fn = ( [ "String" ], "repeat" )
+                            , int = intValue
+                            , intDescription = "length"
+                            , replacementDescription = "an empty string"
+                            , replacement = emptyStringAsString
+                            , lastArg = secondArg checkInfo
+                            }
+                            checkInfo
 
                 _ ->
                     Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1754,7 +1754,7 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                         case argsAfterFirst of
                             right :: [] ->
                                 Just
-                                    (fullyAppliedPrefixOperatorChecks
+                                    (fullyAppliedPrefixOperatorError
                                         { operator = operator
                                         , operatorRange = operatorRange
                                         , left = firstArg
@@ -8594,14 +8594,14 @@ negationChecks checkInfo =
 -- FULLY APPLIED PREFIX OPERATORS
 
 
-fullyAppliedPrefixOperatorChecks :
+fullyAppliedPrefixOperatorError :
     { operator : String
     , operatorRange : Range
     , left : Node Expression
     , right : Node Expression
     }
     -> Error {}
-fullyAppliedPrefixOperatorChecks checkInfo =
+fullyAppliedPrefixOperatorError checkInfo =
     Rule.errorWithFix
         { message = "Use the infix form (a + b) over the prefix form ((+) a b)"
         , details = [ "The prefix form is generally more unfamiliar to Elm developers, and therefore it is nicer when the infix form is used." ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3655,8 +3655,8 @@ basicsAlwaysCompositionChecks checkInfo =
             []
 
 
-reportEmptyListSecondArgument : ( ModuleName, String ) -> CheckInfo -> List (Error {})
-reportEmptyListSecondArgument ( moduleName, name ) checkInfo =
+callingWithSecondArgumentEmptyListReturnsEmptyListCheck : ( ModuleName, String ) -> CheckInfo -> List (Error {})
+callingWithSecondArgumentEmptyListReturnsEmptyListCheck ( moduleName, name ) checkInfo =
     case secondArg checkInfo of
         Just (Node _ (Expression.ListExpr [])) ->
             [ Rule.errorWithFix
@@ -4410,7 +4410,7 @@ findConsecutiveListLiterals firstListElement restOfListElements =
 listConcatMapChecks : CheckInfo -> List (Error {})
 listConcatMapChecks checkInfo =
     firstThatReportsError
-        [ \() -> reportEmptyListSecondArgument ( [ "List" ], "concatMap" ) checkInfo
+        [ \() -> callingWithSecondArgumentEmptyListReturnsEmptyListCheck ( [ "List" ], "concatMap" ) checkInfo
         , \() ->
             if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
                 [ Rule.errorWithFix
@@ -4506,7 +4506,7 @@ listConcatCompositionChecks checkInfo =
 listIndexedMapChecks : CheckInfo -> List (Error {})
 listIndexedMapChecks checkInfo =
     firstThatReportsError
-        [ \() -> reportEmptyListSecondArgument ( [ "List" ], "indexedMap" ) checkInfo
+        [ \() -> callingWithSecondArgumentEmptyListReturnsEmptyListCheck ( [ "List" ], "indexedMap" ) checkInfo
         , \() ->
             case AstHelpers.removeParens checkInfo.firstArg of
                 Node lambdaRange (Expression.LambdaExpression lambda) ->
@@ -4564,7 +4564,7 @@ listIndexedMapChecks checkInfo =
 
 listIntersperseChecks : CheckInfo -> List (Error {})
 listIntersperseChecks checkInfo =
-    reportEmptyListSecondArgument ( [ "List" ], "intersperse" ) checkInfo
+    callingWithSecondArgumentEmptyListReturnsEmptyListCheck ( [ "List" ], "intersperse" ) checkInfo
 
 
 listAppendEmptyErrorInfo : { message : String, details : List String }
@@ -5462,7 +5462,7 @@ listAnyChecks checkInfo =
 listFilterMapChecks : CheckInfo -> List (Error {})
 listFilterMapChecks checkInfo =
     firstThatReportsError
-        [ \() -> reportEmptyListSecondArgument ( [ "List" ], "filterMap" ) checkInfo
+        [ \() -> callingWithSecondArgumentEmptyListReturnsEmptyListCheck ( [ "List" ], "filterMap" ) checkInfo
         , \() ->
             case constructsSpecificInAllBranches ( [ "Maybe" ], "Just" ) checkInfo.lookupTable checkInfo.firstArg of
                 Determined justConstruction ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6113,18 +6113,19 @@ listTakeChecks checkInfo =
     in
     firstThatReportsError
         [ \() ->
-            if Evaluate.getInt checkInfo checkInfo.firstArg == Just 0 then
-                Just
-                    (Rule.errorWithFix
-                        { message = "Taking 0 items from a list will result in []"
-                        , details = [ "You can replace this call by []." ]
-                        }
-                        checkInfo.fnRange
-                        (replaceByEmptyFix "[]" checkInfo.parentRange maybeListArg checkInfo)
-                    )
+            case Evaluate.getInt checkInfo checkInfo.firstArg of
+                Just 0 ->
+                    Just
+                        (Rule.errorWithFix
+                            { message = "Taking 0 items from a list will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            }
+                            checkInfo.fnRange
+                            (replaceByEmptyFix "[]" checkInfo.parentRange maybeListArg checkInfo)
+                        )
 
-            else
-                Nothing
+                _ ->
+                    Nothing
         , \() ->
             case maybeListArg of
                 Just listArg ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3671,22 +3671,6 @@ callingWithSecondArgumentEmptyListReturnsEmptyListCheck ( moduleName, name ) che
             []
 
 
-callingWithFirstArgumentEmptyListReturnsEmptyListCheck : ( ModuleName, String ) -> CheckInfo -> List (Error {})
-callingWithFirstArgumentEmptyListReturnsEmptyListCheck ( moduleName, name ) checkInfo =
-    case checkInfo.firstArg of
-        Node _ (Expression.ListExpr []) ->
-            [ Rule.errorWithFix
-                { message = "Using " ++ qualifiedToString ( moduleName, name ) ++ " on an empty list will result in an empty list"
-                , details = [ "You can replace this call by an empty list." ]
-                }
-                checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange "[]" ]
-            ]
-
-        _ ->
-            []
-
-
 callingWithEmptyListArgumentReturnsEmptyListCheck : { checkedArg : Node Expression, fn : ( ModuleName, String ), checkInfo : CheckInfo } -> List (Error {})
 callingWithEmptyListArgumentReturnsEmptyListCheck config =
     case AstHelpers.getListLiteral config.checkedArg of
@@ -4262,7 +4246,11 @@ listConcatChecks : CheckInfo -> List (Error {})
 listConcatChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            callingWithFirstArgumentEmptyListReturnsEmptyListCheck ( [ "List" ], "concat" ) checkInfo
+            callingWithEmptyListArgumentReturnsEmptyListCheck
+                { checkedArg = checkInfo.firstArg
+                , fn = ( [ "List" ], "concat" )
+                , checkInfo = checkInfo
+                }
         , \() ->
             case Node.value checkInfo.firstArg of
                 Expression.ListExpr list ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4032,18 +4032,22 @@ stringLengthChecks checkInfo =
 
 stringRepeatChecks : CheckInfo -> Maybe (Error {})
 stringRepeatChecks checkInfo =
-    case secondArg checkInfo of
-        Just (Node _ (Expression.Literal "")) ->
-            Just
-                (Rule.errorWithFix
-                    { message = "Using String.repeat with an empty string will result in an empty string"
-                    , details = [ "You can replace this call by an empty string." ]
-                    }
-                    checkInfo.fnRange
-                    [ Fix.replaceRangeBy checkInfo.parentRange emptyStringAsString ]
-                )
+    firstThatReportsError
+        [ \() ->
+            case secondArg checkInfo of
+                Just (Node _ (Expression.Literal "")) ->
+                    Just
+                        (Rule.errorWithFix
+                            { message = "Using String.repeat with an empty string will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
+                            }
+                            checkInfo.fnRange
+                            [ Fix.replaceRangeBy checkInfo.parentRange emptyStringAsString ]
+                        )
 
-        _ ->
+                _ ->
+                    Nothing
+        , \() ->
             case Evaluate.getInt checkInfo checkInfo.firstArg of
                 Just intValue ->
                     if intValue == 1 then
@@ -4071,6 +4075,8 @@ stringRepeatChecks checkInfo =
 
                 _ ->
                     Nothing
+        ]
+        ()
 
 
 stringReplaceChecks : CheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2797,24 +2797,26 @@ plusplusChecks checkInfo =
             case ( Node.value checkInfo.left, Node.value checkInfo.right ) of
                 ( Expression.Literal "", Expression.Literal _ ) ->
                     Just
-                        (errorForAddingEmptyStrings
-                            { removed =
-                                { start = checkInfo.leftRange.start
-                                , end = checkInfo.rightRange.start
+                        (Rule.errorWithFix
+                            (concatenateEmptyErrorInfo { represents = "string" })
+                            checkInfo.operatorRange
+                            (keepOnlyFix
+                                { keep = checkInfo.rightRange
+                                , parentRange = checkInfo.parentRange
                                 }
-                            , error = checkInfo.operatorRange
-                            }
+                            )
                         )
 
                 ( Expression.Literal _, Expression.Literal "" ) ->
                     Just
-                        (errorForAddingEmptyStrings
-                            { removed =
-                                { start = checkInfo.leftRange.end
-                                , end = checkInfo.rightRange.end
+                        (Rule.errorWithFix
+                            (concatenateEmptyErrorInfo { represents = "string" })
+                            checkInfo.operatorRange
+                            (keepOnlyFix
+                                { keep = checkInfo.leftRange
+                                , parentRange = checkInfo.parentRange
                                 }
-                            , error = checkInfo.operatorRange
-                            }
+                            )
                         )
 
                 _ ->
@@ -2823,13 +2825,14 @@ plusplusChecks checkInfo =
             case AstHelpers.getListLiteral checkInfo.left of
                 Just [] ->
                     Just
-                        (errorForAddingEmptyLists
-                            { removed =
-                                { start = checkInfo.leftRange.start
-                                , end = checkInfo.rightRange.start
+                        (Rule.errorWithFix
+                            (concatenateEmptyErrorInfo { represents = "list" })
+                            checkInfo.operatorRange
+                            (keepOnlyFix
+                                { keep = checkInfo.rightRange
+                                , parentRange = checkInfo.parentRange
                                 }
-                            , error = checkInfo.operatorRange
-                            }
+                            )
                         )
 
                 _ ->
@@ -2838,13 +2841,14 @@ plusplusChecks checkInfo =
             case AstHelpers.getListLiteral checkInfo.right of
                 Just [] ->
                     Just
-                        (errorForAddingEmptyLists
-                            { removed =
-                                { start = checkInfo.leftRange.end
-                                , end = checkInfo.rightRange.end
+                        (Rule.errorWithFix
+                            (concatenateEmptyErrorInfo { represents = "list" })
+                            checkInfo.operatorRange
+                            (keepOnlyFix
+                                { keep = checkInfo.leftRange
+                                , parentRange = checkInfo.parentRange
                                 }
-                            , error = checkInfo.operatorRange
-                            }
+                            )
                         )
 
                 _ ->
@@ -2896,24 +2900,11 @@ plusplusChecks checkInfo =
         ()
 
 
-errorForAddingEmptyStrings : { error : Range, removed : Range } -> Error {}
-errorForAddingEmptyStrings ranges =
-    Rule.errorWithFix
-        { message = "Unnecessary concatenation with an empty string"
-        , details = [ "You should remove the concatenation with the empty string." ]
-        }
-        ranges.error
-        [ Fix.removeRange ranges.removed ]
-
-
-errorForAddingEmptyLists : { error : Range, removed : Range } -> Error {}
-errorForAddingEmptyLists ranges =
-    Rule.errorWithFix
-        { message = "Unnecessary concatenation with an empty list"
-        , details = [ "You should remove the concatenation with the empty list." ]
-        }
-        ranges.error
-        [ Fix.removeRange ranges.removed ]
+concatenateEmptyErrorInfo : { represents : String } -> { message : String, details : List String }
+concatenateEmptyErrorInfo config =
+    { message = "Unnecessary concatenation with an empty " ++ config.represents
+    , details = [ "You should remove the concatenation with the empty " ++ config.represents ++ "." ]
+    }
 
 
 consChecks : OperatorCheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7097,15 +7097,12 @@ resultAndThenChecks checkInfo =
                             ]
 
                         DirectConstruction ->
-                            [ Rule.errorWithFix
-                                -- TODO use identityError and replace Just by Ok
-                                { message = "Using " ++ qualifiedToString ( [ "Result" ], "andThen" ) ++ " with a function that will always return Just is the same as not using " ++ qualifiedToString ( [ "Result" ], "andThen" )
-                                , details = [ "You can remove this call and replace it by the value itself." ]
+                            [ identityError
+                                { toFix = qualifiedToString ( [ "Result" ], "andThen" ) ++ " with a function equivalent to Ok"
+                                , lastArgName = "result"
+                                , lastArg = maybeResultArg
+                                , resources = checkInfo
                                 }
-                                checkInfo.fnRange
-                                (toIdentityFix
-                                    { lastArg = maybeResultArg, resources = checkInfo }
-                                )
                             ]
 
                 Undetermined ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2211,7 +2211,7 @@ functionCallChecks =
         , ( ( [ "List" ], "concat" ), listConcatChecks )
         , ( ( [ "List" ], "concatMap" ), listConcatMapChecks )
         , ( ( [ "List" ], "indexedMap" ), listIndexedMapChecks )
-        , ( ( [ "List" ], "intersperse" ), \checkInfo -> reportEmptyListSecondArgument ( [ "List" ], "intersperse" ) checkInfo )
+        , ( ( [ "List" ], "intersperse" ), listIntersperseChecks )
         , ( ( [ "List" ], "sum" ), listSumChecks )
         , ( ( [ "List" ], "product" ), listProductChecks )
         , ( ( [ "List" ], "minimum" ), listMinimumChecks )
@@ -4560,6 +4560,11 @@ listIndexedMapChecks checkInfo =
                     []
         ]
         ()
+
+
+listIntersperseChecks : CheckInfo -> List (Error {})
+listIntersperseChecks checkInfo =
+    reportEmptyListSecondArgument ( [ "List" ], "intersperse" ) checkInfo
 
 
 listAppendEmptyErrorInfo : { message : String, details : List String }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3687,6 +3687,22 @@ callingWithFirstArgumentEmptyListReturnsEmptyListCheck ( moduleName, name ) chec
             []
 
 
+callingWithEmptyListArgumentReturnsEmptyListCheck : { checkedArg : Node Expression, fn : ( ModuleName, String ), checkInfo : CheckInfo } -> List (Error {})
+callingWithEmptyListArgumentReturnsEmptyListCheck config =
+    case AstHelpers.getListLiteral config.checkedArg of
+        Just [] ->
+            [ Rule.errorWithFix
+                { message = "Using " ++ qualifiedToString config.fn ++ " on an empty list will result in an empty list"
+                , details = [ "You can replace this call by an empty list." ]
+                }
+                config.checkInfo.fnRange
+                [ Fix.replaceRangeBy config.checkInfo.parentRange "[]" ]
+            ]
+
+        _ ->
+            []
+
+
 
 -- STRING
 
@@ -4245,7 +4261,8 @@ resultMapErrorCompositionChecks checkInfo =
 listConcatChecks : CheckInfo -> List (Error {})
 listConcatChecks checkInfo =
     firstThatReportsError
-        [ \() -> callingWithFirstArgumentEmptyListReturnsEmptyListCheck ( [ "List" ], "concat" ) checkInfo
+        [ \() ->
+            callingWithFirstArgumentEmptyListReturnsEmptyListCheck ( [ "List" ], "concat" ) checkInfo
         , \() ->
             case Node.value checkInfo.firstArg of
                 Expression.ListExpr list ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3877,7 +3877,7 @@ stringSliceChecks checkInfo =
                             , details = [ "You can replace this call by an empty string." ]
                             }
                             checkInfo.fnRange
-                            (replaceByEmptyFix emptyStringAsString checkInfo.parentRange (thirdArg checkInfo) checkInfo)
+                            [ Fix.replaceRangeBy checkInfo.parentRange emptyStringAsString ]
                         )
 
                 _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1427,11 +1427,11 @@ expressionVisitor node config context =
                                 RangeDict.remove expressionRange withNewBranchLocalBindings
                         }
 
-            expressionChecked : { errors : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
+            expressionChecked : { error : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
             expressionChecked =
                 expressionVisitorHelp node config contextWithInferredConstantsAndLocalBindings
         in
-        ( expressionChecked.errors |> maybeToList
+        ( expressionChecked.error |> maybeToList
         , { contextWithInferredConstantsAndLocalBindings
             | rangesToIgnore = RangeDict.union expressionChecked.rangesToIgnore context.rangesToIgnore
             , rightSidesOfPlusPlus = RangeDict.union expressionChecked.rightSidesOfPlusPlus context.rightSidesOfPlusPlus
@@ -1645,18 +1645,18 @@ expressionExitVisitor (Node expressionRange _) context =
         contextWithUpdatedLocalBindings
 
 
-errorsAndRangesToIgnore : Maybe (Error {}) -> RangeDict () -> { errors : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
+errorsAndRangesToIgnore : Maybe (Error {}) -> RangeDict () -> { error : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
 errorsAndRangesToIgnore maybeError rangesToIgnore =
-    { errors = maybeError
+    { error = maybeError
     , rangesToIgnore = rangesToIgnore
     , rightSidesOfPlusPlus = RangeDict.empty
     , inferredConstants = []
     }
 
 
-onlyErrors : Maybe (Error {}) -> { errors : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
+onlyErrors : Maybe (Error {}) -> { error : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
 onlyErrors maybeError =
-    { errors = maybeError
+    { error = maybeError
     , rangesToIgnore = RangeDict.empty
     , rightSidesOfPlusPlus = RangeDict.empty
     , inferredConstants = []
@@ -1668,7 +1668,7 @@ firstThatReportsError remainingChecks data =
     findMap (\checkFn -> checkFn data) remainingChecks
 
 
-expressionVisitorHelp : Node Expression -> { config | expectNaN : Bool } -> ModuleContext -> { errors : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
+expressionVisitorHelp : Node Expression -> { config | expectNaN : Bool } -> ModuleContext -> { error : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
 expressionVisitorHelp (Node expressionRange expression) config context =
     let
         toCheckInfo :
@@ -1947,7 +1947,7 @@ expressionVisitorHelp (Node expressionRange expression) config context =
         Expression.OperatorApplication operator _ left right ->
             case Dict.get operator operatorChecks of
                 Just checkFn ->
-                    { errors =
+                    { error =
                         let
                             leftRange : Range
                             leftRange =
@@ -2061,7 +2061,7 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                     errorsAndRangesToIgnore (Just ifErrors.errors) ifErrors.rangesToIgnore
 
                 Nothing ->
-                    { errors = Nothing
+                    { error = Nothing
                     , rangesToIgnore = RangeDict.empty
                     , rightSidesOfPlusPlus = RangeDict.empty
                     , inferredConstants =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2826,8 +2826,8 @@ plusplusChecks checkInfo =
                 _ ->
                     Nothing
         , \() ->
-            case Node.value checkInfo.left of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.left of
+                Just [] ->
                     Just
                         (errorForAddingEmptyLists
                             { removed =
@@ -2844,8 +2844,8 @@ plusplusChecks checkInfo =
                 _ ->
                     Nothing
         , \() ->
-            case Node.value checkInfo.right of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.right of
+                Just [] ->
                     Just
                         (errorForAddingEmptyLists
                             { removed =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3671,8 +3671,8 @@ callingWithSecondArgumentEmptyListReturnsEmptyListCheck ( moduleName, name ) che
             []
 
 
-reportEmptyListFirstArgument : ( ModuleName, String ) -> CheckInfo -> List (Error {})
-reportEmptyListFirstArgument ( moduleName, name ) checkInfo =
+callingWithFirstArgumentEmptyListReturnsEmptyListCheck : ( ModuleName, String ) -> CheckInfo -> List (Error {})
+callingWithFirstArgumentEmptyListReturnsEmptyListCheck ( moduleName, name ) checkInfo =
     case checkInfo.firstArg of
         Node _ (Expression.ListExpr []) ->
             [ Rule.errorWithFix
@@ -4245,7 +4245,7 @@ resultMapErrorCompositionChecks checkInfo =
 listConcatChecks : CheckInfo -> List (Error {})
 listConcatChecks checkInfo =
     firstThatReportsError
-        [ \() -> reportEmptyListFirstArgument ( [ "List" ], "concat" ) checkInfo
+        [ \() -> callingWithFirstArgumentEmptyListReturnsEmptyListCheck ( [ "List" ], "concat" ) checkInfo
         , \() ->
             case Node.value checkInfo.firstArg of
                 Expression.ListExpr list ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2871,8 +2871,8 @@ plusplusChecks checkInfo =
                             }
                             checkInfo.parentRange
                             [ Fix.replaceRangeBy
-                                { start = { row = checkInfo.leftRange.end.row, column = checkInfo.leftRange.end.column - 1 }
-                                , end = { row = checkInfo.rightRange.start.row, column = checkInfo.rightRange.start.column + 1 }
+                                { start = endWithoutBoundary checkInfo.leftRange
+                                , end = startWithoutBoundary checkInfo.rightRange
                                 }
                                 ","
                             ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3735,8 +3735,8 @@ stringFromListChecks : CheckInfo -> Maybe (Error {})
 stringFromListChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case Node.value checkInfo.firstArg of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.firstArg of
+                Just [] ->
                     Just
                         (Rule.errorWithFix
                             { message = "Calling " ++ qualifiedToString ( [ "String" ], "fromList" ) ++ " [] will result in " ++ emptyStringAsString
@@ -3796,8 +3796,8 @@ stringIsEmptyChecks checkInfo =
 
 stringConcatChecks : CheckInfo -> Maybe (Error {})
 stringConcatChecks checkInfo =
-    case Node.value checkInfo.firstArg of
-        Expression.ListExpr [] ->
+    case AstHelpers.getListLiteral checkInfo.firstArg of
+        Just [] ->
             Just
                 (Rule.errorWithFix
                     { message = "Using String.concat on an empty list will result in an empty string"
@@ -5148,8 +5148,8 @@ listSumChecks : CheckInfo -> Maybe (Error {})
 listSumChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case Node.value checkInfo.firstArg of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.firstArg of
+                Just [] ->
                     Just
                         (Rule.errorWithFix
                             { message = "Using " ++ qualifiedToString ( [ "List" ], "sum" ) ++ " on [] will result in 0"
@@ -5183,8 +5183,8 @@ listProductChecks : CheckInfo -> Maybe (Error {})
 listProductChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case Node.value checkInfo.firstArg of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.firstArg of
+                Just [] ->
                     Just
                         (Rule.errorWithFix
                             { message = "Using " ++ qualifiedToString ( [ "List" ], "product" ) ++ " on [] will result in 1"
@@ -5218,8 +5218,8 @@ listMinimumChecks : CheckInfo -> Maybe (Error {})
 listMinimumChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case Node.value checkInfo.firstArg of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.firstArg of
+                Just [] ->
                     Just
                         (Rule.errorWithFix
                             { message = "Using " ++ qualifiedToString ( [ "List" ], "minimum" ) ++ " on [] will result in Nothing"
@@ -5258,8 +5258,8 @@ listMaximumChecks : CheckInfo -> Maybe (Error {})
 listMaximumChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case Node.value checkInfo.firstArg of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.firstArg of
+                Just [] ->
                     Just
                         (Rule.errorWithFix
                             { message = "Using " ++ qualifiedToString ( [ "List" ], "maximum" ) ++ " on [] will result in Nothing"
@@ -5875,8 +5875,8 @@ listReverseChecks : CheckInfo -> Maybe (Error {})
 listReverseChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case Node.value (AstHelpers.removeParens checkInfo.firstArg) of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.firstArg of
+                Just [] ->
                     Just
                         (Rule.errorWithFix
                             { message = "Using " ++ qualifiedToString ( [ "List" ], "reverse" ) ++ " on [] will result in []"
@@ -5901,8 +5901,8 @@ listSortChecks : CheckInfo -> Maybe (Error {})
 listSortChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            case checkInfo.firstArg of
-                Node _ (Expression.ListExpr []) ->
+            case AstHelpers.getListLiteral checkInfo.firstArg of
+                Just [] ->
                     Just
                         (Rule.errorWithFix
                             { message = "Using " ++ qualifiedToString ( [ "List" ], "sort" ) ++ " on [] will result in []"
@@ -5943,8 +5943,8 @@ listSortByChecks checkInfo =
             Just listArg ->
                 firstThatReportsError
                     [ \() ->
-                        case listArg of
-                            Node _ (Expression.ListExpr []) ->
+                        case AstHelpers.getListLiteral listArg of
+                            Just [] ->
                                 Just
                                     (Rule.errorWithFix
                                         { message = "Using " ++ qualifiedToString ( [ "List" ], "sortBy" ) ++ " on [] will result in []"
@@ -6021,8 +6021,8 @@ listSortWithChecks checkInfo =
             Just listArg ->
                 firstThatReportsError
                     [ \() ->
-                        case listArg of
-                            Node _ (Expression.ListExpr []) ->
+                        case AstHelpers.getListLiteral listArg of
+                            Just [] ->
                                 Just
                                     (Rule.errorWithFix
                                         { message = "Using " ++ qualifiedToString ( [ "List" ], "sortWith" ) ++ " on [] will result in []"
@@ -6206,7 +6206,7 @@ listDropChecks checkInfo =
 
 listMapNChecks : { n : Int } -> CheckInfo -> Maybe (Error {})
 listMapNChecks { n } checkInfo =
-    if List.any (\(Node _ list) -> list == Expression.ListExpr []) checkInfo.argsAfterFirst then
+    if List.any (\list -> AstHelpers.getListLiteral list == Just []) checkInfo.argsAfterFirst then
         let
             callReplacement : String
             callReplacement =
@@ -6227,8 +6227,8 @@ listMapNChecks { n } checkInfo =
 
 listUnzipChecks : CheckInfo -> Maybe (Error {})
 listUnzipChecks checkInfo =
-    case Node.value checkInfo.firstArg of
-        Expression.ListExpr [] ->
+    case AstHelpers.getListLiteral checkInfo.firstArg of
+        Just [] ->
             Just
                 (Rule.errorWithFix
                     { message = "Using " ++ qualifiedToString ( [ "List" ], "unzip" ) ++ " on [] will result in ( [], [] )"
@@ -6296,8 +6296,8 @@ subAndCmdBatchChecks : String -> CheckInfo -> Maybe (Error {})
 subAndCmdBatchChecks moduleName checkInfo =
     firstThatReportsError
         [ \() ->
-            case Node.value checkInfo.firstArg of
-                Expression.ListExpr [] ->
+            case AstHelpers.getListLiteral checkInfo.firstArg of
+                Just [] ->
                     Just
                         (Rule.errorWithFix
                             { message = "Replace by " ++ moduleName ++ ".batch"
@@ -6309,7 +6309,7 @@ subAndCmdBatchChecks moduleName checkInfo =
                             ]
                         )
 
-                Expression.ListExpr (arg0 :: arg1 :: arg2Up) ->
+                Just (arg0 :: arg1 :: arg2Up) ->
                     neighboringMap
                         (\arg ->
                             case AstHelpers.removeParens arg.current of
@@ -7971,8 +7971,8 @@ collectionSizeChecks collection checkInfo =
 
 collectionFromListChecks : Collection -> CheckInfo -> Maybe (Error {})
 collectionFromListChecks collection checkInfo =
-    case Node.value checkInfo.firstArg of
-        Expression.ListExpr [] ->
+    case AstHelpers.getListLiteral checkInfo.firstArg of
+        Just [] ->
             let
                 collectionEmptyAsString : String
                 collectionEmptyAsString =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1743,7 +1743,7 @@ expressionVisitorHelp (Node expressionRange expression) config context =
 
                     Node _ (Expression.ParenthesizedExpression (Node lambdaRange (Expression.LambdaExpression lambda))) ->
                         Just
-                            (appliedLambdaChecks
+                            (appliedLambdaError
                                 { nodeRange = expressionRange
                                 , lambdaRange = lambdaRange
                                 , lambda = lambda
@@ -7491,7 +7491,7 @@ fullyAppliedLambdaInPipelineChecks checkInfo =
 
                 _ ->
                     Just
-                        (appliedLambdaChecks
+                        (appliedLambdaError
                             { nodeRange = checkInfo.nodeRange
                             , lambdaRange = lambdaRange
                             , lambda = lambda
@@ -8616,8 +8616,8 @@ fullyAppliedPrefixOperatorError checkInfo =
 -- APPLIED LAMBDA
 
 
-appliedLambdaChecks : { nodeRange : Range, lambdaRange : Range, lambda : Expression.Lambda } -> Error {}
-appliedLambdaChecks checkInfo =
+appliedLambdaError : { nodeRange : Range, lambdaRange : Range, lambda : Expression.Lambda } -> Error {}
+appliedLambdaError checkInfo =
     case checkInfo.lambda.args of
         (Node unitRange Pattern.UnitPattern) :: otherPatterns ->
             Rule.errorWithFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1645,8 +1645,8 @@ expressionExitVisitor (Node expressionRange _) context =
         contextWithUpdatedLocalBindings
 
 
-errorsAndRangesToIgnore : Maybe (Error {}) -> RangeDict () -> { error : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
-errorsAndRangesToIgnore maybeError rangesToIgnore =
+maybeErrorAndRangesToIgnore : Maybe (Error {}) -> RangeDict () -> { error : Maybe (Error {}), rangesToIgnore : RangeDict (), rightSidesOfPlusPlus : RangeDict (), inferredConstants : List ( Range, Infer.Inferred ) }
+maybeErrorAndRangesToIgnore maybeError rangesToIgnore =
     { error = maybeError
     , rangesToIgnore = rangesToIgnore
     , rightSidesOfPlusPlus = RangeDict.empty
@@ -1801,7 +1801,7 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                         Just moduleName ->
                             case Dict.get ( moduleName, fnName ) functionCallChecks of
                                 Just checkFn ->
-                                    errorsAndRangesToIgnore
+                                    maybeErrorAndRangesToIgnore
                                         (checkFn
                                             (toCheckInfo
                                                 { fnRange = fnRange
@@ -1863,7 +1863,7 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                         Just moduleName ->
                             case Dict.get ( moduleName, fnName ) functionCallChecks of
                                 Just checks ->
-                                    errorsAndRangesToIgnore
+                                    maybeErrorAndRangesToIgnore
                                         (checks
                                             (toCheckInfo
                                                 { fnRange = fnRange
@@ -2058,7 +2058,7 @@ expressionVisitorHelp (Node expressionRange expression) config context =
             in
             case ifChecks ifCheckInfo of
                 Just ifErrors ->
-                    errorsAndRangesToIgnore (Just ifErrors.errors) ifErrors.rangesToIgnore
+                    maybeErrorAndRangesToIgnore (Just ifErrors.errors) ifErrors.rangesToIgnore
 
                 Nothing ->
                     { error = Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4496,8 +4496,7 @@ listConcatCompositionChecks checkInfo =
                 { message = qualifiedToString ( [ "List" ], "map" ) ++ " and " ++ qualifiedToString ( [ "List" ], "concat" ) ++ " can be combined using " ++ qualifiedToString ( [ "List" ], "concatMap" ) ++ ""
                 , details = [ qualifiedToString ( [ "List" ], "concatMap" ) ++ " is meant for this exact purpose and will also be faster." ]
                 }
-                -- TODO switch to later.fnRange
-                checkInfo.later.range
+                checkInfo.later.fnRange
                 (Fix.replaceRangeBy checkInfo.earlier.fnRange
                     (qualifiedToString (qualify ( [ "List" ], "concatMap" ) checkInfo))
                     :: keepOnlyFix { parentRange = checkInfo.parentRange, keep = checkInfo.earlier.range }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3655,16 +3655,16 @@ basicsAlwaysCompositionChecks checkInfo =
             []
 
 
-callWithEmptyListArgReturnsEmptyListCheck : { checkedArg : Node Expression, fn : ( ModuleName, String ), checkInfo : CheckInfo } -> List (Error {})
-callWithEmptyListArgReturnsEmptyListCheck config =
+callWithEmptyListArgReturnsEmptyListCheck : { checkedArg : Node Expression, fn : ( ModuleName, String ) } -> CheckInfo -> List (Error {})
+callWithEmptyListArgReturnsEmptyListCheck config checkInfo =
     case AstHelpers.getListLiteral config.checkedArg of
         Just [] ->
             [ Rule.errorWithFix
                 { message = "Using " ++ qualifiedToString config.fn ++ " on an empty list will result in an empty list"
                 , details = [ "You can replace this call by an empty list." ]
                 }
-                config.checkInfo.fnRange
-                [ Fix.replaceRangeBy config.checkInfo.parentRange "[]" ]
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy checkInfo.parentRange "[]" ]
             ]
 
         _ ->
@@ -4231,10 +4231,8 @@ listConcatChecks checkInfo =
     firstThatReportsError
         [ \() ->
             callWithEmptyListArgReturnsEmptyListCheck
-                { checkedArg = checkInfo.firstArg
-                , fn = ( [ "List" ], "concat" )
-                , checkInfo = checkInfo
-                }
+                { fn = ( [ "List" ], "concat" ), checkedArg = checkInfo.firstArg }
+                checkInfo
         , \() ->
             case Node.value checkInfo.firstArg of
                 Expression.ListExpr list ->
@@ -4474,7 +4472,8 @@ listConcatMapChecks checkInfo =
                                     []
                         , \() ->
                             callWithEmptyListArgReturnsEmptyListCheck
-                                { checkedArg = listArg, fn = ( [ "List" ], "concatMap" ), checkInfo = checkInfo }
+                                { fn = ( [ "List" ], "concatMap" ), checkedArg = listArg }
+                                checkInfo
                         ]
                         ()
 
@@ -4510,7 +4509,8 @@ listIndexedMapChecks checkInfo =
             case secondArg checkInfo of
                 Just listArg ->
                     callWithEmptyListArgReturnsEmptyListCheck
-                        { checkedArg = listArg, fn = ( [ "List" ], "indexedMap" ), checkInfo = checkInfo }
+                        { fn = ( [ "List" ], "indexedMap" ), checkedArg = listArg }
+                        checkInfo
 
                 Nothing ->
                     []
@@ -4574,7 +4574,8 @@ listIntersperseChecks checkInfo =
     case secondArg checkInfo of
         Just listArg ->
             callWithEmptyListArgReturnsEmptyListCheck
-                { checkedArg = listArg, fn = ( [ "List" ], "intersperse" ), checkInfo = checkInfo }
+                { fn = ( [ "List" ], "intersperse" ), checkedArg = listArg }
+                checkInfo
 
         Nothing ->
             []
@@ -5523,7 +5524,8 @@ listFilterMapChecks checkInfo =
                     firstThatReportsError
                         [ \() ->
                             callWithEmptyListArgReturnsEmptyListCheck
-                                { checkedArg = listArg, fn = ( [ "List" ], "filterMap" ), checkInfo = checkInfo }
+                                { fn = ( [ "List" ], "filterMap" ), checkedArg = listArg }
+                                checkInfo
                         , \() ->
                             if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
                                 firstThatReportsError

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3902,7 +3902,8 @@ stringLeftChecks checkInfo =
             case Evaluate.getInt checkInfo checkInfo.firstArg of
                 Just length ->
                     callWithNonPositiveIntCanBeReplacedByCheck
-                        { int = length
+                        { fn = ( [ "String" ], "left" )
+                        , int = length
                         , intDescription = "length"
                         , replacementDescription = "an empty string"
                         , replacement = emptyStringAsString
@@ -3931,7 +3932,8 @@ stringLeftChecks checkInfo =
 
 
 callWithNonPositiveIntCanBeReplacedByCheck :
-    { int : number
+    { fn : ( ModuleName, String )
+    , int : number
     , intDescription : String
     , replacement : String
     , replacementDescription : String
@@ -3952,7 +3954,7 @@ callWithNonPositiveIntCanBeReplacedByCheck config checkInfo =
         in
         Just
             (Rule.errorWithFix
-                { message = "Using String.left with " ++ lengthDescription ++ " will result in " ++ config.replacementDescription
+                { message = "Using " ++ qualifiedToString config.fn ++ " with " ++ lengthDescription ++ " will result in " ++ config.replacementDescription
                 , details = [ "You can replace this call by " ++ config.replacementDescription ++ "." ]
                 }
                 checkInfo.fnRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6113,7 +6113,7 @@ listTakeChecks checkInfo =
     in
     firstThatReportsError
         [ \() ->
-            if AstHelpers.getUncomputedNumberValue checkInfo.firstArg == Just 0 then
+            if Evaluate.getInt checkInfo checkInfo.firstArg == Just 0 then
                 Just
                     (Rule.errorWithFix
                         { message = "Taking 0 items from a list will result in []"

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8723,35 +8723,31 @@ recordAccessChecks :
     }
     -> Maybe (Error {})
 recordAccessChecks checkInfo =
-    firstThatReportsError
-        [ \() ->
-            let
-                maybeMatchingSetterValue : Maybe (Node Expression)
-                maybeMatchingSetterValue =
-                    findMap
-                        (\(Node _ ( Node _ setterField, setterValue )) ->
-                            if setterField == checkInfo.fieldName then
-                                Just setterValue
+    let
+        maybeMatchingSetterValue : Maybe (Node Expression)
+        maybeMatchingSetterValue =
+            findMap
+                (\(Node _ ( Node _ setterField, setterValue )) ->
+                    if setterField == checkInfo.fieldName then
+                        Just setterValue
 
-                            else
-                                Nothing
-                        )
-                        checkInfo.setters
-            in
-            case maybeMatchingSetterValue of
-                Just setter ->
-                    Just
-                        (Rule.errorWithFix
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value" ]
-                            }
-                            checkInfo.nodeRange
-                            (replaceBySubExpressionFix checkInfo.nodeRange setter)
-                        )
+                    else
+                        Nothing
+                )
+                checkInfo.setters
+    in
+    case maybeMatchingSetterValue of
+        Just setter ->
+            Just
+                (Rule.errorWithFix
+                    { message = "Field access can be simplified"
+                    , details = [ "Accessing the field of a record or record update can be simplified to just that field's value" ]
+                    }
+                    checkInfo.nodeRange
+                    (replaceBySubExpressionFix checkInfo.nodeRange setter)
+                )
 
-                Nothing ->
-                    Nothing
-        , \() ->
+        Nothing ->
             case checkInfo.maybeRecordNameRange of
                 Just recordNameRange ->
                     Just
@@ -8767,8 +8763,6 @@ recordAccessChecks checkInfo =
 
                 Nothing ->
                     Nothing
-        ]
-        ()
 
 
 distributeFieldAccess : String -> Range -> List (Node Expression) -> Node String -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3655,8 +3655,8 @@ basicsAlwaysCompositionChecks checkInfo =
             []
 
 
-callingWithEmptyListArgumentReturnsEmptyListCheck : { checkedArg : Node Expression, fn : ( ModuleName, String ), checkInfo : CheckInfo } -> List (Error {})
-callingWithEmptyListArgumentReturnsEmptyListCheck config =
+callWithEmptyListArgReturnsEmptyListCheck : { checkedArg : Node Expression, fn : ( ModuleName, String ), checkInfo : CheckInfo } -> List (Error {})
+callWithEmptyListArgReturnsEmptyListCheck config =
     case AstHelpers.getListLiteral config.checkedArg of
         Just [] ->
             [ Rule.errorWithFix
@@ -4230,7 +4230,7 @@ listConcatChecks : CheckInfo -> List (Error {})
 listConcatChecks checkInfo =
     firstThatReportsError
         [ \() ->
-            callingWithEmptyListArgumentReturnsEmptyListCheck
+            callWithEmptyListArgReturnsEmptyListCheck
                 { checkedArg = checkInfo.firstArg
                 , fn = ( [ "List" ], "concat" )
                 , checkInfo = checkInfo
@@ -4473,7 +4473,7 @@ listConcatMapChecks checkInfo =
                                 Nothing ->
                                     []
                         , \() ->
-                            callingWithEmptyListArgumentReturnsEmptyListCheck
+                            callWithEmptyListArgReturnsEmptyListCheck
                                 { checkedArg = listArg, fn = ( [ "List" ], "concatMap" ), checkInfo = checkInfo }
                         ]
                         ()
@@ -4509,7 +4509,7 @@ listIndexedMapChecks checkInfo =
         [ \() ->
             case secondArg checkInfo of
                 Just listArg ->
-                    callingWithEmptyListArgumentReturnsEmptyListCheck
+                    callWithEmptyListArgReturnsEmptyListCheck
                         { checkedArg = listArg, fn = ( [ "List" ], "indexedMap" ), checkInfo = checkInfo }
 
                 Nothing ->
@@ -4573,7 +4573,7 @@ listIntersperseChecks : CheckInfo -> List (Error {})
 listIntersperseChecks checkInfo =
     case secondArg checkInfo of
         Just listArg ->
-            callingWithEmptyListArgumentReturnsEmptyListCheck
+            callWithEmptyListArgReturnsEmptyListCheck
                 { checkedArg = listArg, fn = ( [ "List" ], "intersperse" ), checkInfo = checkInfo }
 
         Nothing ->
@@ -5522,7 +5522,7 @@ listFilterMapChecks checkInfo =
                 Just listArg ->
                     firstThatReportsError
                         [ \() ->
-                            callingWithEmptyListArgumentReturnsEmptyListCheck
+                            callWithEmptyListArgReturnsEmptyListCheck
                                 { checkedArg = listArg, fn = ( [ "List" ], "filterMap" ), checkInfo = checkInfo }
                         , \() ->
                             if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -4797,20 +4797,6 @@ a =
   else
     3
 """
-                        , Review.Test.error
-                            { message = "Comparison is always False"
-                            , details = alwaysSameDetails
-                            , under = "a && b"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a =
-  if a || b then
-    1
-  else if b then
-    2
-  else
-    3
-"""
                         ]
         , test "should remove branches where the condition may not match (a && b --> a --> b)" <|
             \() ->

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14533,8 +14533,8 @@ a = Result.andThen Ok x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Using Result.andThen with a function that will always return Just is the same as not using Result.andThen"
-                            , details = [ "You can remove this call and replace it by the value itself." ]
+                            { message = "Using Result.andThen with a function equivalent to Ok will always return the same given result"
+                            , details = [ "You can replace this call by the result itself." ]
                             , under = "Result.andThen"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -11548,7 +11548,7 @@ a = List.any ((==) x)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Use List.member instead"
-                            , details = [ "This call to List.any checks for the presence of a value, which what List.member is for." ]
+                            , details = [ "This call to List.any checks for the presence of a value. List.member is meant for this exact purpose." ]
                             , under = "List.any"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11564,7 +11564,7 @@ a = List.any (\\y -> y == x)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Use List.member instead"
-                            , details = [ "This call to List.any checks for the presence of a value, which what List.member is for." ]
+                            , details = [ "This call to List.any checks for the presence of a value. List.member is meant for this exact purpose." ]
                             , under = "List.any"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -11580,7 +11580,7 @@ a = List.any (\\y -> x == y)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Use List.member instead"
-                            , details = [ "This call to List.any checks for the presence of a value, which what List.member is for." ]
+                            , details = [ "This call to List.any checks for the presence of a value. List.member is meant for this exact purpose." ]
                             , under = "List.any"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -12430,15 +12430,15 @@ a = List.take 0 x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Taking 0 items from a list will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            { message = "Using List.take with length 0 will result in an empty list"
+                            , details = [ "You can replace this call by an empty list." ]
                             , under = "List.take"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = []
 """
                         ]
-        , test "should replace List.take 0 by (always [])" <|
+        , test "should replace List.take 0 by always []" <|
             \() ->
                 """module A exposing (..)
 a = List.take 0
@@ -12446,8 +12446,8 @@ a = List.take 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Taking 0 items from a list will result in []"
-                            , details = [ "You can replace this call by []." ]
+                            { message = "Using List.take with length 0 will result in an empty list"
+                            , details = [ "You can replace this call by an empty list." ]
                             , under = "List.take"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -12454,6 +12454,22 @@ a = List.take 0
 a = always []
 """
                         ]
+        , test "should replace List.take -literal by always []" <|
+            \() ->
+                """module A exposing (..)
+a = List.take -1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Using List.take with negative length will result in an empty list"
+                            , details = [ "You can replace this call by an empty list." ]
+                            , under = "List.take"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always []
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5453,7 +5453,7 @@ a = "a" ++ ""
                         [ Review.Test.error
                             { message = "Unnecessary concatenation with an empty string"
                             , details = [ "You should remove the concatenation with the empty string." ]
-                            , under = "++ \"\""
+                            , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = "a"
@@ -5476,7 +5476,7 @@ a = "" ++ "a"
                         [ Review.Test.error
                             { message = "Unnecessary concatenation with an empty string"
                             , details = [ "You should remove the concatenation with the empty string." ]
-                            , under = "\"\" ++"
+                            , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = "a"
@@ -5492,7 +5492,7 @@ a = [ 1 ] ++ [ 2, 3 ]
                         [ Review.Test.error
                             { message = "Expression could be simplified to be a single List"
                             , details = [ "Try moving all the elements into a single list." ]
-                            , under = "[ 1 ] ++ [ 2, 3 ]"
+                            , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = [ 1 , 2, 3 ]
@@ -5508,7 +5508,7 @@ a = [ a, 1 ] ++ [ b, 2 ]
                         [ Review.Test.error
                             { message = "Expression could be simplified to be a single List"
                             , details = [ "Try moving all the elements into a single list." ]
-                            , under = "[ a, 1 ] ++ [ b, 2 ]"
+                            , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = [ a, 1 , b, 2 ]
@@ -5524,7 +5524,7 @@ a = [] ++ something
                         [ Review.Test.error
                             { message = "Unnecessary concatenation with an empty list"
                             , details = [ "You should remove the concatenation with the empty list." ]
-                            , under = "[] ++"
+                            , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = something
@@ -5540,7 +5540,7 @@ a = something ++ []
                         [ Review.Test.error
                             { message = "Unnecessary concatenation with an empty list"
                             , details = [ "You should remove the concatenation with the empty list." ]
-                            , under = "++ []"
+                            , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = something
@@ -5556,7 +5556,7 @@ a = [ b ] ++ c
                         [ Review.Test.error
                             { message = "Should use (::) instead of (++)"
                             , details = [ "Concatenating a list with a single value is the same as using (::) on the list with the value." ]
-                            , under = "[ b ] ++ c"
+                            , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = b :: c
@@ -5572,7 +5572,7 @@ a = [ f n ] ++ c
                         [ Review.Test.error
                             { message = "Should use (::) instead of (++)"
                             , details = [ "Concatenating a list with a single value is the same as using (::) on the list with the value." ]
-                            , under = "[ f n ] ++ c"
+                            , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (f n) :: c

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1497,7 +1497,7 @@ a = not >> not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not >> not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1513,7 +1513,7 @@ a = a >> not >> not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not >> not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1529,7 +1529,7 @@ a = not >> not >> a
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not >> not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1545,7 +1545,7 @@ a = not << not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not << not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1561,7 +1561,7 @@ a = not << not << a
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not << not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1577,7 +1577,7 @@ a = a << not << not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not << not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1593,7 +1593,7 @@ a = (not >> a) << not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not >> a) << not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1616,7 +1616,7 @@ a = not (not x)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not (not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1632,7 +1632,7 @@ a = x |> not |> not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not |> not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1648,7 +1648,7 @@ a = (x |> not) |> not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not) |> not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1664,7 +1664,7 @@ a = (not <| x) |> not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not <| x) |> not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1680,7 +1680,7 @@ a = not x |> not
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not x |> not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1696,7 +1696,7 @@ a = not <| not x
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.not"
-                            , details = [ "Composing Basics.not with Basics.not cancels each other out." ]
+                            , details = [ "Chaining Basics.not with Basics.not makes both functions cancel each other out." ]
                             , under = "not <| not"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2725,7 +2725,7 @@ a = negate >> negate
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.negate"
-                            , details = [ "Composing Basics.negate with Basics.negate cancels each other out." ]
+                            , details = [ "Chaining Basics.negate with Basics.negate makes both functions cancel each other out." ]
                             , under = "negate >> negate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2741,7 +2741,7 @@ a = a >> negate >> negate
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.negate"
-                            , details = [ "Composing Basics.negate with Basics.negate cancels each other out." ]
+                            , details = [ "Chaining Basics.negate with Basics.negate makes both functions cancel each other out." ]
                             , under = "negate >> negate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2757,7 +2757,7 @@ a = negate >> negate >> a
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.negate"
-                            , details = [ "Composing Basics.negate with Basics.negate cancels each other out." ]
+                            , details = [ "Chaining Basics.negate with Basics.negate makes both functions cancel each other out." ]
                             , under = "negate >> negate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2773,7 +2773,7 @@ a = negate << negate
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.negate"
-                            , details = [ "Composing Basics.negate with Basics.negate cancels each other out." ]
+                            , details = [ "Chaining Basics.negate with Basics.negate makes both functions cancel each other out." ]
                             , under = "negate << negate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2789,7 +2789,7 @@ a = negate << negate << a
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.negate"
-                            , details = [ "Composing Basics.negate with Basics.negate cancels each other out." ]
+                            , details = [ "Chaining Basics.negate with Basics.negate makes both functions cancel each other out." ]
                             , under = "negate << negate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2805,7 +2805,7 @@ a = a << negate << negate
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.negate"
-                            , details = [ "Composing Basics.negate with Basics.negate cancels each other out." ]
+                            , details = [ "Chaining Basics.negate with Basics.negate makes both functions cancel each other out." ]
                             , under = "negate << negate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2821,7 +2821,7 @@ a = (negate >> a) << negate
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.negate"
-                            , details = [ "Composing Basics.negate with Basics.negate cancels each other out." ]
+                            , details = [ "Chaining Basics.negate with Basics.negate makes both functions cancel each other out." ]
                             , under = "negate >> a) << negate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2844,7 +2844,7 @@ a = negate <| negate x
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary double Basics.negate"
-                            , details = [ "Composing Basics.negate with Basics.negate cancels each other out." ]
+                            , details = [ "Chaining Basics.negate with Basics.negate makes both functions cancel each other out." ]
                             , under = "negate <| negate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5885,8 +5885,8 @@ a = String.repeat 0 str
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.repeat will result in an empty string"
-                            , details = [ "Using String.repeat with a number less than 1 will result in an empty string. You can replace this call by an empty string." ]
+                            { message = "Using String.repeat with length 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
                             , under = "String.repeat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5901,8 +5901,8 @@ a = String.repeat 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.repeat will result in an empty string"
-                            , details = [ "Using String.repeat with a number less than 1 will result in an empty string. You can replace this call by an empty string." ]
+                            { message = "Using String.repeat with length 0 will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
                             , under = "String.repeat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5917,8 +5917,8 @@ a = String.repeat -5 str
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.repeat will result in an empty string"
-                            , details = [ "Using String.repeat with a number less than 1 will result in an empty string. You can replace this call by an empty string." ]
+                            { message = "Using String.repeat with negative length will result in an empty string"
+                            , details = [ "You can replace this call by an empty string." ]
                             , under = "String.repeat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)


### PR DESCRIPTION
### incomplete list of things done
- [x] change errors from a list to a maybe

### dump of notes of what I still want to do

== 1 then


Introduce general callWithArgResultsIn { checkedArg, check, () -> result }
    - on an empty [string] will result in an empty [list]
    - on an empty [string] will result in an empty [string]

Result.mapErr Err, Result.map Ok, "String.repeat 1 won't do anything" call Unnecessary

consChecks, listProductChecks, listSumChecks, listReverseChecks
listSortChecks, listUnzipChecks, collectionFromListChecks, stringFromListChecks, listConcatChecks
stringLinesChecks, stringWordsChecks, stringReverseChecks, stringSliceChecks,
stringLeftChecks, stringRightChecks, stringJoinChecks, stringRepeatChecks, plusplusChecks, listTakeChecks
stringRepeatChecks
use replaceByEmptyError

&& -- have the same sign → better error

do not return error from functionCallChecks, instead { info, fix } and always use fnRange as error range

try the same with compositionChecks

always report operationChecks at operatorRange

listReverseChecks, listSortChecks, listSortByChecks, listSortWithChecks
"Using " ++ qualifiedToString ( resultCollection.moduleName, "andThen" ) ++ " on an error will result in the error"
use operationDoesNotChangeSpecificLastArgErrorInfo or better the listEmptyReplaceCheck

collectionDiffChecks first cases, collectionUnionChecks both cases
use callOnEmptyReturnsEmptyCheck

Add parameter { collectionArg : Maybe (Node Expression) } to collectionInsertChecks

collectionFromListChecks say fromList on an empty list

"Diffing a " ++ collection.represents ++ " with " ++ collectionEmptyAsString ++ " will result in the " ++ collection.represents ++ " itself"
use keepOnlyFix