### PR TITLE
Add Task.sequence simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6112,6 +6112,7 @@ wrapperSequenceChecks wrapper checkInfo =
                         mapFn =
                             ( wrapper.moduleName, wrapper.mapFnName )
 
+                        replacement : QualifyResources a -> String
                         replacement qualifyResources =
                             qualifiedToString (qualify mapFn qualifyResources)
                                 ++ " "
@@ -6169,6 +6170,7 @@ mappableSequenceCompositionChecks mappable checkInfo =
                 mapFn =
                     ( mappable.moduleName, mappable.mapFnName )
 
+                replacement : QualifyResources a -> String
                 replacement qualifyResources =
                     qualifiedToString (qualify mapFn qualifyResources)
                         ++ " "


### PR DESCRIPTION
Implementation should also make it easy to extend to `Maybe/Result/Random/Parser.Extra.sequence/combine` in the future
```elm
Task.sequence [ Task.succeed a, Task.succeed b ]
--> Task.succeed [ a, b ]

Task.sequence [ Task.succeed a, Task.fail x ]
--> Task.fail x

Task.sequence [ task ]
--> Task.map List.singleton task

Task.sequence [ a, Task.fail x, b ]
--> Task.sequence [ a, Task.fail x ]

-- for example not in summary
Task.sequence << List.singleton
--> Task.map List.singleton

-- not in summary because theoretically same case as the first but with a separate error
Task.sequence []
--> Task.succeed []
```
Note that we do not simplify
```elm
Task.sequence [ task, Task.fail x ]
--> Task.fail x
```
because `task` could fail earlier.
We also don't simplify it to
```elm
Task.sequence [ task, Task.fail x ]
--> Task.onError (always (Task.fail x)) task
```
because this is arguably a code style choice.