### PR TITLE
Add Dict.fromList on toList simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -790,6 +790,9 @@ Destructuring using case expressions
     Dict.fromList []
     --> Dict.empty
 
+    Dict.fromList (Dict.toList set)
+    --> dict
+
     Dict.isEmpty Dict.empty
     --> True
 
@@ -2475,7 +2478,7 @@ functionCallChecks =
         , ( ( [ "Set" ], "union" ), collectionUnionChecks setCollection )
         , ( ( [ "Set" ], "insert" ), collectionInsertChecks setCollection )
         , ( ( [ "Dict" ], "isEmpty" ), collectionIsEmptyChecks dictCollection )
-        , ( ( [ "Dict" ], "fromList" ), collectionFromListChecks dictCollection )
+        , ( ( [ "Dict" ], "fromList" ), dictFromListChecks )
         , ( ( [ "Dict" ], "toList" ), emptiableToListChecks dictCollection )
         , ( ( [ "Dict" ], "size" ), collectionSizeChecks dictCollection )
         , ( ( [ "Dict" ], "member" ), collectionMemberChecks dictCollection )
@@ -2581,6 +2584,7 @@ compositionChecks =
     , inversesCompositionCheck { later = ( [ "String" ], "toList" ), earlier = ( [ "String" ], "fromList" ) }
     , inversesCompositionCheck { later = ( [ "String" ], "fromList" ), earlier = ( [ "String" ], "toList" ) }
     , inversesCompositionCheck { later = ( [ "Set" ], "fromList" ), earlier = ( [ "Set" ], "toList" ) }
+    , inversesCompositionCheck { later = ( [ "Dict" ], "fromList" ), earlier = ( [ "Dict" ], "toList" ) }
     , \checkInfo ->
         case
             ( AstHelpers.getValueOrFunctionOrFunctionCall checkInfo.earlier
@@ -6601,6 +6605,15 @@ setFromListChecks checkInfo =
 setFromListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 setFromListCompositionChecks checkInfo =
     wrapperFromListSingletonCompositionChecks setCollection checkInfo
+
+
+dictFromListChecks : CheckInfo -> Maybe (Error {})
+dictFromListChecks checkInfo =
+    firstThatConstructsJust
+        [ \() -> collectionFromListChecks dictCollection checkInfo
+        , \() -> onCallToInverseReturnsItsArgumentCheck ( [ "Dict" ], "toList" ) checkInfo
+        ]
+        ()
 
 
 subAndCmdBatchChecks :

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -790,7 +790,7 @@ Destructuring using case expressions
     Dict.fromList []
     --> Dict.empty
 
-    Dict.fromList (Dict.toList set)
+    Dict.fromList (Dict.toList dict)
     --> dict
 
     Dict.isEmpty Dict.empty

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -741,6 +741,9 @@ Destructuring using case expressions
     Set.fromList [ a ]
     --> Set.singleton a
 
+    Set.fromList (Set.toList set)
+    --> set
+
     Set.map f Set.empty -- same for Set.filter, Set.remove...
     --> Set.empty
 


### PR DESCRIPTION
With this, #184 is complete.
```elm
Dict.fromList (Dict.toList dict)
--> dict
```
including composition checks.

Bonus: Adding #186 to summary