### PR TITLE
Add wrapper mapN simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6081,6 +6081,34 @@ wrapperMapNChecks config wrapper checkInfo =
         Nothing
 
 
+{-| If we find an empty argument given to the `mapN`, we either
+
+  - replace the whole call by the first empty argument if all earlier arguments are wrapped
+
+        map3 f (wrap first) empty thirdWrapper
+        --> empty
+
+        map2 f empty secondWrapper
+        --> empty
+
+    For example given `resultWithOkAsWrap`:
+
+        Result.map3 f (Ok x) (Err y) thirdResult
+        --> Err y
+
+  - ignore arguments after the known empty argument because they will never have an effect on the result
+
+        map3 f emptyOrWrappedWeDoNotKnow empty thirdWrapper
+        --> map2 f emptyOrWrappedWeDoNotKnow empty
+
+    For example given `resultWithOkAsWrap`:
+
+        Result.map3 f errorOrOkWeDoNotKnow (Err x) thirdResult
+        --> Result.map2 f errorOrOkWeDoNotKnow (Err x)
+
+This is pretty similar to `sequenceOrFirstEmptyChecks` where we look at arguments instead of list elements.
+
+-}
 mapNOrFirstEmptyConstructionChecks :
     { n : Int }
     ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6160,7 +6160,7 @@ mapNOrFirstEmptyConstructionChecks config emptiable checkInfo =
                                     let
                                         lambdaStart : String
                                         lambdaStart =
-                                            "\\" ++ String.join " " (List.repeat atLeast2 "_") ++ " -> "
+                                            "\\" ++ String.repeat atLeast2 "_ " ++ "-> "
                                     in
                                     { description =
                                         lambdaStart ++ "with " ++ descriptionForDefinite "the first" emptiable.empty.description
@@ -6244,7 +6244,7 @@ mapNOrFirstEmptyConstructionChecks config emptiable checkInfo =
                                         let
                                             lambdaStart : String
                                             lambdaStart =
-                                                "\\" ++ String.join " " (List.repeat atLeast2 "_") ++ " -> "
+                                                "\\" ++ String.repeat atLeast2 "_ " ++ "-> "
                                         in
                                         { fix =
                                             [ Fix.replaceRangeBy

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6072,9 +6072,17 @@ wrapperMapNChecks config wrapper checkInfo =
                             , keep = Node.range checkInfo.firstArg
                             }
                             ++ List.concatMap (\wrap -> replaceBySubExpressionFix wrap.nodeRange wrap.value) wraps
-                            ++ [ Fix.insertAt checkInfo.parentRange.end ")"
-                               , Fix.insertAt checkInfo.parentRange.start (qualifiedToString (qualify wrapFn checkInfo) ++ " (")
-                               ]
+                            ++ (if checkInfo.usingRightPizza then
+                                    [ Fix.insertAt checkInfo.parentRange.end
+                                        (" |> " ++ qualifiedToString (qualify wrapFn checkInfo))
+                                    ]
+
+                                else
+                                    -- <| or application
+                                    [ Fix.insertAt checkInfo.parentRange.end ")"
+                                    , Fix.insertAt checkInfo.parentRange.start (qualifiedToString (qualify wrapFn checkInfo) ++ " (")
+                                    ]
+                               )
                         )
                     )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6056,11 +6056,15 @@ wrapperMapNChecks config wrapper checkInfo =
                     wrapFn : ( ModuleName, String )
                     wrapFn =
                         ( wrapper.moduleName, wrapper.wrap.fnName )
+
+                    wrapFnDescription : String
+                    wrapFnDescription =
+                        qualifiedToString (qualify wrapFn defaultQualifyResources)
                 in
                 Just
                     (Rule.errorWithFix
-                        { message = qualifiedToString checkInfo.fn ++ " where each " ++ wrapper.represents ++ " is " ++ descriptionForIndefinite wrapper.wrap.description ++ " will result in " ++ qualifiedToString ( wrapper.moduleName, wrapper.wrap.fnName ) ++ " on the values inside"
-                        , details = [ "You can replace this call by " ++ qualifiedToString wrapFn ++ " where each " ++ wrapper.represents ++ " is replaced by its value inside " ++ descriptionForDefinite "the" wrapper.wrap.description ++ "." ]
+                        { message = qualifiedToString checkInfo.fn ++ " where each " ++ wrapper.represents ++ " is " ++ descriptionForIndefinite wrapper.wrap.description ++ " will result in " ++ wrapFnDescription ++ " on the values inside"
+                        , details = [ "You can replace this call by " ++ wrapFnDescription ++ " with the function applied to the values inside each " ++ descriptionWithoutArticle wrapper.wrap.description ++ "." ]
                         }
                         checkInfo.fnRange
                         (keepOnlyFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6032,6 +6032,20 @@ emptiableMapNChecks { n } emptiable checkInfo =
         Nothing
 
 
+{-| When all arguments of a fully applied `mapN` are wrapped,
+apply the given function to the values inside and wrap the whole thing again:
+
+    map2 f (wrap first) (wrap second)
+    --> wrap (f first second)
+
+For example given `resultWithOkAsWrap`:
+
+    Result.map2 f (Ok first) (Ok second)
+    --> Ok (f first second)
+
+This is pretty similar to `wrapperSequenceChecks` where we look at arguments instead of list elements.
+
+-}
 wrapperMapNChecks : { n : Int } -> WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
 wrapperMapNChecks config wrapper checkInfo =
     if List.length checkInfo.argsAfterFirst == config.n then

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -8,7 +8,7 @@ module Simplify.AstHelpers exposing
     , getCollapsedCons, getListLiteral, getListSingleton
     , getTuple2, getTuple2Literal
     , boolToString, orderToString, emptyStringAsString
-    , moduleNameFromString, qualifiedName, qualifiedToString
+    , moduleNameFromString, qualifiedName, qualifiedModuleName, qualifiedToString
     , declarationListBindings, letDeclarationListBindings, patternBindings, patternListBindings
     , getTypeExposeIncludingVariants, nameOfExpose
     )
@@ -43,7 +43,7 @@ module Simplify.AstHelpers exposing
 
 ### qualification
 
-@docs moduleNameFromString, qualifiedName, qualifiedToString
+@docs moduleNameFromString, qualifiedName, qualifiedModuleName, qualifiedToString
 
 
 ### misc
@@ -946,6 +946,11 @@ qualifiedToString ( moduleName, name ) =
 qualifiedName : ( ModuleName, String ) -> String
 qualifiedName ( _, name ) =
     name
+
+
+qualifiedModuleName : ( ModuleName, String ) -> ModuleName
+qualifiedModuleName ( moduleName, _ ) =
+    moduleName
 
 
 moduleNameToString : ModuleName -> String

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15406,10 +15406,43 @@ c = Result.map3 f result0
 d = Result.map3 f result0 result1
 e = Result.map3 f result0 result1 result2
 f = Result.map3 f (Ok h) result1 result2 -- because this is a code style choice
+f = Result.map3 f (Ok h)
 g = Result.map3 f result0 result1 (Err x) -- because result0/1 can have an earlier error
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+        , test "should replace Result.map3 f (Ok a) (Ok b) (Ok c) by Ok (f a b c)" <|
+            \() ->
+                """module A exposing (..)
+a = Result.map3 f (Ok a) (Ok b) (Ok c)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Result.map3 where each result is an okay result will result in Ok on the values inside"
+                            , details = [ "You can replace this call by Ok with the function applied to the values inside each okay result." ]
+                            , under = "Result.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Ok (f a b c)
+"""
+                        ]
+        , test "should replace c |> g |> Ok |> Result.map3 f (Ok a) (Ok b) by Ok ((c |> g) |> f a b)" <|
+            \() ->
+                """module A exposing (..)
+a = c |> g |> Ok |> Result.map3 f (Ok a) (Ok b)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Result.map3 where each result is an okay result will result in Ok on the values inside"
+                            , details = [ "You can replace this call by Ok with the function applied to the values inside each okay result." ]
+                            , under = "Result.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Ok ((c |> g) |> f a b)
+"""
+                        ]
         , test "should replace Result.map3 f (Ok a) (Err x) result2 by (Err x)" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15427,7 +15427,7 @@ a = Result.map3 f (Ok a) (Ok b) (Ok c)
 a = Ok (f a b c)
 """
                         ]
-        , test "should replace c |> g |> Ok |> Result.map3 f (Ok a) (Ok b) by Ok ((c |> g) |> f a b)" <|
+        , test "should replace c |> g |> Ok |> Result.map3 f (Ok a) (Ok b) by (c |> g) |> f a b |> Ok" <|
             \() ->
                 """module A exposing (..)
 a = c |> g |> Ok |> Result.map3 f (Ok a) (Ok b)
@@ -15440,7 +15440,7 @@ a = c |> g |> Ok |> Result.map3 f (Ok a) (Ok b)
                             , under = "Result.map3"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Ok ((c |> g) |> f a b)
+a = (c |> g) |> f a b |> Ok
 """
                         ]
         , test "should replace Result.map3 f (Ok a) (Err x) result2 by (Err x)" <|


### PR DESCRIPTION
Since we don't want unused code around, this is already applied to `Result.map2-5`:
```elm
-- the following simplifications for map3 work for all Result.mapN
Result.map3 f (Ok a) (Ok b) (Ok c)
--> Ok (f a b c)

Result.map3 f (Ok a) (Err x) thirdResult
--> Err x

Result.map3 f firstResult (Err x) thirdResult
--> Result.map2 f firstResult (Err x)
```
includes all combinations with currying, for example
```elm
Result.map3 f firstResult (Err x)
--> always (Result.map2 f firstResult (Err x))

Result.map4 f firstResult (Err x)
--> (\_ _ -> Result.map2 f firstResult (Err x))
```
The same checks can be applied to `Task`, `Json.Decode`, `Fuzz` etc. with minimal effort.

Note that we don't simplify for example
```elm
Result.map2 (\a b -> a + b) firtResult (Ok second)
--> Result.map (\a -> a + second) firstResult
```
because some consider this a valid code style, e.g.
```elm
Result.map2 YourRecord
    (Json.Decode.field "a" aDecoder)
    (Json.Decode.succeed second)
    (Json.Decode.field "c" cDecoder)
```
I personally disagree strongly but at the same time I'd prefer this to be a separate rule (the fixes are also not trivial, not sure we want to alter the existing code this much).