### PR TITLE
Add reverse on wrapped simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -636,6 +636,9 @@ Destructuring using case expressions
     List.drop 0 list
     --> list
 
+    List.reverse []
+    --> []
+
     List.reverse [ a ]
     --> [ a ]
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6277,6 +6277,70 @@ a = String.reverse ""
 a = ""
 """
                         ]
+        , test "should replace String.reverse (String.fromChar a) by (String.fromChar a)" <|
+            \() ->
+                """module A exposing (..)
+a = String.reverse (String.fromChar b)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.reverse on a single-char string will result in the given single-char string"
+                            , details = [ "You can replace this call by the given single-char string." ]
+                            , under = "String.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (String.fromChar b)
+"""
+                        ]
+        , test "should replace a |> String.fromChar |> String.reverse by a |> String.fromChar" <|
+            \() ->
+                """module A exposing (..)
+a = b |> String.fromChar |> String.reverse
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.reverse on a single-char string will result in the given single-char string"
+                            , details = [ "You can replace this call by the given single-char string." ]
+                            , under = "String.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b |> String.fromChar
+"""
+                        ]
+        , test "should replace String.reverse << String.fromChar by String.fromChar" <|
+            \() ->
+                """module A exposing (..)
+a = String.reverse << String.fromChar
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.reverse on a single-char string will result in the given string"
+                            , details = [ "You can replace this call by String.fromChar." ]
+                            , under = "String.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.fromChar
+"""
+                        ]
+        , test "should replace String.fromChar >> String.reverse by String.fromChar" <|
+            \() ->
+                """module A exposing (..)
+a = String.fromChar >> String.reverse
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.reverse on a single-char string will result in the given string"
+                            , details = [ "You can replace this call by String.fromChar." ]
+                            , under = "String.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.fromChar
+"""
+                        ]
         , test "should replace String.reverse <| String.reverse <| x by x" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -12589,6 +12589,86 @@ a = List.reverse []
 a = []
 """
                         ]
+        , test "should replace List.reverse [ a ] by [ a ]" <|
+            \() ->
+                """module A exposing (..)
+a = List.reverse [ b ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.reverse on a singleton list will result in the given singleton list"
+                            , details = [ "You can replace this call by the given singleton list." ]
+                            , under = "List.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ b ]
+"""
+                        ]
+        , test "should replace List.reverse (List.singleton a) by (List.singleton a)" <|
+            \() ->
+                """module A exposing (..)
+a = List.reverse (List.singleton b)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.reverse on a singleton list will result in the given singleton list"
+                            , details = [ "You can replace this call by the given singleton list." ]
+                            , under = "List.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.singleton b)
+"""
+                        ]
+        , test "should replace a |> List.singleton |> List.reverse by a |> List.singleton" <|
+            \() ->
+                """module A exposing (..)
+a = b |> List.singleton |> List.reverse
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.reverse on a singleton list will result in the given singleton list"
+                            , details = [ "You can replace this call by the given singleton list." ]
+                            , under = "List.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b |> List.singleton
+"""
+                        ]
+        , test "should replace List.reverse << List.singleton by List.singleton" <|
+            \() ->
+                """module A exposing (..)
+a = List.reverse << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.reverse on a singleton list will result in the given list"
+                            , details = [ "You can replace this call by List.singleton." ]
+                            , under = "List.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.singleton
+"""
+                        ]
+        , test "should replace List.singleton >> List.reverse by List.singleton" <|
+            \() ->
+                """module A exposing (..)
+a = List.singleton >> List.reverse
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.reverse on a singleton list will result in the given list"
+                            , details = [ "You can replace this call by List.singleton." ]
+                            , under = "List.reverse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.singleton
+"""
+                        ]
         , test "should replace List.reverse <| List.reverse <| x by x" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
Implements #143 including your comment.
```elm
List.reverse [ a ]
--> [ a ]

-- not in summary for example
List.reverse << List.singleton
--> List.singleton


String.reverse (String.fromChar a)
--> String.fromChar a

-- not in summary
String.reverse << String.fromChar
--> String.fromChar
```

As an unrelated extra, adds  the missing `List.reverse [] --> []` to the summary.
