### PR TITLE
Add Array.initialize simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The rule now simplifies:
 - `Array.isEmpty Array.empty` to `True`
 - `Array.isEmpty (Array.fromList [ x ])` to `False`
 - `Array.repeat 0 n` to `Array.empty`
+- `Array.initialize 0 f` to `Array.empty`
 - `List.singleton >> String.fromList` to `String.fromChar`
 
 ## [2.1.1] - 2023-09-18

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -729,6 +729,9 @@ Destructuring using case expressions
     Array.repeat 0 x
     --> Array.empty
 
+    Array.initialize 0 f
+    --> Array.empty
+
 
 ### Sets
 
@@ -2457,6 +2460,7 @@ functionCallChecks =
         , ( ( [ "Array" ], "filter" ), emptiableFilterChecks arrayCollection )
         , ( ( [ "Array" ], "isEmpty" ), collectionIsEmptyChecks arrayCollection )
         , ( ( [ "Array" ], "repeat" ), arrayRepeatChecks )
+        , ( ( [ "Array" ], "initialize" ), arrayInitializeChecks )
         , ( ( [ "Set" ], "map" ), emptiableMapChecks setCollection )
         , ( ( [ "Set" ], "filter" ), emptiableFilterChecks setCollection )
         , ( ( [ "Set" ], "remove" ), collectionRemoveChecks setCollection )
@@ -6068,6 +6072,11 @@ listRepeatChecks checkInfo =
 
 arrayRepeatChecks : CheckInfo -> Maybe (Error {})
 arrayRepeatChecks checkInfo =
+    emptiableRepeatChecks arrayCollection checkInfo
+
+
+arrayInitializeChecks : CheckInfo -> Maybe (Error {})
+arrayInitializeChecks checkInfo =
     emptiableRepeatChecks arrayCollection checkInfo
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14297,6 +14297,7 @@ arrayTests =
         , arrayFilterTests
         , arrayIsEmptyTests
         , arrayRepeatTests
+        , arrayInitializeTests
         ]
 
 
@@ -14997,6 +14998,85 @@ a = Array.repeat -5 x
                             { message = "Array.repeat with negative length will always result in Array.empty"
                             , details = [ "You can replace this call by Array.empty." ]
                             , under = "Array.repeat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.empty
+"""
+                        ]
+        ]
+
+
+arrayInitializeTests : Test
+arrayInitializeTests =
+    describe "Array.initialize"
+        [ test "should not report Array.initialize used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.initialize n
+b = Array.initialize 2
+c = Array.initialize n f
+d = Array.initialize 5 f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should not replace Array.initialize n f by f" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.initialize n f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Array.initialize 0 f by Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.initialize 0 f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.initialize with length 0 will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.initialize"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.empty
+"""
+                        ]
+        , test "should replace Array.initialize 0 by always Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.initialize 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.initialize with length 0 will always result in Array.empty"
+                            , details = [ "You can replace this call by always Array.empty." ]
+                            , under = "Array.initialize"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always Array.empty
+"""
+                        ]
+        , test "should replace Array.initialize -5 f by Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.initialize -5 f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.initialize with negative length will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.initialize"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array


### PR DESCRIPTION
Adds simplifications for `Array.initialize` #174

- [x] `Array.initialize 0 f` -> `Array.empty`
- [x] `Array.initialize -1 f` -> `Array.empty`