### PR TITLE
Respect function call style

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6117,8 +6117,12 @@ wrapperMapNChecks config wrapper checkInfo =
                                             (" |> " ++ qualifiedToString (qualify wrapFn checkInfo))
                                         ]
 
-                                    -- Pipe RightToLeft | application ->
-                                    _ ->
+                                    Pipe RightToLeft ->
+                                        [ Fix.insertAt checkInfo.parentRange.start
+                                            (qualifiedToString (qualify wrapFn checkInfo) ++ " <| ")
+                                        ]
+
+                                    Application ->
                                         [ Fix.insertAt checkInfo.parentRange.end ")"
                                         , Fix.insertAt checkInfo.parentRange.start (qualifiedToString (qualify wrapFn checkInfo) ++ " (")
                                         ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2353,6 +2353,13 @@ type alias CheckInfo =
     }
 
 
+{-| How an argument is given as input to a function:
+
+  - `Pipe RightToLeft`: `function <| argument`
+  - `Pipe LeftToRight`: `argument |> function`
+  - `Application`: `function argument`
+
+-}
 type FunctionCallStyle
     = Application
     | Pipe LeftOrRightDirection

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7676,8 +7676,13 @@ mapWrapChecks wrapper checkInfo =
                                     ]
                                         ++ removeWrapCalls
 
-                                -- Pipe RightToLeft | Application
-                                _ ->
+                                Pipe RightToLeft ->
+                                    Fix.replaceRangeBy
+                                        { start = checkInfo.parentRange.start, end = mappingArgRange.start }
+                                        (qualifiedToString (qualify ( wrapper.moduleName, wrapper.wrap.fnName ) checkInfo) ++ " <| ")
+                                        :: removeWrapCalls
+
+                                Application ->
                                     [ Fix.replaceRangeBy
                                         { start = checkInfo.parentRange.start, end = mappingArgRange.start }
                                         (qualifiedToString (qualify ( wrapper.moduleName, wrapper.wrap.fnName ) checkInfo) ++ " (")

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15644,6 +15644,22 @@ a = c |> g |> Ok |> Result.map3 f (Ok a) (Ok b)
 a = (c |> g) |> f a b |> Ok
 """
                         ]
+        , test "should replace Result.map3 f (Ok a) (Ok b) <| Ok <| g <| c by Ok <| f a b <| (g <| c)" <|
+            \() ->
+                """module A exposing (..)
+a = Result.map3 f (Ok a) (Ok b) <| Ok <| g <| c
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Result.map3 where each result is an okay result will result in Ok on the values inside"
+                            , details = [ "You can replace this call by Ok with the function applied to the values inside each okay result." ]
+                            , under = "Result.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Ok <| f a b <| (g <| c)
+"""
+                        ]
         , test "should replace Result.map3 f (Ok a) (Err x) result2 by (Err x)" <|
             \() ->
                 """module A exposing (..)
@@ -19427,6 +19443,24 @@ a = c |> g |> Task.succeed |> Task.map3 f (Task.succeed a) (Task.succeed b)
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
 a = (c |> g) |> f a b |> Task.succeed
+"""
+                        ]
+        , test "should replace Task.map3 f (Task.succeed a) (Task.succeed b) <| Task.succeed <| g <| c by Task.succeed <| f a b <| (g <| c)" <|
+            \() ->
+                """module A exposing (..)
+import Task
+a = Task.map3 f (Task.succeed a) (Task.succeed b) <| Task.succeed <| g <| c
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Task.map3 where each task is a succeeding task will result in Task.succeed on the values inside"
+                            , details = [ "You can replace this call by Task.succeed with the function applied to the values inside each succeeding task." ]
+                            , under = "Task.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Task
+a = Task.succeed <| f a b <| (g <| c)
 """
                         ]
         , test "should replace Task.map3 f (Task.succeed a) (Task.fail x) task2 by (Task.fail x)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14800,7 +14800,7 @@ a = Maybe.map f (Just x)
 a = Just (f x)
 """
                         ]
-        , test "should replace Maybe.map f <| Just x by Just (f x)" <|
+        , test "should replace Maybe.map f <| Just x by Just <| f <| x" <|
             \() ->
                 """module A exposing (..)
 a = Maybe.map f <| Just x
@@ -14813,7 +14813,7 @@ a = Maybe.map f <| Just x
                             , under = "Maybe.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Just (f <| x)
+a = Just <| f <| x
 """
                         ]
         , test "should replace Just x |> Maybe.map f by x |> f |> Just" <|
@@ -14861,7 +14861,7 @@ a = Maybe.map f <| Just <| x
                             , under = "Maybe.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Just (f <| x)
+a = Just <| f <| x
 """
                         ]
         , test "should replace Maybe.map f << Just by Just << f" <|
@@ -15447,7 +15447,7 @@ a = Result.map f (Ok x)
 a = Ok (f x)
 """
                         ]
-        , test "should replace Result.map f <| Ok x by Ok (f x)" <|
+        , test "should replace Result.map f <| Ok x by Ok <| f <| x" <|
             \() ->
                 """module A exposing (..)
 a = Result.map f <| Ok x
@@ -15460,7 +15460,7 @@ a = Result.map f <| Ok x
                             , under = "Result.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Ok (f <| x)
+a = Ok <| f <| x
 """
                         ]
         , test "should replace Ok x |> Result.map f by x |> f |> Ok" <|
@@ -15508,7 +15508,7 @@ a = Result.map f <| Ok <| x
                             , under = "Result.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Ok (f <| x)
+a = Ok <| f <| x
 """
                         ]
         , test "should replace Result.map f << Ok by Ok << f" <|
@@ -15963,7 +15963,7 @@ a = Result.mapError f (Err x)
 a = Err (f x)
 """
                         ]
-        , test "should replace Result.mapError f <| Err x by Err (f x)" <|
+        , test "should replace Result.mapError f <| Err x by Err <| f <| x" <|
             \() ->
                 """module A exposing (..)
 a = Result.mapError f <| Err x
@@ -15976,7 +15976,7 @@ a = Result.mapError f <| Err x
                             , under = "Result.mapError"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Err (f <| x)
+a = Err <| f <| x
 """
                         ]
         , test "should replace Err x |> Result.mapError f by x |> f |> Err" <|
@@ -16024,7 +16024,7 @@ a = Result.mapError f <| Err <| x
                             , under = "Result.mapError"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Err (f <| x)
+a = Err <| f <| x
 """
                         ]
         , test "should replace Result.mapError f << Err by Err << f" <|
@@ -19297,7 +19297,7 @@ import Task
 a = Task.succeed (f x)
 """
                         ]
-        , test "should replace Task.map f <| Task.succeed x by Task.succeed (f x)" <|
+        , test "should replace Task.map f <| Task.succeed x by Task.succeed <| f <| x" <|
             \() ->
                 """module A exposing (..)
 import Task
@@ -19312,7 +19312,7 @@ a = Task.map f <| Task.succeed x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.succeed (f <| x)
+a = Task.succeed <| f <| x
 """
                         ]
         , test "should replace Task.succeed x |> Task.map f by x |> f |> Task.succeed" <|
@@ -19366,7 +19366,7 @@ a = Task.map f <| Task.succeed <| x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.succeed (f <| x)
+a = Task.succeed <| f <| x
 """
                         ]
         , test "should replace Task.map f << Task.succeed by Task.succeed << f" <|
@@ -19767,7 +19767,7 @@ import Task
 a = Task.fail (f x)
 """
                         ]
-        , test "should replace Task.mapError f <| Task.fail x by Task.fail (f x)" <|
+        , test "should replace Task.mapError f <| Task.fail x by Task.fail <| f <| x" <|
             \() ->
                 """module A exposing (..)
 import Task
@@ -19782,7 +19782,7 @@ a = Task.mapError f <| Task.fail x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.fail (f <| x)
+a = Task.fail <| f <| x
 """
                         ]
         , test "should replace Task.fail x |> Task.mapError f by x |> f |> Task.fail" <|
@@ -19836,7 +19836,7 @@ a = Task.mapError f <| Task.fail <| x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.fail (f <| x)
+a = Task.fail <| f <| x
 """
                         ]
         , test "should replace Task.mapError f << Task.fail by Task.fail << f" <|
@@ -21881,7 +21881,7 @@ import Random
 a = Random.constant (f x)
 """
                         ]
-        , test "should replace Random.map f <| Random.constant x by Random.constant (f x)" <|
+        , test "should replace Random.map f <| Random.constant x by Random.constant <| f <| x" <|
             \() ->
                 """module A exposing (..)
 import Random
@@ -21896,7 +21896,7 @@ a = Random.map f <| Random.constant x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Random
-a = Random.constant (f <| x)
+a = Random.constant <| f <| x
 """
                         ]
         , test "should replace Random.constant x |> Random.map f by x |> f |> Random.constant" <|
@@ -21950,7 +21950,7 @@ a = Random.map f <| Random.constant <| x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Random
-a = Random.constant (f <| x)
+a = Random.constant <| f <| x
 """
                         ]
         , test "should replace Random.map f << Random.constant by Random.constant << f" <|


### PR DESCRIPTION
Replaces `usingRightPizza : Bool` by `callStyle : FunctionCallStyle` where
```elm
FunctionCallStyle = Application | Pipe LeftOrRightDirection
```

wrapper mapN and map wrap now get fixes that preserve the parent's call style.