### PR TITLE
Add Array.repeat simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The rule now simplifies:
 - the same operations for `Array.filter` as for other types like `List.filter` and `Set.filter`
 - `Array.isEmpty Array.empty` to `True`
 - `Array.isEmpty (Array.fromList [ x ])` to `False`
+- `Array.repeat 0 n` to `Array.empty`
 - `List.singleton >> String.fromList` to `String.fromChar`
 
 ## [2.1.1] - 2023-09-18

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -710,6 +710,9 @@ Destructuring using case expressions
     Array.isEmpty Array.empty
     --> True
 
+    Array.repeat 0 x
+    --> Array.empty
+
 
 ### Sets
 
@@ -2406,6 +2409,7 @@ functionCallChecks =
         , ( ( [ "Array" ], "map" ), emptiableMapChecks arrayCollection )
         , ( ( [ "Array" ], "filter" ), emptiableFilterChecks arrayCollection )
         , ( ( [ "Array" ], "isEmpty" ), collectionIsEmptyChecks arrayCollection )
+        , ( ( [ "Array" ], "repeat" ), arrayRepeatChecks )
         , ( ( [ "Set" ], "map" ), emptiableMapChecks setCollection )
         , ( ( [ "Set" ], "filter" ), emptiableFilterChecks setCollection )
         , ( ( [ "Set" ], "remove" ), collectionRemoveChecks setCollection )
@@ -5769,6 +5773,11 @@ listRepeatChecks checkInfo =
         , \() -> wrapperRepeatChecks listCollection checkInfo
         ]
         ()
+
+
+arrayRepeatChecks : CheckInfo -> Maybe (Error {})
+arrayRepeatChecks checkInfo =
+    emptiableRepeatChecks arrayCollection checkInfo
 
 
 emptiableRepeatChecks : CollectionProperties otherProperties -> CheckInfo -> Maybe (Error {})

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13987,6 +13987,7 @@ arrayTests =
         , arrayMapTests
         , arrayFilterTests
         , arrayIsEmptyTests
+        , arrayRepeatTests
         ]
 
 
@@ -14614,6 +14615,85 @@ a = Array.isEmpty (Array.initialize n f)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+        ]
+
+
+arrayRepeatTests : Test
+arrayRepeatTests =
+    describe "Array.repeat"
+        [ test "should not report Array.repeat used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.repeat n
+b = Array.repeat 2
+c = Array.repeat n x
+d = Array.repeat 5 x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should not replace Array.repeat n x by x" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.repeat n x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Array.repeat 0 x by Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.repeat 0 x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.repeat with length 0 will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.repeat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.empty
+"""
+                        ]
+        , test "should replace Array.repeat 0 by always Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.repeat 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.repeat with length 0 will always result in Array.empty"
+                            , details = [ "You can replace this call by always Array.empty." ]
+                            , under = "Array.repeat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always Array.empty
+"""
+                        ]
+        , test "should replace Array.repeat -5 x by Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.repeat -5 x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.repeat with negative length will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.repeat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.empty
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Adds simplifications for `Array.repeat` #174

- [x] `Array.repeat 0 x` -> `Array.empty`
- [x] `Array.repeat -1 x` -> `Array.empty`

I also wanted to do
```elm
Array.repeat 1 f -- Only when the number is 1
--> Array.fromList [ x ]
```
but the existing checks (`wrapperRepeatChecks`) don't work for this type which doesn't have a `Array.singleton` function.
@lue-bird if you can think of an easy way to add this, let me know, otherwise I'll leave it for later and focus on other issues first :smile: 