### PR TITLE
Add irrelevantEmptyElementInGivenListArgCheck to listFilterMapChecks

### DIFF
--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -18819,6 +18819,7 @@ a = Dict.empty
         , test "should replace x |> f |> Dict.toList |> Dict.fromList by x |> f" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = x |> f |> Dict.toList |> Dict.fromList
 """
                     |> Review.Test.run (rule defaults)
@@ -18829,12 +18830,14 @@ a = x |> f |> Dict.toList |> Dict.fromList
                             , under = "Dict.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = x |> f
 """
                         ]
         , test "should replace Dict.fromList << Dict.toList by identity" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.fromList << Dict.toList
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18845,12 +18848,14 @@ a = Dict.fromList << Dict.toList
                             , under = "Dict.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = identity
 """
                         ]
         , test "should replace Dict.fromList << (Dict.toList << f) by (f)" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.fromList << (Dict.toList << f)
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18861,12 +18866,14 @@ a = Dict.fromList << (Dict.toList << f)
                             , under = "Dict.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = (f)
 """
                         ]
         , test "should replace Dict.fromList << (Dict.toList << g << f) by (g << f)" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.fromList << (Dict.toList << g << f)
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18877,12 +18884,14 @@ a = Dict.fromList << (Dict.toList << g << f)
                             , under = "Dict.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = (g << f)
 """
                         ]
         , test "should replace Dict.fromList << (f >> Dict.toList) by (f)" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.fromList << (f >> Dict.toList)
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18893,12 +18902,14 @@ a = Dict.fromList << (f >> Dict.toList)
                             , under = "Dict.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = (f)
 """
                         ]
         , test "should replace (f << Dict.fromList) << Dict.toList by f" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = (f << Dict.fromList) << Dict.toList
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18909,12 +18920,14 @@ a = (f << Dict.fromList) << Dict.toList
                             , under = "Dict.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = f
 """
                         ]
         , test "should replace (Dict.fromList >> f) << Dict.toList by f" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = (Dict.fromList >> f) << Dict.toList
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18925,12 +18938,14 @@ a = (Dict.fromList >> f) << Dict.toList
                             , under = "Dict.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = f
 """
                         ]
         , test "should replace (Dict.fromList >> f >> g) << Dict.toList by (f >> g)" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = (Dict.fromList >> f >> g) << Dict.toList
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18941,6 +18956,7 @@ a = (Dict.fromList >> f >> g) << Dict.toList
                             , under = "Dict.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = (f >> g)
 """
                         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -9577,6 +9577,22 @@ a = List.map f >> List.filterMap identity
 a = List.filterMap f
 """
                         ]
+        , test "should replace List.filterMap identity [ a, Nothing, b ] by List.filterMap identity [ a, b ]" <|
+            \() ->
+                """module A exposing (..)
+a = List.filterMap identity [ a, Nothing, b ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.filterMap on a list containing an irrelevant Nothing"
+                            , details = [ "Including Nothing in the list does not change the result of this call. You can remove the Nothing element." ]
+                            , under = "Nothing"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.filterMap identity [ a, b ]
+"""
+                        ]
         , test "should replace List.filterMap identity << List.map f by List.filterMap f" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -19647,7 +19647,7 @@ a = Cmd.batch [ b ]
 a = b
 """
                         ]
-        , test "should replace Cmd.batch [ b, Cmd.none ] by Cmd.batch []" <|
+        , test "should replace Cmd.batch [ b, Cmd.none ] by Cmd.batch [ b ]" <|
             \() ->
                 """module A exposing (..)
 a = Cmd.batch [ b, Cmd.none ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -17982,6 +17982,7 @@ a = Set.singleton
         , test "should replace x |> f |> Set.toList |> Set.fromList by x |> f" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = x |> f |> Set.toList |> Set.fromList
 """
                     |> Review.Test.run (rule defaults)
@@ -17992,12 +17993,14 @@ a = x |> f |> Set.toList |> Set.fromList
                             , under = "Set.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = x |> f
 """
                         ]
         , test "should replace Set.fromList << Set.toList by identity" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = Set.fromList << Set.toList
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18008,12 +18011,14 @@ a = Set.fromList << Set.toList
                             , under = "Set.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = identity
 """
                         ]
         , test "should replace Set.fromList << (Set.toList << f) by (f)" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = Set.fromList << (Set.toList << f)
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18024,12 +18029,14 @@ a = Set.fromList << (Set.toList << f)
                             , under = "Set.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = (f)
 """
                         ]
         , test "should replace Set.fromList << (Set.toList << g << f) by (g << f)" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = Set.fromList << (Set.toList << g << f)
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18040,12 +18047,14 @@ a = Set.fromList << (Set.toList << g << f)
                             , under = "Set.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = (g << f)
 """
                         ]
         , test "should replace Set.fromList << (f >> Set.toList) by (f)" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = Set.fromList << (f >> Set.toList)
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18056,12 +18065,14 @@ a = Set.fromList << (f >> Set.toList)
                             , under = "Set.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = (f)
 """
                         ]
         , test "should replace (f << Set.fromList) << Set.toList by f" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = (f << Set.fromList) << Set.toList
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18072,12 +18083,14 @@ a = (f << Set.fromList) << Set.toList
                             , under = "Set.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = f
 """
                         ]
         , test "should replace (Set.fromList >> f) << Set.toList by f" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = (Set.fromList >> f) << Set.toList
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18088,12 +18101,14 @@ a = (Set.fromList >> f) << Set.toList
                             , under = "Set.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = f
 """
                         ]
         , test "should replace (Set.fromList >> f >> g) << Set.toList by (f >> g)" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = (Set.fromList >> f >> g) << Set.toList
 """
                     |> Review.Test.run ruleWithDefaults
@@ -18104,6 +18119,7 @@ a = (Set.fromList >> f >> g) << Set.toList
                             , under = "Set.fromList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = (f >> g)
 """
                         ]


### PR DESCRIPTION
Part of #188 
```elm
List.filterMap identity [ a, Nothing, b ]
--> List.filterMap identity [ a, b ]
```
Bonus:
- Added Set and Dict imports
- Corrected name of a Cmd.batch test