### PR TITLE
Add simplifications for List.intersperse on a singleton list

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -530,6 +530,9 @@ Destructuring using case expressions
     List.intersperse a []
     --> []
 
+    List.intersperse s [ a ]
+    --> [ a ]
+
     List.isEmpty []
     --> True
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2479,6 +2479,7 @@ compositionIntoChecks =
         , ( ( [ "List" ], "reverse" ), listReverseCompositionChecks )
         , ( ( [ "List" ], "map" ), listMapCompositionChecks )
         , ( ( [ "List" ], "filterMap" ), listFilterMapCompositionChecks )
+        , ( ( [ "List" ], "intersperse" ), listIntersperseCompositionChecks )
         , ( ( [ "List" ], "concat" ), listConcatCompositionChecks )
         , ( ( [ "List" ], "foldl" ), listFoldlCompositionChecks )
         , ( ( [ "List" ], "foldr" ), listFoldrCompositionChecks )
@@ -4509,8 +4510,21 @@ getReplaceAlwaysByItsResultFix lookupTable expressionNode =
 
 listIntersperseChecks : CheckInfo -> Maybe (Error {})
 listIntersperseChecks checkInfo =
-    Maybe.andThen (\listArg -> callOnEmptyReturnsEmptyCheck listArg listCollection checkInfo)
-        (secondArg checkInfo)
+    case secondArg checkInfo of
+        Just listArg ->
+            firstThatConstructsJust
+                [ \() -> callOnEmptyReturnsEmptyCheck listArg listCollection checkInfo
+                , \() -> callOnWrappedDoesNotChangeItCheck listArg listCollection checkInfo
+                ]
+                ()
+
+        Nothing ->
+            Nothing
+
+
+listIntersperseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+listIntersperseCompositionChecks checkInfo =
+    compositionAfterWrapIsUnnecessaryCheck listCollection checkInfo
 
 
 listAppendChecks : CheckInfo -> Maybe (Error {})

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13086,6 +13086,86 @@ a = List.intersperse x []
 a = []
 """
                         ]
+        , test "should replace List.intersperse s [ a ] by [ a ]" <|
+            \() ->
+                """module A exposing (..)
+a = List.intersperse s [ b ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.intersperse on a singleton list will result in the given singleton list"
+                            , details = [ "You can replace this call by the given singleton list." ]
+                            , under = "List.intersperse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ b ]
+"""
+                        ]
+        , test "should replace List.intersperse s (List.singleton a) by (List.singleton a)" <|
+            \() ->
+                """module A exposing (..)
+a = List.intersperse s (List.singleton b)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.intersperse on a singleton list will result in the given singleton list"
+                            , details = [ "You can replace this call by the given singleton list." ]
+                            , under = "List.intersperse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.singleton b)
+"""
+                        ]
+        , test "should replace a |> List.singleton |> List.intersperse s by a |> List.singleton" <|
+            \() ->
+                """module A exposing (..)
+a = b |> List.singleton |> List.intersperse s
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.intersperse on a singleton list will result in the given singleton list"
+                            , details = [ "You can replace this call by the given singleton list." ]
+                            , under = "List.intersperse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b |> List.singleton
+"""
+                        ]
+        , test "should replace List.intersperse s << List.singleton by List.singleton" <|
+            \() ->
+                """module A exposing (..)
+a = List.intersperse s << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.intersperse on a singleton list will result in the given list"
+                            , details = [ "You can replace this call by List.singleton." ]
+                            , under = "List.intersperse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.singleton
+"""
+                        ]
+        , test "should replace List.singleton >> List.intersperse s by List.singleton" <|
+            \() ->
+                """module A exposing (..)
+a = List.singleton >> List.intersperse s
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.intersperse on a singleton list will result in the given list"
+                            , details = [ "You can replace this call by List.singleton." ]
+                            , under = "List.intersperse"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.singleton
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Implements #142 without the last fix.
```elm
List.intersperse s [ a ]
--> [ a ]

-- not shown in the summary for example
List.intersperse a << List.singleton
--> List.singleton
```
