### PR TITLE
Add Tuple.first, Tuple.second on tuple simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3913,27 +3913,7 @@ tuplePartChecks partConfig checkInfo =
                 checkInfo.fnRange
                 (replaceBySubExpressionFix checkInfo.parentRange (tuple |> partConfig.access))
         )
-        (getTuple2 checkInfo.firstArg checkInfo.lookupTable)
-
-
-getTuple2 : Node Expression -> ModuleNameLookupTable -> Maybe { first : Node Expression, second : Node Expression }
-getTuple2 expressionNode lookupTable =
-    case AstHelpers.removeParens expressionNode of
-        Node _ (Expression.TupledExpression (first :: second :: [])) ->
-            Just { first = first, second = second }
-
-        _ ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Tuple" ], "pair" ) lookupTable expressionNode of
-                Just tuplePairCall ->
-                    case tuplePairCall.argsAfterFirst of
-                        second :: _ ->
-                            Just { first = tuplePairCall.firstArg, second = second }
-
-                        [] ->
-                            Nothing
-
-                Nothing ->
-                    Nothing
+        (AstHelpers.getTuple2 checkInfo.firstArg checkInfo.lookupTable)
 
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3881,7 +3881,7 @@ tupleSecondChecks checkInfo =
 tupleSecondCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 tupleSecondCompositionChecks checkInfo =
     case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
-        ( ( [ "Tuple" ], "pair" ), first :: [] ) ->
+        ( ( [ "Tuple" ], "pair" ), _ :: [] ) ->
             Just
                 { info =
                     { message = qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in the incoming second part"

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5922,7 +5922,7 @@ htmlAttributesClassListChecks checkInfo =
 
         getTupleWithSpecificSecond : Bool -> Node Expression -> Maybe { range : Range, first : Node Expression }
         getTupleWithSpecificSecond specificBool expressionNode =
-            case AstHelpers.getTuple expressionNode of
+            case AstHelpers.getTuple2Literal expressionNode of
                 Just tuple ->
                     case AstHelpers.getSpecificBool specificBool checkInfo.lookupTable tuple.second of
                         Just _ ->
@@ -5944,7 +5944,7 @@ htmlAttributesClassListChecks checkInfo =
         [ \() ->
             case AstHelpers.getListSingleton checkInfo.lookupTable listArg of
                 Just single ->
-                    case AstHelpers.getTuple single.element of
+                    case AstHelpers.getTuple2Literal single.element of
                         Just tuple ->
                             case AstHelpers.getBool checkInfo.lookupTable tuple.second of
                                 Just bool ->
@@ -9085,7 +9085,7 @@ sameInAllBranches getSpecific baseExpressionNode =
 
 getComparableExpressionInTupleFirst : Node Expression -> Maybe (List Expression)
 getComparableExpressionInTupleFirst expressionNode =
-    case AstHelpers.getTuple expressionNode of
+    case AstHelpers.getTuple2Literal expressionNode of
         Just tuple ->
             getComparableExpression tuple.first
 

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -6,7 +6,7 @@ module Simplify.AstHelpers exposing
     , isTupleFirstAccess, isTupleSecondAccess
     , getOrder, getSpecificBool, getBool, getBoolPattern, getUncomputedNumberValue
     , getCollapsedCons, getListLiteral, getListSingleton
-    , getTuple
+    , getTuple2Literal
     , boolToString, orderToString, emptyStringAsString
     , moduleNameFromString, qualifiedName, qualifiedToString
     , declarationListBindings, letDeclarationListBindings, patternBindings, patternListBindings
@@ -33,7 +33,7 @@ module Simplify.AstHelpers exposing
 @docs isTupleFirstAccess, isTupleSecondAccess
 @docs getOrder, getSpecificBool, getBool, getBoolPattern, getUncomputedNumberValue
 @docs getCollapsedCons, getListLiteral, getListSingleton
-@docs getTuple
+@docs getTuple2Literal
 
 
 ### literal as string
@@ -733,8 +733,8 @@ getSpecificBool specificBool lookupTable expressionNode =
     getSpecificValueOrFunction ( [ "Basics" ], boolToString specificBool ) lookupTable expressionNode
 
 
-getTuple : Node Expression -> Maybe { range : Range, first : Node Expression, second : Node Expression }
-getTuple expressionNode =
+getTuple2Literal : Node Expression -> Maybe { range : Range, first : Node Expression, second : Node Expression }
+getTuple2Literal expressionNode =
     case Node.value expressionNode of
         Expression.TupledExpression (first :: second :: []) ->
             Just { range = Node.range expressionNode, first = first, second = second }

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -6,7 +6,7 @@ module Simplify.AstHelpers exposing
     , isTupleFirstAccess, isTupleSecondAccess
     , getOrder, getSpecificBool, getBool, getBoolPattern, getUncomputedNumberValue
     , getCollapsedCons, getListLiteral, getListSingleton
-    , getTuple2Literal
+    , getTuple2, getTuple2Literal
     , boolToString, orderToString, emptyStringAsString
     , moduleNameFromString, qualifiedName, qualifiedToString
     , declarationListBindings, letDeclarationListBindings, patternBindings, patternListBindings
@@ -33,7 +33,7 @@ module Simplify.AstHelpers exposing
 @docs isTupleFirstAccess, isTupleSecondAccess
 @docs getOrder, getSpecificBool, getBool, getBoolPattern, getUncomputedNumberValue
 @docs getCollapsedCons, getListLiteral, getListSingleton
-@docs getTuple2Literal
+@docs getTuple2, getTuple2Literal
 
 
 ### literal as string
@@ -741,6 +741,26 @@ getTuple2Literal expressionNode =
 
         _ ->
             Nothing
+
+
+getTuple2 : Node Expression -> ModuleNameLookupTable -> Maybe { first : Node Expression, second : Node Expression }
+getTuple2 expressionNode lookupTable =
+    case removeParens expressionNode of
+        Node _ (Expression.TupledExpression (first :: second :: [])) ->
+            Just { first = first, second = second }
+
+        _ ->
+            case getSpecificFunctionCall ( [ "Tuple" ], "pair" ) lookupTable expressionNode of
+                Just tuplePairCall ->
+                    case tuplePairCall.argsAfterFirst of
+                        second :: _ ->
+                            Just { first = tuplePairCall.firstArg, second = second }
+
+                        [] ->
+                            Nothing
+
+                Nothing ->
+                    Nothing
 
 
 getBoolPattern : ModuleNameLookupTable -> Node Pattern -> Maybe Bool

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -24,6 +24,7 @@ all =
         , fullyAppliedPrefixOperatorTests
         , appliedLambdaTests
         , usingPlusPlusTests
+        , tupleTests
         , stringSimplificationTests
         , listSimplificationTests
         , maybeTests
@@ -13654,6 +13655,142 @@ a = List.map5 f list0 list1 list2 list3 []
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = []
+"""
+                        ]
+        ]
+
+
+
+-- Tuple
+
+
+tupleTests : Test
+tupleTests =
+    describe "Tuple"
+        [ tupleFirstTests
+        , tupleSecondTests
+        ]
+
+
+tupleFirstTests : Test
+tupleFirstTests =
+    describe "Tuple.first"
+        [ test "should not report Tuple.first used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.first
+b = Tuple.first tuple
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Tuple.first ( first |> f, second ) by (first |> f)" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.first ( first |> f, second )
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.first on a known tuple will result in the tuple's first part"
+                            , details = [ "You can replace this call by the tuple's first part." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (first |> f)
+"""
+                        ]
+        , test "should replace Tuple.first (second |> Tuple.pair first) by first" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.first (second |> Tuple.pair first)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.first on a known tuple will result in the tuple's first part"
+                            , details = [ "You can replace this call by the tuple's first part." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = first
+"""
+                        ]
+        , test "should replace Tuple.first << (first |> f |> Tuple.pair) by always (first |> f)" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.first << (first |> f |> Tuple.pair)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.pair with a first part, then Tuple.first will always result in that first part"
+                            , details = [ "You can replace this call by always with the first argument given to Tuple.pair." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always (first |> f)
+"""
+                        ]
+        ]
+
+
+tupleSecondTests : Test
+tupleSecondTests =
+    describe "Tuple.second"
+        [ test "should not report Tuple.second used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.second
+b = Tuple.second tuple
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Tuple.second ( first, second |> f ) by (second |> f)" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.second ( first, second |> f )
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.second on a known tuple will result in the tuple's second part"
+                            , details = [ "You can replace this call by the tuple's second part." ]
+                            , under = "Tuple.second"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (second |> f)
+"""
+                        ]
+        , test "should replace Tuple.second (second |> Tuple.pair first) by second" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.second (second |> Tuple.pair first)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.second on a known tuple will result in the tuple's second part"
+                            , details = [ "You can replace this call by the tuple's second part." ]
+                            , under = "Tuple.second"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = second
+"""
+                        ]
+        , test "should replace Tuple.second << Tuple.pair first by identity" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.second << (second |> f |> Tuple.pair)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.pair with a first part, then Tuple.second will always result in the incoming second part"
+                            , details = [ "You can replace this call by identity." ]
+                            , under = "Tuple.second"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
 """
                         ]
         ]


### PR DESCRIPTION
`Tuple.first` and `Tuple.second` simplifications from #2 + some for composition
```elm
Tuple.first ( a, b )
--> a

Tuple.second ( a, b )
--> b

-- not shown in summary
Tuple.first (Tuple.pair a b)
--> a

-- not shown in summary
Tuple.second (Tuple.pair a b)
--> b

-- not shown in summary
Tuple.second << Tuple.pair a
--> identity

-- not shown in summary
Tuple.first << Tuple.pair a
--> always a
```