### PR TITLE
Add String.fromList-toList simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3342,6 +3342,7 @@ For example
 inversesCompositionCheck : ( ModuleName, String ) -> ( ModuleName, String ) -> CompositionCheckInfo -> Maybe (Error {})
 inversesCompositionCheck inverseFn0 inverseFn1 checkInfo =
     let
+        checkFnInfosForInverses : { earlierFnInfo : { range : Range, name : String }, laterFnInfo : { range : Range, name : String }, details : List String, fix : List Fix } -> Maybe (Error {})
         checkFnInfosForInverses config =
             case ( ModuleNameLookupTable.moduleNameAt checkInfo.lookupTable config.earlierFnInfo.range, ModuleNameLookupTable.moduleNameAt checkInfo.lookupTable config.laterFnInfo.range ) of
                 ( Just earlierModuleName, Just laterModuleName ) ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6117,8 +6117,12 @@ wrapperMapNChecks config wrapper checkInfo =
                                             (" |> " ++ qualifiedToString (qualify wrapFn checkInfo))
                                         ]
 
-                                    -- Pipe RightToLeft | application ->
-                                    _ ->
+                                    Pipe RightToLeft ->
+                                        [ Fix.insertAt checkInfo.parentRange.start
+                                            (qualifiedToString (qualify wrapFn checkInfo) ++ " <| ")
+                                        ]
+
+                                    Application ->
                                         [ Fix.insertAt checkInfo.parentRange.end ")"
                                         , Fix.insertAt checkInfo.parentRange.start (qualifiedToString (qualify wrapFn checkInfo) ++ " (")
                                         ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2353,6 +2353,13 @@ type alias CheckInfo =
     }
 
 
+{-| How an argument is given as input to a function:
+
+  - `Pipe RightToLeft`: `function <| argument`
+  - `Pipe LeftToRight`: `argument |> function`
+  - `Application`: `function argument`
+
+-}
 type FunctionCallStyle
     = Application
     | Pipe LeftOrRightDirection

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3312,6 +3312,34 @@ consChecks checkInfo =
         ()
 
 
+{-| Chaining two operations that are inverses of each other and therefore cancel each other out.
+For example
+
+    Array.fromList (Array.toList array)
+    --> array
+
+    Array.toList (Array.fromList list)
+    --> list
+
+These usually exist in pairs, like above so make sure to add this check for both functions.
+Tip: Add `inversesCompositionCheck` for the same thing for both sides as a composition check.
+
+But there are exceptions!
+
+    Set.fromList (Set.toList set)
+    --> set
+
+This will always work because `Set.toList` will never produce a list with duplicate elements. However
+
+    Set.toList (Set.fromList list)
+    --> list
+
+would be an incorrect fix. See for example
+
+    Set.toList (Set.fromList [ 0, 0 ])
+    --> not [ 0, 0 ] bit actually [ 0 ]
+
+-}
 onCallToInverseReturnsItsArgumentCheck : ( ModuleName, String ) -> CheckInfo -> Maybe (Error {})
 onCallToInverseReturnsItsArgumentCheck inverseFn checkInfo =
     case AstHelpers.getSpecificFunctionCall inverseFn checkInfo.lookupTable checkInfo.firstArg of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -281,6 +281,12 @@ Destructuring using case expressions
     String.fromList [ a ]
     --> String.fromChar a
 
+    String.fromList (String.toList str)
+    --> str
+
+    String.toList (String.fromList list)
+    --> list
+
     String.isEmpty ""
     --> True
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7676,8 +7676,13 @@ mapWrapChecks wrapper checkInfo =
                                     ]
                                         ++ removeWrapCalls
 
-                                -- Pipe RightToLeft | Application
-                                _ ->
+                                Pipe RightToLeft ->
+                                    Fix.replaceRangeBy
+                                        { start = checkInfo.parentRange.start, end = mappingArgRange.start }
+                                        (qualifiedToString (qualify ( wrapper.moduleName, wrapper.wrap.fnName ) checkInfo) ++ " <| ")
+                                        :: removeWrapCalls
+
+                                Application ->
                                     [ Fix.replaceRangeBy
                                         { start = checkInfo.parentRange.start, end = mappingArgRange.start }
                                         (qualifiedToString (qualify ( wrapper.moduleName, wrapper.wrap.fnName ) checkInfo) ++ " (")

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3351,7 +3351,7 @@ onCallToInverseReturnsItsArgumentCheck inverseFn checkInfo =
                     , details = [ "You can replace this call by the argument given to " ++ qualifiedToString inverseFn ++ "." ]
                     }
                     checkInfo.fnRange
-                    (replaceBySubExpressionFix checkInfo.parentRange call.firstArg)
+                    (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range call.firstArg })
                 )
 
         Nothing ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3431,7 +3431,7 @@ inversesCompositionCheck inverseFn checkInfo =
                 }
 
         ( Just earlierFnInfo, Nothing ) ->
-            case AstHelpers.getComposition checkInfo.later of
+            case getFullComposition checkInfo.later of
                 Just composition ->
                     case AstHelpers.getValueOrFunction composition.earlier of
                         Just laterFnInfo ->
@@ -3439,9 +3439,7 @@ inversesCompositionCheck inverseFn checkInfo =
                                 { earlierFnInfo = earlierFnInfo
                                 , laterFnInfo = laterFnInfo
                                 , details = [ "You can remove these two functions." ]
-                                , fix =
-                                    keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.later }
-                                        ++ removeAndBetweenFix { remove = Node.range composition.earlier, keep = Node.range composition.later }
+                                , fix = replaceBySubExpressionFix checkInfo.parentRange composition.composedLater
                                 }
 
                         Nothing ->

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -1,6 +1,6 @@
 module Simplify.AstHelpers exposing
     ( removeParens, removeParensFromPattern
-    , getComposition, getValueOrFunctionOrFunctionCall
+    , getComposition, getValueOrFunctionOrFunctionCall, getValueOrFunction
     , getSpecificFunctionCall, getSpecificValueOrFunction
     , isIdentity, getAlwaysResult, isSpecificUnappliedBinaryOperation
     , isTupleFirstAccess, isTupleSecondAccess
@@ -23,7 +23,7 @@ module Simplify.AstHelpers exposing
 
 ### value/function/function call/composition
 
-@docs getComposition, getValueOrFunctionOrFunctionCall
+@docs getComposition, getValueOrFunctionOrFunctionCall, getValueOrFunction
 @docs getSpecificFunctionCall, getSpecificValueOrFunction
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15644,6 +15644,22 @@ a = c |> g |> Ok |> Result.map3 f (Ok a) (Ok b)
 a = (c |> g) |> f a b |> Ok
 """
                         ]
+        , test "should replace Result.map3 f (Ok a) (Ok b) <| Ok <| g <| c by Ok <| f a b <| (g <| c)" <|
+            \() ->
+                """module A exposing (..)
+a = Result.map3 f (Ok a) (Ok b) <| Ok <| g <| c
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Result.map3 where each result is an okay result will result in Ok on the values inside"
+                            , details = [ "You can replace this call by Ok with the function applied to the values inside each okay result." ]
+                            , under = "Result.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Ok <| f a b <| (g <| c)
+"""
+                        ]
         , test "should replace Result.map3 f (Ok a) (Err x) result2 by (Err x)" <|
             \() ->
                 """module A exposing (..)
@@ -19427,6 +19443,24 @@ a = c |> g |> Task.succeed |> Task.map3 f (Task.succeed a) (Task.succeed b)
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
 a = (c |> g) |> f a b |> Task.succeed
+"""
+                        ]
+        , test "should replace Task.map3 f (Task.succeed a) (Task.succeed b) <| Task.succeed <| g <| c by Task.succeed <| f a b <| (g <| c)" <|
+            \() ->
+                """module A exposing (..)
+import Task
+a = Task.map3 f (Task.succeed a) (Task.succeed b) <| Task.succeed <| g <| c
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Task.map3 where each task is a succeeding task will result in Task.succeed on the values inside"
+                            , details = [ "You can replace this call by Task.succeed with the function applied to the values inside each succeeding task." ]
+                            , under = "Task.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Task
+a = Task.succeed <| f a b <| (g <| c)
 """
                         ]
         , test "should replace Task.map3 f (Task.succeed a) (Task.fail x) task2 by (Task.fail x)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6400,7 +6400,7 @@ stringFromListTests =
             \() ->
                 """module A exposing (..)
 a = String.fromList
-b = String.fromList str
+b = String.fromList list
 c = String.fromList << f << String.toList
 d = (String.fromList << f) << String.toList
 e = String.fromList << (f << String.toList)
@@ -6423,10 +6423,10 @@ a = String.fromList []
 a = ""
 """
                         ]
-        , test "should replace String.fromList [ a ] by String.fromChar a" <|
+        , test "should replace String.fromList [ char ] by String.fromChar char" <|
             \() ->
                 """module A exposing (..)
-a = String.fromList [ a ]
+a = String.fromList [ char ]
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -6436,7 +6436,7 @@ a = String.fromList [ a ]
                             , under = "String.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = String.fromChar a
+a = String.fromChar char
 """
                         ]
         , test "should replace String.fromList [ f a ] by String.fromChar (f a)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6278,6 +6278,22 @@ e = String.toList << (f << String.fromList)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+        , test "should replace x |> f |> String.fromList |> String.toList by (x |> f)" <|
+            \() ->
+                """module A exposing (..)
+a = x |> f |> String.fromList |> String.toList
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.fromList and String.toList cancel each other out"
+                            , details = [ "You can replace this call by the argument given to String.fromList." ]
+                            , under = "String.toList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (x |> f)
+"""
+                        ]
         , test "should replace String.toList << String.fromList by identity" <|
             \() ->
                 """module A exposing (..)
@@ -6466,6 +6482,22 @@ a = List.singleton >> String.fromList
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = String.fromChar
+"""
+                        ]
+        , test "should replace x |> f |> String.toList |> String.fromList by (x |> f)" <|
+            \() ->
+                """module A exposing (..)
+a = x |> f |> String.toList |> String.fromList
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.toList and String.fromList cancel each other out"
+                            , details = [ "You can replace this call by the argument given to String.toList." ]
+                            , under = "String.fromList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (x |> f)
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14800,7 +14800,7 @@ a = Maybe.map f (Just x)
 a = Just (f x)
 """
                         ]
-        , test "should replace Maybe.map f <| Just x by Just (f x)" <|
+        , test "should replace Maybe.map f <| Just x by Just <| f <| x" <|
             \() ->
                 """module A exposing (..)
 a = Maybe.map f <| Just x
@@ -14813,7 +14813,7 @@ a = Maybe.map f <| Just x
                             , under = "Maybe.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Just (f <| x)
+a = Just <| f <| x
 """
                         ]
         , test "should replace Just x |> Maybe.map f by x |> f |> Just" <|
@@ -14861,7 +14861,7 @@ a = Maybe.map f <| Just <| x
                             , under = "Maybe.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Just (f <| x)
+a = Just <| f <| x
 """
                         ]
         , test "should replace Maybe.map f << Just by Just << f" <|
@@ -15447,7 +15447,7 @@ a = Result.map f (Ok x)
 a = Ok (f x)
 """
                         ]
-        , test "should replace Result.map f <| Ok x by Ok (f x)" <|
+        , test "should replace Result.map f <| Ok x by Ok <| f <| x" <|
             \() ->
                 """module A exposing (..)
 a = Result.map f <| Ok x
@@ -15460,7 +15460,7 @@ a = Result.map f <| Ok x
                             , under = "Result.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Ok (f <| x)
+a = Ok <| f <| x
 """
                         ]
         , test "should replace Ok x |> Result.map f by x |> f |> Ok" <|
@@ -15508,7 +15508,7 @@ a = Result.map f <| Ok <| x
                             , under = "Result.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Ok (f <| x)
+a = Ok <| f <| x
 """
                         ]
         , test "should replace Result.map f << Ok by Ok << f" <|
@@ -15963,7 +15963,7 @@ a = Result.mapError f (Err x)
 a = Err (f x)
 """
                         ]
-        , test "should replace Result.mapError f <| Err x by Err (f x)" <|
+        , test "should replace Result.mapError f <| Err x by Err <| f <| x" <|
             \() ->
                 """module A exposing (..)
 a = Result.mapError f <| Err x
@@ -15976,7 +15976,7 @@ a = Result.mapError f <| Err x
                             , under = "Result.mapError"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Err (f <| x)
+a = Err <| f <| x
 """
                         ]
         , test "should replace Err x |> Result.mapError f by x |> f |> Err" <|
@@ -16024,7 +16024,7 @@ a = Result.mapError f <| Err <| x
                             , under = "Result.mapError"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Err (f <| x)
+a = Err <| f <| x
 """
                         ]
         , test "should replace Result.mapError f << Err by Err << f" <|
@@ -19297,7 +19297,7 @@ import Task
 a = Task.succeed (f x)
 """
                         ]
-        , test "should replace Task.map f <| Task.succeed x by Task.succeed (f x)" <|
+        , test "should replace Task.map f <| Task.succeed x by Task.succeed <| f <| x" <|
             \() ->
                 """module A exposing (..)
 import Task
@@ -19312,7 +19312,7 @@ a = Task.map f <| Task.succeed x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.succeed (f <| x)
+a = Task.succeed <| f <| x
 """
                         ]
         , test "should replace Task.succeed x |> Task.map f by x |> f |> Task.succeed" <|
@@ -19366,7 +19366,7 @@ a = Task.map f <| Task.succeed <| x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.succeed (f <| x)
+a = Task.succeed <| f <| x
 """
                         ]
         , test "should replace Task.map f << Task.succeed by Task.succeed << f" <|
@@ -19767,7 +19767,7 @@ import Task
 a = Task.fail (f x)
 """
                         ]
-        , test "should replace Task.mapError f <| Task.fail x by Task.fail (f x)" <|
+        , test "should replace Task.mapError f <| Task.fail x by Task.fail <| f <| x" <|
             \() ->
                 """module A exposing (..)
 import Task
@@ -19782,7 +19782,7 @@ a = Task.mapError f <| Task.fail x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.fail (f <| x)
+a = Task.fail <| f <| x
 """
                         ]
         , test "should replace Task.fail x |> Task.mapError f by x |> f |> Task.fail" <|
@@ -19836,7 +19836,7 @@ a = Task.mapError f <| Task.fail <| x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Task
-a = Task.fail (f <| x)
+a = Task.fail <| f <| x
 """
                         ]
         , test "should replace Task.mapError f << Task.fail by Task.fail << f" <|
@@ -21881,7 +21881,7 @@ import Random
 a = Random.constant (f x)
 """
                         ]
-        , test "should replace Random.map f <| Random.constant x by Random.constant (f x)" <|
+        , test "should replace Random.map f <| Random.constant x by Random.constant <| f <| x" <|
             \() ->
                 """module A exposing (..)
 import Random
@@ -21896,7 +21896,7 @@ a = Random.map f <| Random.constant x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Random
-a = Random.constant (f <| x)
+a = Random.constant <| f <| x
 """
                         ]
         , test "should replace Random.constant x |> Random.map f by x |> f |> Random.constant" <|
@@ -21950,7 +21950,7 @@ a = Random.map f <| Random.constant <| x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Random
-a = Random.constant (f <| x)
+a = Random.constant <| f <| x
 """
                         ]
         , test "should replace Random.map f << Random.constant by Random.constant << f" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6278,7 +6278,7 @@ e = String.toList << (f << String.fromList)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should replace x |> f |> String.fromList |> String.toList by (x |> f)" <|
+        , test "should replace x |> f |> String.fromList |> String.toList by x |> f" <|
             \() ->
                 """module A exposing (..)
 a = x |> f |> String.fromList |> String.toList
@@ -6291,7 +6291,7 @@ a = x |> f |> String.fromList |> String.toList
                             , under = "String.toList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (x |> f)
+a = x |> f
 """
                         ]
         , test "should replace String.toList << String.fromList by identity" <|
@@ -6487,7 +6487,7 @@ a = List.singleton >> String.fromList
 a = String.fromChar
 """
                         ]
-        , test "should replace x |> f |> String.toList |> String.fromList by (x |> f)" <|
+        , test "should replace x |> f |> String.toList |> String.fromList by x |> f" <|
             \() ->
                 """module A exposing (..)
 a = x |> f |> String.toList |> String.fromList
@@ -6500,7 +6500,7 @@ a = x |> f |> String.toList |> String.fromList
                             , under = "String.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (x |> f)
+a = x |> f
 """
                         ]
         , test "should replace String.fromList << String.toList by identity" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6326,6 +6326,22 @@ a = String.toList << (String.fromList << f)
 a = (f)
 """
                         ]
+        , test "should replace String.toList << (String.fromList << g << f) by (g << f)" <|
+            \() ->
+                """module A exposing (..)
+a = String.toList << (String.fromList << g << f)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.fromList, then String.toList cancels each other out"
+                            , details = [ "You can remove these two functions." ]
+                            , under = "String.toList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (g << f)
+"""
+                        ]
         , test "should replace String.toList << (f >> String.fromList) by (f)" <|
             \() ->
                 """module A exposing (..)
@@ -6342,6 +6358,22 @@ a = String.toList << (f >> String.fromList)
 a = (f)
 """
                         ]
+        , test "should replace String.toList << (f >> g >> String.fromList) by (f >> g)" <|
+            \() ->
+                """module A exposing (..)
+a = String.toList << (f >> g >> String.fromList)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.fromList, then String.toList cancels each other out"
+                            , details = [ "You can remove these two functions." ]
+                            , under = "String.toList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (f >> g)
+"""
+                        ]
         , test "should replace (f << String.toList) << String.fromList by (f)" <|
             \() ->
                 """module A exposing (..)
@@ -6356,6 +6388,22 @@ a = (f << String.toList) << String.fromList
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (f)
+"""
+                        ]
+        , test "should replace (g << f << String.toList) << String.fromList by (g << f)" <|
+            \() ->
+                """module A exposing (..)
+a = (g << f << String.toList) << String.fromList
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.fromList, then String.toList cancels each other out"
+                            , details = [ "You can remove these two functions." ]
+                            , under = "String.toList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (g << f)
 """
                         ]
         , test "should replace (String.toList >> f) << String.fromList by (f)" <|
@@ -6533,6 +6581,22 @@ a = String.fromList << (String.toList << f)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (f)
+"""
+                        ]
+        , test "should replace String.fromList << (String.toList << g << f) by (g << f)" <|
+            \() ->
+                """module A exposing (..)
+a = String.fromList << (String.toList << g << f)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.toList, then String.fromList cancels each other out"
+                            , details = [ "You can remove these two functions." ]
+                            , under = "String.fromList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (g << f)
 """
                         ]
         , test "should replace String.fromList << (f >> String.toList) by (f)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6374,7 +6374,7 @@ a = String.toList << (f >> g >> String.fromList)
 a = (f >> g)
 """
                         ]
-        , test "should replace (f << String.toList) << String.fromList by (f)" <|
+        , test "should replace (f << String.toList) << String.fromList by f" <|
             \() ->
                 """module A exposing (..)
 a = (f << String.toList) << String.fromList
@@ -6387,7 +6387,7 @@ a = (f << String.toList) << String.fromList
                             , under = "String.toList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (f)
+a = f
 """
                         ]
         , test "should replace (g << f << String.toList) << String.fromList by (g << f)" <|
@@ -6406,7 +6406,7 @@ a = (g << f << String.toList) << String.fromList
 a = (g << f)
 """
                         ]
-        , test "should replace (String.toList >> f) << String.fromList by (f)" <|
+        , test "should replace (String.toList >> f) << String.fromList by f" <|
             \() ->
                 """module A exposing (..)
 a = (String.toList >> f) << String.fromList
@@ -6419,7 +6419,7 @@ a = (String.toList >> f) << String.fromList
                             , under = "String.toList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (f)
+a = f
 """
                         ]
         , test "should replace (String.toList >> f >> g) << String.fromList by (f >> g)" <|
@@ -6615,7 +6615,7 @@ a = String.fromList << (f >> String.toList)
 a = (f)
 """
                         ]
-        , test "should replace (f << String.fromList) << String.toList by (f)" <|
+        , test "should replace (f << String.fromList) << String.toList by f" <|
             \() ->
                 """module A exposing (..)
 a = (f << String.fromList) << String.toList
@@ -6628,10 +6628,10 @@ a = (f << String.fromList) << String.toList
                             , under = "String.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (f)
+a = f
 """
                         ]
-        , test "should replace (String.fromList >> f) << String.toList by (f)" <|
+        , test "should replace (String.fromList >> f) << String.toList by f" <|
             \() ->
                 """module A exposing (..)
 a = (String.fromList >> f) << String.toList
@@ -6644,7 +6644,7 @@ a = (String.fromList >> f) << String.toList
                             , under = "String.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (f)
+a = f
 """
                         ]
         , test "should replace (String.fromList >> f >> g) << String.toList by (f >> g)" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6286,7 +6286,7 @@ a = x |> f |> String.fromList |> String.toList
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.fromList and String.toList cancel each other out"
+                            { message = "String.fromList, then String.toList cancels each other out"
                             , details = [ "You can replace this call by the argument given to String.fromList." ]
                             , under = "String.toList"
                             }
@@ -6302,7 +6302,7 @@ a = String.toList << String.fromList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.fromList and String.toList cancel each other out"
+                            { message = "String.fromList, then String.toList cancels each other out"
                             , details = [ "You can replace this composition by identity." ]
                             , under = "String.toList"
                             }
@@ -6318,7 +6318,7 @@ a = String.toList << (String.fromList << f)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.fromList and String.toList cancel each other out"
+                            { message = "String.fromList, then String.toList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.toList"
                             }
@@ -6334,7 +6334,7 @@ a = String.toList << (f >> String.fromList)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.fromList and String.toList cancel each other out"
+                            { message = "String.fromList, then String.toList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.toList"
                             }
@@ -6350,7 +6350,7 @@ a = (f << String.toList) << String.fromList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.fromList and String.toList cancel each other out"
+                            { message = "String.fromList, then String.toList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.toList"
                             }
@@ -6366,7 +6366,7 @@ a = (String.toList >> f) << String.fromList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.fromList and String.toList cancel each other out"
+                            { message = "String.fromList, then String.toList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.toList"
                             }
@@ -6382,7 +6382,7 @@ a = (String.toList >> f >> g) << String.fromList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.fromList and String.toList cancel each other out"
+                            { message = "String.fromList, then String.toList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.toList"
                             }
@@ -6495,7 +6495,7 @@ a = x |> f |> String.toList |> String.fromList
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.toList and String.fromList cancel each other out"
+                            { message = "String.toList, then String.fromList cancels each other out"
                             , details = [ "You can replace this call by the argument given to String.toList." ]
                             , under = "String.fromList"
                             }
@@ -6511,7 +6511,7 @@ a = String.fromList << String.toList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.toList and String.fromList cancel each other out"
+                            { message = "String.toList, then String.fromList cancels each other out"
                             , details = [ "You can replace this composition by identity." ]
                             , under = "String.fromList"
                             }
@@ -6527,7 +6527,7 @@ a = String.fromList << (String.toList << f)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.toList and String.fromList cancel each other out"
+                            { message = "String.toList, then String.fromList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.fromList"
                             }
@@ -6543,7 +6543,7 @@ a = String.fromList << (f >> String.toList)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.toList and String.fromList cancel each other out"
+                            { message = "String.toList, then String.fromList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.fromList"
                             }
@@ -6559,7 +6559,7 @@ a = (f << String.fromList) << String.toList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.toList and String.fromList cancel each other out"
+                            { message = "String.toList, then String.fromList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.fromList"
                             }
@@ -6575,7 +6575,7 @@ a = (String.fromList >> f) << String.toList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.toList and String.fromList cancel each other out"
+                            { message = "String.toList, then String.fromList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.fromList"
                             }
@@ -6591,7 +6591,7 @@ a = (String.fromList >> f >> g) << String.toList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.toList and String.fromList cancel each other out"
+                            { message = "String.toList, then String.fromList cancels each other out"
                             , details = [ "You can remove these two functions." ]
                             , under = "String.fromList"
                             }


### PR DESCRIPTION
```elm
String.fromList (String.toList str)
--> str

String.toList (String.fromList list)
--> list

-- all below are not in summary
String.toList << String.fromList
--> identity

String.fromList << String.toList
--> identity

String.toList << (String.fromList << f)
--> f

(f << String.toList) << String.fromList
--> f

String.fromList << (String.toList << f)
--> f

(f << String.fromList) << String.toList
--> f
```
and all variations with `<<`/`>>`

Not fully confident that the error messages are easy to understand/read.