### PR TITLE
Remove check about immediately invoked lambdas with variable name

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -209,9 +209,6 @@ Destructuring using case expressions
     (\_ y -> x) data
     --> (\y -> x)
 
-    (\x y -> x + y) n m
-    -- Reported because simplifiable but not autofixed
-
 
 ### Operators
 
@@ -1751,13 +1748,11 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                                 Nothing
 
                     Node _ (Expression.ParenthesizedExpression (Node lambdaRange (Expression.LambdaExpression lambda))) ->
-                        Just
-                            (appliedLambdaError
-                                { nodeRange = expressionRange
-                                , lambdaRange = lambdaRange
-                                , lambda = lambda
-                                }
-                            )
+                        appliedLambdaError
+                            { nodeRange = expressionRange
+                            , lambdaRange = lambdaRange
+                            , lambda = lambda
+                            }
 
                     Node operatorRange (Expression.PrefixOperator operator) ->
                         case argsAfterFirst of
@@ -6921,13 +6916,11 @@ fullyAppliedLambdaInPipelineChecks checkInfo =
                     Nothing
 
                 _ ->
-                    Just
-                        (appliedLambdaError
-                            { nodeRange = checkInfo.nodeRange
-                            , lambdaRange = lambdaRange
-                            , lambda = lambda
-                            }
-                        )
+                    appliedLambdaError
+                        { nodeRange = checkInfo.nodeRange
+                        , lambdaRange = lambdaRange
+                        , lambda = lambda
+                        }
 
         _ ->
             Nothing
@@ -8023,58 +8016,51 @@ fullyAppliedPrefixOperatorError checkInfo =
 -- APPLIED LAMBDA
 
 
-appliedLambdaError : { nodeRange : Range, lambdaRange : Range, lambda : Expression.Lambda } -> Error {}
+appliedLambdaError : { nodeRange : Range, lambdaRange : Range, lambda : Expression.Lambda } -> Maybe (Error {})
 appliedLambdaError checkInfo =
     case checkInfo.lambda.args of
         (Node unitRange Pattern.UnitPattern) :: otherPatterns ->
-            Rule.errorWithFix
-                { message = "Unnecessary unit argument"
-                , details =
-                    [ "This function is expecting a unit, but also passing it directly."
-                    , "Maybe this was made in attempt to make the computation lazy, but in practice the function will be evaluated eagerly."
-                    ]
-                }
-                unitRange
-                (case otherPatterns of
-                    [] ->
-                        replaceBySubExpressionFix checkInfo.nodeRange checkInfo.lambda.expression
+            Just
+                (Rule.errorWithFix
+                    { message = "Unnecessary unit argument"
+                    , details =
+                        [ "This function is expecting a unit, but also passing it directly."
+                        , "Maybe this was made in attempt to make the computation lazy, but in practice the function will be evaluated eagerly."
+                        ]
+                    }
+                    unitRange
+                    (case otherPatterns of
+                        [] ->
+                            replaceBySubExpressionFix checkInfo.nodeRange checkInfo.lambda.expression
 
-                    secondPattern :: _ ->
-                        Fix.removeRange { start = unitRange.start, end = (Node.range secondPattern).start }
-                            :: keepOnlyAndParenthesizeFix { parentRange = checkInfo.nodeRange, keep = checkInfo.lambdaRange }
+                        secondPattern :: _ ->
+                            Fix.removeRange { start = unitRange.start, end = (Node.range secondPattern).start }
+                                :: keepOnlyAndParenthesizeFix { parentRange = checkInfo.nodeRange, keep = checkInfo.lambdaRange }
+                    )
                 )
 
         (Node allRange Pattern.AllPattern) :: otherPatterns ->
-            Rule.errorWithFix
-                { message = "Unnecessary wildcard argument argument"
-                , details =
-                    [ "This function is being passed an argument that is directly ignored."
-                    , "Maybe this was made in attempt to make the computation lazy, but in practice the function will be evaluated eagerly."
-                    ]
-                }
-                allRange
-                (case otherPatterns of
-                    [] ->
-                        replaceBySubExpressionFix checkInfo.nodeRange checkInfo.lambda.expression
+            Just
+                (Rule.errorWithFix
+                    { message = "Unnecessary wildcard argument argument"
+                    , details =
+                        [ "This function is being passed an argument that is directly ignored."
+                        , "Maybe this was made in attempt to make the computation lazy, but in practice the function will be evaluated eagerly."
+                        ]
+                    }
+                    allRange
+                    (case otherPatterns of
+                        [] ->
+                            replaceBySubExpressionFix checkInfo.nodeRange checkInfo.lambda.expression
 
-                    secondPattern :: _ ->
-                        Fix.removeRange { start = allRange.start, end = (Node.range secondPattern).start }
-                            :: keepOnlyAndParenthesizeFix { parentRange = checkInfo.nodeRange, keep = checkInfo.lambdaRange }
+                        secondPattern :: _ ->
+                            Fix.removeRange { start = allRange.start, end = (Node.range secondPattern).start }
+                                :: keepOnlyAndParenthesizeFix { parentRange = checkInfo.nodeRange, keep = checkInfo.lambdaRange }
+                    )
                 )
 
         _ ->
-            Rule.error
-                { message = "Anonymous function is immediately invoked"
-                , details =
-                    [ "This expression defines a function which then gets called directly afterwards, which overly complexifies the intended computation."
-                    , "While there are reasonable uses for this in languages like JavaScript, the same benefits aren't there in Elm because of not allowing name shadowing."
-                    , "Here are a few ways you can simplify this:"
-                    , """- Remove the lambda and reference the arguments directly instead of giving them new names
-- Remove the lambda and use let variables to give names to the current arguments
-- Extract the lambda to a named function (at the top-level or defined in a let expression)"""
-                    ]
-                }
-                checkInfo.lambdaRange
+            Nothing
 
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5346,40 +5346,14 @@ a = (\\y -> x)
 a = (\\x y -> x + y) n
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Anonymous function is immediately invoked"
-                            , details =
-                                [ "This expression defines a function which then gets called directly afterwards, which overly complexifies the intended computation."
-                                , "While there are reasonable uses for this in languages like JavaScript, the same benefits aren't there in Elm because of not allowing name shadowing."
-                                , "Here are a few ways you can simplify this:"
-                                , """- Remove the lambda and reference the arguments directly instead of giving them new names
-- Remove the lambda and use let variables to give names to the current arguments
-- Extract the lambda to a named function (at the top-level or defined in a let expression)"""
-                                ]
-                            , under = "\\x y -> x + y"
-                            }
-                        ]
+                    |> Review.Test.expectNoErrors
         , test "should report but not fix non-simplifiable lambdas that are directly called in a |> pipeline" <|
             \() ->
                 """module A exposing (..)
 a = n |> (\\x y -> x + y)
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Anonymous function is immediately invoked"
-                            , details =
-                                [ "This expression defines a function which then gets called directly afterwards, which overly complexifies the intended computation."
-                                , "While there are reasonable uses for this in languages like JavaScript, the same benefits aren't there in Elm because of not allowing name shadowing."
-                                , "Here are a few ways you can simplify this:"
-                                , """- Remove the lambda and reference the arguments directly instead of giving them new names
-- Remove the lambda and use let variables to give names to the current arguments
-- Extract the lambda to a named function (at the top-level or defined in a let expression)"""
-                                ]
-                            , under = "\\x y -> x + y"
-                            }
-                        ]
+                    |> Review.Test.expectNoErrors
         , test "should not report lambdas that are directly called in a |> pipeline if the argument is a pipeline itself" <|
             \() ->
                 """module A exposing (..)
@@ -5393,20 +5367,7 @@ a = n |> f |> (\\x y -> x + y)
 a = (\\x y -> x + y) <| n
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Anonymous function is immediately invoked"
-                            , details =
-                                [ "This expression defines a function which then gets called directly afterwards, which overly complexifies the intended computation."
-                                , "While there are reasonable uses for this in languages like JavaScript, the same benefits aren't there in Elm because of not allowing name shadowing."
-                                , "Here are a few ways you can simplify this:"
-                                , """- Remove the lambda and reference the arguments directly instead of giving them new names
-- Remove the lambda and use let variables to give names to the current arguments
-- Extract the lambda to a named function (at the top-level or defined in a let expression)"""
-                                ]
-                            , under = "\\x y -> x + y"
-                            }
-                        ]
+                    |> Review.Test.expectNoErrors
         , test "should not report lambdas that are directly called in a <| pipeline if the argument is a pipeline itself" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
Removed the check introduced in https://github.com/jfmengels/elm-review-simplify/pull/124

This simplification is pretty nice, but has a few problems:
- It stands out as a simplification because it does not have an autofix (because there are multiple solutions for it, relating to code style)
- There are some edge cases where this simplification is not necessarily appropriate
  - Record updates `f a |> (\v -> { v | a = 1 })`
  - Extracting through destructuring `f a |> (\(Thing thing) -> thing)`

From feedback, people seem to think the idea is good and that it improves the readability of the code (with the exceptions that probably need some refinement), but I think it stands out too much (especially the non-fixing part) and should therefore be moved to a separate rule, probably in `jfmengels/elm-review-code-style`, where autofix could be supported by configuring the rule (PRs welcome :smile: )