### PR TITLE
Add Random.andThen simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -860,8 +860,8 @@ All of these also apply for `Sub`.
     Random.andThen (\a -> Random.constant b) generator
     --> Random.map (\a -> b) generator
 
-    Random.andThen (always generator)
-    --> generator
+    Random.andThen (always thenGenerator) generator
+    --> thenGenerator
 
 -}
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6141,9 +6141,7 @@ nonEmptiableWrapperAndThenAlwaysChecks wrapper checkInfo =
                         case secondArg checkInfo of
                             Nothing ->
                                 { replacementDescription = "always with the " ++ wrapper.represents ++ " produced by the function"
-                                , fix =
-                                    -- maybe a bit too clever?
-                                    keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg }
+                                , fix = keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg }
                                 }
 
                             Just _ ->


### PR DESCRIPTION
With that, #109 is fully implemented.
```elm
Random.andThen f (Random.constant x)
--> f x

Random.andThen Random.constant generator
--> generator

Random.andThen (\a -> Random.constant b) generator
--> Random.map (\a -> b) generator

Random.andThen (always thenGenerator) generator
--> thenGenerator

-- not in summary
Random.andThen (always thenGenerator)
--> (always thenGenerator)
```
