### PR TITLE
Task.on error simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7192,14 +7192,19 @@ wrapperAndThenChecks wrapper checkInfo =
                     checkInfo.firstArg
             of
                 Determined wrapCalls ->
+                    let
+                        mapFn : ( ModuleName, String )
+                        mapFn =
+                            ( wrapper.moduleName, "map" )
+                    in
                     Just
                         (Rule.errorWithFix
-                            { message = qualifiedToString checkInfo.fn ++ " with a function that always returns " ++ descriptionForIndefinite wrapper.wrap.description ++ " is the same as " ++ qualifiedToString ( wrapper.moduleName, "map" ) ++ " with the function returning the value inside"
-                            , details = [ "You can replace this call by " ++ qualifiedToString ( wrapper.moduleName, "map" ) ++ " with the function returning the value inside " ++ descriptionForDefinite "the" wrapper.wrap.description ++ "." ]
+                            { message = qualifiedToString checkInfo.fn ++ " with a function that always returns " ++ descriptionForIndefinite wrapper.wrap.description ++ " is the same as " ++ qualifiedToString mapFn ++ " with the function returning the value inside"
+                            , details = [ "You can replace this call by " ++ qualifiedToString mapFn ++ " with the function returning the value inside " ++ descriptionForDefinite "the" wrapper.wrap.description ++ "." ]
                             }
                             checkInfo.fnRange
                             (Fix.replaceRangeBy checkInfo.fnRange
-                                (qualifiedToString (qualify ( wrapper.moduleName, "map" ) checkInfo))
+                                (qualifiedToString (qualify mapFn checkInfo))
                                 :: List.concatMap (\call -> replaceBySubExpressionFix call.nodeRange call.value) wrapCalls
                             )
                         )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6506,7 +6506,7 @@ emptyAsString qualifyResources emptiable =
     emptiable.empty.asString (extractQualifyResources qualifyResources)
 
 
-randomGeneratorWrapper : NonEmptiableProperties (WrapperProperties {})
+randomGeneratorWrapper : NonEmptiableProperties (WrapperProperties { mapFnName : String })
 randomGeneratorWrapper =
     { moduleName = [ "Random" ]
     , represents = "random generator"
@@ -6518,12 +6518,13 @@ randomGeneratorWrapper =
                 Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Random" ], "constant" ) lookupTable expr)
         }
     , empty = { invalid = () }
+    , mapFnName = "map"
     }
 
 
 maybeWithJustAsWrap :
     EmptiableProperties
-        (WrapperProperties {})
+        (WrapperProperties { mapFnName : String })
 maybeWithJustAsWrap =
     { moduleName = [ "Maybe" ]
     , represents = "maybe"
@@ -6543,6 +6544,7 @@ maybeWithJustAsWrap =
             \lookupTable expr ->
                 Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Maybe" ], "Just" ) lookupTable expr)
         }
+    , mapFnName = "map"
     }
 
 
@@ -6552,6 +6554,7 @@ resultWithOkAsWrap :
             { description : Description
             , is : ModuleNameLookupTable -> Node Expression -> Bool
             }
+        , mapFnName : String
         }
 resultWithOkAsWrap =
     { moduleName = [ "Result" ]
@@ -6569,6 +6572,7 @@ resultWithOkAsWrap =
             \lookupTable expr ->
                 isJust (AstHelpers.getSpecificFunctionCall ( [ "Result" ], "Err" ) lookupTable expr)
         }
+    , mapFnName = "map"
     }
 
 
@@ -6604,6 +6608,7 @@ taskWithSucceedAsWrap :
             { description : Description
             , is : ModuleNameLookupTable -> Node Expression -> Bool
             }
+        , mapFnName : String
         }
 taskWithSucceedAsWrap =
     { moduleName = [ "Task" ]
@@ -6621,12 +6626,13 @@ taskWithSucceedAsWrap =
             \lookupTable expr ->
                 isJust (AstHelpers.getSpecificFunctionCall ( [ "Task" ], "fail" ) lookupTable expr)
         }
+    , mapFnName = "map"
     }
 
 
 listCollection :
     CollectionProperties
-        (WrapperProperties {})
+        (WrapperProperties { mapFnName : String })
 listCollection =
     { moduleName = [ "List" ]
     , represents = "list"
@@ -6644,6 +6650,7 @@ listCollection =
             \lookupTable expr ->
                 Maybe.map .element (AstHelpers.getListSingleton lookupTable expr)
         }
+    , mapFnName = "map"
     }
 
 
@@ -7139,7 +7146,7 @@ getValueWithNodeRange getValue expressionNode =
 
 
 wrapperAndThenChecks :
-    WrapperProperties otherProperties
+    WrapperProperties { otherProperties | mapFnName : String }
     -> CheckInfo
     -> Maybe (Error {})
 wrapperAndThenChecks wrapper checkInfo =
@@ -7195,7 +7202,7 @@ wrapperAndThenChecks wrapper checkInfo =
                     let
                         mapFn : ( ModuleName, String )
                         mapFn =
-                            ( wrapper.moduleName, "map" )
+                            ( wrapper.moduleName, wrapper.mapFnName )
                     in
                     Just
                         (Rule.errorWithFix

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -18275,15 +18275,17 @@ taskAndThenTests =
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen f x
+a = Task.andThen
+b = Task.andThen f
+c = Task.andThen f x
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should replace Task.andThen f (Task.fail z) by (Task.fail z)" <|
+        , test "should replace Task.andThen f (Task.fail x) by (Task.fail x)" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen f (Task.fail z)
+a = Task.andThen f (Task.fail x)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -18294,22 +18296,22 @@ a = Task.andThen f (Task.fail z)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = (Task.fail z)
+a = (Task.fail x)
 """
                         ]
-        , test "should not report Task.andThen (always (Task.fail z)) x" <|
+        , test "should not report Task.andThen (always (Task.fail x)) task" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen (always (Task.fail z)) x
+a = Task.andThen (always (Task.fail x)) task
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should replace Task.andThen Task.succeed x by Task.map identity x" <|
+        , test "should replace Task.andThen Task.succeed task by task" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen Task.succeed x
+a = Task.andThen Task.succeed task
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -18320,14 +18322,14 @@ a = Task.andThen Task.succeed x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = x
+a = task
 """
                         ]
-        , test "should replace Task.andThen (\\b -> Task.succeed c) x by Task.map (\\b -> c) x" <|
+        , test "should replace Task.andThen (\\b -> Task.succeed c) task by Task.map (\\b -> c) task" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen (\\b -> Task.succeed c) x
+a = Task.andThen (\\b -> Task.succeed c) task
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -18338,14 +18340,14 @@ a = Task.andThen (\\b -> Task.succeed c) x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.map (\\b -> c) x
+a = Task.map (\\b -> c) task
 """
                         ]
-        , test "should replace Task.andThen (\\b -> let y = 1 in Task.succeed y) x by Task.map (\\b -> let y = 1 in y) x" <|
+        , test "should replace Task.andThen (\\b -> let y = 1 in Task.succeed y) task by Task.map (\\b -> let y = 1 in y) task" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen (\\b -> let y = 1 in Task.succeed y) x
+a = Task.andThen (\\b -> let y = 1 in Task.succeed y) task
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -18356,14 +18358,14 @@ a = Task.andThen (\\b -> let y = 1 in Task.succeed y) x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.map (\\b -> let y = 1 in y) x
+a = Task.map (\\b -> let y = 1 in y) task
 """
                         ]
-        , test "should replace Task.andThen (\\b -> if cond then Task.succeed b else Task.succeed c) x by Task.map (\\b -> if cond then b else c) x" <|
+        , test "should replace Task.andThen (\\b -> if cond then Task.succeed b else Task.succeed c) task by Task.map (\\b -> if cond then b else c) task" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen (\\b -> if cond then Task.succeed b else Task.succeed c) x
+a = Task.andThen (\\b -> if cond then Task.succeed b else Task.succeed c) task
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -18374,22 +18376,22 @@ a = Task.andThen (\\b -> if cond then Task.succeed b else Task.succeed c) x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.map (\\b -> if cond then b else c) x
+a = Task.map (\\b -> if cond then b else c) task
 """
                         ]
-        , test "should not report Task.andThen (\\b -> if cond then Task.succeed b else Task.fail c) x" <|
+        , test "should not report Task.andThen (\\b -> if cond then Task.succeed b else Task.fail c) task" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen (\\b -> if cond then Task.succeed b else Task.fail c) x
+a = Task.andThen (\\b -> if cond then Task.succeed b else Task.fail c) task
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should replace Task.andThen f (Task.succeed x) by f (x)" <|
+        , test "should replace Task.andThen f (Task.succeed a) by f a" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.andThen f (Task.succeed x)
+a = Task.andThen f (Task.succeed a)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -18400,14 +18402,14 @@ a = Task.andThen f (Task.succeed x)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = f x
+a = f a
 """
                         ]
-        , test "should replace Task.succeed x |> Task.andThen f by f (x)" <|
+        , test "should replace Task.succeed a |> Task.andThen f by a |> f" <|
             \() ->
                 """module A exposing (..)
 import Task
-a = Task.succeed x |> Task.andThen f
+a = Task.succeed a |> Task.andThen f
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -18418,7 +18420,7 @@ a = Task.succeed x |> Task.andThen f
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = x |> f
+a = a |> f
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15271,7 +15271,7 @@ a = Result.andThen (always (Err z)) x
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should replace Result.andThen Ok x by Result.map identity x" <|
+        , test "should replace Result.andThen Ok x by x" <|
             \() ->
                 """module A exposing (..)
 a = Result.andThen Ok x
@@ -15342,7 +15342,7 @@ a = Result.andThen (\\b -> if cond then Ok b else Err c) x
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should replace Result.andThen f (Ok x) by f (x)" <|
+        , test "should replace Result.andThen f (Ok x) by f x" <|
             \() ->
                 """module A exposing (..)
 a = Result.andThen f (Ok x)
@@ -15358,7 +15358,7 @@ a = Result.andThen f (Ok x)
 a = f x
 """
                         ]
-        , test "should replace Ok x |> Result.andThen f by f (x)" <|
+        , test "should replace Ok x |> Result.andThen f by x |> f" <|
             \() ->
                 """module A exposing (..)
 a = Ok x |> Result.andThen f


### PR DESCRIPTION
`Task.onError`, the `andThen` for failing tasks (that I wish result etc had as well).
```elm
Task.onError f (Task.succeed a)
--> Task.succeed a

Task.onError f (Task.fail x)
--> f x

Task.onError Task.fail task
--> task

Task.onError (\x -> Task.fail y) task
--> Task.mapError (\x -> y) x
```
Bonus: Minor improvements to the tests of `Result.andThen` and `Task.andThen`