### PR TITLE
Add Array.length simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The rule now simplifies:
 - `Array.length (Array.fromList [ a, b, c ])` to `3`
 - `Array.length (Array.repeat 3 x)` to `3`
 - `Array.length (Array.initialize 3 f)` to `3`
+- `Array.length (Array.repeat n x)` to `max 0 n`
+- `Array.length (Array.initialize n f)` to `max 0 n`
 - `List.singleton >> String.fromList` to `String.fromChar`
 
 ## [2.1.1] - 2023-09-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The rule now simplifies:
 - `Array.isEmpty (Array.fromList [ x ])` to `False`
 - `Array.repeat 0 n` to `Array.empty`
 - `Array.initialize 0 f` to `Array.empty`
+- `Array.length Array.empty` to `0`
+- `Array.length (Array.fromList [ a, b, c ])` to `3`
+- `Array.length (Array.repeat 3 x)` to `3`
+- `Array.length (Array.initialize 3 f)` to `3`
 - `List.singleton >> String.fromList` to `String.fromChar`
 
 ## [2.1.1] - 2023-09-18

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -744,6 +744,18 @@ Destructuring using case expressions
     Array.initialize 0 f
     --> Array.empty
 
+    Array.length Array.empty
+    --> 0
+
+    Array.length (Array.fromList [ a, b, c ])
+    --> 3
+
+    Array.length (Array.repeat 3 x)
+    --> 3
+
+    Array.length (Array.initialize 3 f)
+    --> 3
+
 
 ### Sets
 
@@ -2479,6 +2491,7 @@ functionCallChecks =
         , ( ( [ "Array" ], "indexedMap" ), arrayIndexedMapChecks )
         , ( ( [ "Array" ], "filter" ), emptiableFilterChecks arrayCollection )
         , ( ( [ "Array" ], "isEmpty" ), collectionIsEmptyChecks arrayCollection )
+        , ( ( [ "Array" ], "length" ), collectionSizeChecks arrayCollection )
         , ( ( [ "Array" ], "repeat" ), arrayRepeatChecks )
         , ( ( [ "Array" ], "initialize" ), arrayInitializeChecks )
         , ( ( [ "Set" ], "map" ), emptiableMapChecks setCollection )
@@ -7726,7 +7739,7 @@ arrayDetermineSize resources expressionNode =
             case AstHelpers.getSpecificFunctionCall ( [ "Array" ], "repeat" ) resources.lookupTable expressionNode of
                 Just repeatCall ->
                     Evaluate.getInt resources repeatCall.firstArg
-                        |> Maybe.map Exactly
+                        |> Maybe.map (\n -> Exactly (Basics.max n 0))
 
                 Nothing ->
                     Nothing
@@ -7734,7 +7747,7 @@ arrayDetermineSize resources expressionNode =
             case AstHelpers.getSpecificFunctionCall ( [ "Array" ], "initialize" ) resources.lookupTable expressionNode of
                 Just repeatCall ->
                     Evaluate.getInt resources repeatCall.firstArg
-                        |> Maybe.map Exactly
+                        |> Maybe.map (\n -> Exactly (Basics.max n 0))
 
                 Nothing ->
                     Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7739,7 +7739,7 @@ arrayDetermineSize resources expressionNode =
             case AstHelpers.getSpecificFunctionCall ( [ "Array" ], "repeat" ) resources.lookupTable expressionNode of
                 Just repeatCall ->
                     Evaluate.getInt resources repeatCall.firstArg
-                        |> Maybe.map (\n -> Exactly (Basics.max n 0))
+                        |> Maybe.andThen ignoreCollectionSizeIfEmpty
 
                 Nothing ->
                     Nothing
@@ -7747,12 +7747,21 @@ arrayDetermineSize resources expressionNode =
             case AstHelpers.getSpecificFunctionCall ( [ "Array" ], "initialize" ) resources.lookupTable expressionNode of
                 Just repeatCall ->
                     Evaluate.getInt resources repeatCall.firstArg
-                        |> Maybe.map (\n -> Exactly (Basics.max n 0))
+                        |> Maybe.andThen ignoreCollectionSizeIfEmpty
 
                 Nothing ->
                     Nothing
         ]
         ()
+
+
+ignoreCollectionSizeIfEmpty : Int -> Maybe CollectionSize
+ignoreCollectionSizeIfEmpty n =
+    if n <= 0 then
+        Nothing
+
+    else
+        Just (Exactly n)
 
 
 setCollection : CollectionProperties (WrapperProperties {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6226,27 +6226,21 @@ arrayLengthOnArrayRepeatOrInitializeChecks checkInfo =
     in
     case maybeCall of
         Just ( fnName, call ) ->
-            case Evaluate.getInt checkInfo call.firstArg of
-                Just _ ->
-                    -- If size could be determined, then we would already have an error reported for the call to `repeat` or `initialize`.
-                    Nothing
-
-                Nothing ->
-                    let
-                        maxFn : String
-                        maxFn =
-                            qualifiedToString (qualify ( [ "Basics" ], "max" ) defaultQualifyResources)
-                    in
-                    Just
-                        (Rule.errorWithFix
-                            { message = qualifiedToString (qualify checkInfo.fn checkInfo) ++ " on an array created by " ++ qualifiedToString (qualify ( [ "Array" ], fnName ) defaultQualifyResources) ++ " with a given length will result in that length"
-                            , details = [ "You can replace this call by " ++ maxFn ++ " 0 with the given length. " ++ maxFn ++ " 0 makes sure that negative given lengths return 0." ]
-                            }
-                            checkInfo.fnRange
-                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range call.firstArg }
-                                ++ [ Fix.insertAt checkInfo.parentRange.start (qualifiedToString (qualify ( [ "Basics" ], "max" ) checkInfo) ++ " 0 ") ]
-                            )
-                        )
+            let
+                maxFn : String
+                maxFn =
+                    qualifiedToString (qualify ( [ "Basics" ], "max" ) defaultQualifyResources)
+            in
+            Just
+                (Rule.errorWithFix
+                    { message = qualifiedToString (qualify checkInfo.fn checkInfo) ++ " on an array created by " ++ qualifiedToString (qualify ( [ "Array" ], fnName ) defaultQualifyResources) ++ " with a given length will result in that length"
+                    , details = [ "You can replace this call by " ++ maxFn ++ " 0 with the given length. " ++ maxFn ++ " 0 makes sure that negative given lengths return 0." ]
+                    }
+                    checkInfo.fnRange
+                    (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range call.firstArg }
+                        ++ [ Fix.insertAt checkInfo.parentRange.start (qualifiedToString (qualify ( [ "Basics" ], "max" ) checkInfo) ++ " 0 ") ]
+                    )
+                )
 
         Nothing ->
             Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6239,11 +6239,8 @@ arrayLengthOnArrayRepeatOrInitializeChecks checkInfo =
                     in
                     Just
                         (Rule.errorWithFix
-                            { message = "The length of this array is the argument given to " ++ qualifiedToString (qualify ( [ "Array" ], fnName ) defaultQualifyResources)
-                            , details =
-                                [ "This is creating an array of a given size n, to then determine the size."
-                                , "You can replace this expression to " ++ maxFn ++ " 0 n. Calling " ++ maxFn ++ " is to handle the case where n might be negative."
-                                ]
+                            { message = qualifiedToString (qualify checkInfo.fn checkInfo) ++ " on an array created by " ++ qualifiedToString (qualify ( [ "Array" ], fnName ) defaultQualifyResources) ++ " with a given length will result in that length"
+                            , details = [ "You can replace this call by " ++ maxFn ++ " 0 with the given length. " ++ maxFn ++ " 0 makes sure that negative given lengths return 0." ]
                             }
                             checkInfo.fnRange
                             (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range call.firstArg }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15675,6 +15675,134 @@ import Array
 a = 1
 """
                         ]
+        , test "should replace Array.length (Array.repeat n x) by max 0 n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.repeat n x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of this array is the argument given to Array.repeat"
+                            , details =
+                                [ "This is creating an array of a given size n, to then determine the size."
+                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
+                                ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 n
+"""
+                        ]
+        , test "should replace Array.length (Array.repeat n x) by Basics.max 0 n (when max is already in scope)" <|
+            \() ->
+                """module A exposing (..)
+import Array
+max = 1
+a = Array.length (Array.repeat n x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of this array is the argument given to Array.repeat"
+                            , details =
+                                [ "This is creating an array of a given size n, to then determine the size."
+                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
+                                ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+max = 1
+a = Basics.max 0 n
+"""
+                        ]
+        , test "should replace Array.length <| Array.repeat n x by max 0 n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length <| Array.repeat n x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of this array is the argument given to Array.repeat"
+                            , details =
+                                [ "This is creating an array of a given size n, to then determine the size."
+                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
+                                ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 n
+"""
+                        ]
+        , test "should replace Array.length <| Array.repeat n <| x by max 0 n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length <| Array.repeat n <| x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of this array is the argument given to Array.repeat"
+                            , details =
+                                [ "This is creating an array of a given size n, to then determine the size."
+                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
+                                ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 n
+"""
+                        ]
+        , test "should replace Array.repeat n x |> Array.length by max 0 n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.repeat n x |> Array.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of this array is the argument given to Array.repeat"
+                            , details =
+                                [ "This is creating an array of a given size n, to then determine the size."
+                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
+                                ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 n
+"""
+                        ]
+        , test "should replace x |> Array.repeat n |> Array.length by max 0 n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = x |> Array.repeat n |> Array.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of this array is the argument given to Array.repeat"
+                            , details =
+                                [ "This is creating an array of a given size n, to then determine the size."
+                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
+                                ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 n
+"""
+                        ]
         , test "should not replace Array.length (Array.repeat 0 x) by 0 directly" <|
             \() ->
                 """module A exposing (..)
@@ -15763,6 +15891,27 @@ a = Array.length (Array.initialize -1 f)
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
 a = Array.length (Array.empty)
+"""
+                        ]
+        , test "should replace Array.length (Array.initialize n f) by max 0 n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.initialize n f)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of this array is the argument given to Array.initialize"
+                            , details =
+                                [ "This is creating an array of a given size n, to then determine the size."
+                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
+                                ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 n
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15785,7 +15785,7 @@ import Array
 a = max 0 n
 """
                         ]
-        , test "should not replace Array.length (Array.repeat 0 x) by 0 directly" <|
+        , test "should replace Array.length (Array.repeat 0 x) by 0" <|
             \() ->
                 """module A exposing (..)
 import Array
@@ -15802,8 +15802,17 @@ a = Array.length (Array.repeat 0 x)
 import Array
 a = Array.length (Array.empty)
 """
+                        , Review.Test.error
+                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 0
+"""
                         ]
-        , test "should not replace Array.length (Array.repeat -1 x) by 0 directly" <|
+        , test "should replace Array.length (Array.repeat -1 x) by 0" <|
             \() ->
                 """module A exposing (..)
 import Array
@@ -15819,6 +15828,15 @@ a = Array.length (Array.repeat -1 x)
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
 a = Array.length (Array.empty)
+"""
+                        , Review.Test.error
+                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 -1
 """
                         ]
         , test "should replace Array.length (Array.initialize 1 f) by 1" <|
@@ -15839,7 +15857,7 @@ import Array
 a = 1
 """
                         ]
-        , test "should not replace Array.length (Array.initialize 0 f) by 0 directly" <|
+        , test "should replace Array.length (Array.initialize 0 f) by 0" <|
             \() ->
                 """module A exposing (..)
 import Array
@@ -15856,8 +15874,17 @@ a = Array.length (Array.initialize 0 f)
 import Array
 a = Array.length (Array.empty)
 """
+                        , Review.Test.error
+                            { message = "Array.length on an array created by Array.initialize with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 0
+"""
                         ]
-        , test "should not replace Array.length (Array.initialize -1 f) by 0 directly" <|
+        , test "should replace Array.length (Array.initialize -1 f) by 0" <|
             \() ->
                 """module A exposing (..)
 import Array
@@ -15873,6 +15900,15 @@ a = Array.length (Array.initialize -1 f)
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
 a = Array.length (Array.empty)
+"""
+                        , Review.Test.error
+                            { message = "Array.length on an array created by Array.initialize with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = max 0 -1
 """
                         ]
         , test "should replace Array.length (Array.initialize n f) by max 0 n" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15804,12 +15804,12 @@ a = Array.length (Array.empty)
 """
                         , Review.Test.error
                             { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
-                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
+                            , details = [ "You can replace this call by 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
-a = max 0 0
+a = 0
 """
                         ]
         , test "should replace Array.length (Array.repeat -1 x) by 0" <|
@@ -15831,12 +15831,12 @@ a = Array.length (Array.empty)
 """
                         , Review.Test.error
                             { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
-                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
+                            , details = [ "You can replace this call by 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
-a = max 0 -1
+a = 0
 """
                         ]
         , test "should replace Array.length (Array.initialize 1 f) by 1" <|
@@ -15876,12 +15876,12 @@ a = Array.length (Array.empty)
 """
                         , Review.Test.error
                             { message = "Array.length on an array created by Array.initialize with a given length will result in that length"
-                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
+                            , details = [ "You can replace this call by 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
-a = max 0 0
+a = 0
 """
                         ]
         , test "should replace Array.length (Array.initialize -1 f) by 0" <|
@@ -15903,12 +15903,12 @@ a = Array.length (Array.empty)
 """
                         , Review.Test.error
                             { message = "Array.length on an array created by Array.initialize with a given length will result in that length"
-                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
+                            , details = [ "You can replace this call by 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
-a = max 0 -1
+a = 0
 """
                         ]
         , test "should replace Array.length (Array.initialize n f) by max 0 n" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15803,8 +15803,8 @@ import Array
 a = Array.length (Array.empty)
 """
                         , Review.Test.error
-                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
-                            , details = [ "You can replace this call by 0." ]
+                            { message = "The length of the array is 0"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15830,8 +15830,8 @@ import Array
 a = Array.length (Array.empty)
 """
                         , Review.Test.error
-                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
-                            , details = [ "You can replace this call by 0." ]
+                            { message = "The length of the array is 0"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15875,8 +15875,8 @@ import Array
 a = Array.length (Array.empty)
 """
                         , Review.Test.error
-                            { message = "Array.length on an array created by Array.initialize with a given length will result in that length"
-                            , details = [ "You can replace this call by 0." ]
+                            { message = "The length of the array is 0"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15902,8 +15902,8 @@ import Array
 a = Array.length (Array.empty)
 """
                         , Review.Test.error
-                            { message = "Array.length on an array created by Array.initialize with a given length will result in that length"
-                            , details = [ "You can replace this call by 0." ]
+                            { message = "The length of the array is 0"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15675,7 +15675,7 @@ import Array
 a = 1
 """
                         ]
-        , test "should replace Array.length (Array.repeat 0 x) by 0" <|
+        , test "should not replace Array.length (Array.repeat 0 x) by 0 directly" <|
             \() ->
                 """module A exposing (..)
 import Array
@@ -15684,15 +15684,6 @@ a = Array.length (Array.repeat 0 x)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of the array is 0"
-                            , details = [ "The length of the array can be determined by looking at the code." ]
-                            , under = "Array.length"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-import Array
-a = 0
-"""
-                        , Review.Test.error
                             { message = "Array.repeat with length 0 will always result in Array.empty"
                             , details = [ "You can replace this call by Array.empty." ]
                             , under = "Array.repeat"
@@ -15702,7 +15693,7 @@ import Array
 a = Array.length (Array.empty)
 """
                         ]
-        , test "should replace Array.length (Array.repeat -1 x) by 0" <|
+        , test "should not replace Array.length (Array.repeat -1 x) by 0 directly" <|
             \() ->
                 """module A exposing (..)
 import Array
@@ -15711,15 +15702,6 @@ a = Array.length (Array.repeat -1 x)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of the array is 0"
-                            , details = [ "The length of the array can be determined by looking at the code." ]
-                            , under = "Array.length"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-import Array
-a = 0
-"""
-                        , Review.Test.error
                             { message = "Array.repeat with negative length will always result in Array.empty"
                             , details = [ "You can replace this call by Array.empty." ]
                             , under = "Array.repeat"

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14316,6 +14316,7 @@ arrayTests =
         , arrayIsEmptyTests
         , arrayRepeatTests
         , arrayInitializeTests
+        , arrayLengthTests
         ]
 
 
@@ -15585,6 +15586,201 @@ a = Array.initialize -5 f
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
 a = Array.empty
+"""
+                        ]
+        ]
+
+
+arrayLengthTests : Test
+arrayLengthTests =
+    describe "Array.length"
+        [ test "should not report Array.length used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length
+b = Array.length array
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Array.length Array.empty by 0" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length Array.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the array is 0"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = 0
+"""
+                        ]
+        , test "should replace Array.length (Array.fromList [b, c, d]) by 3" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.fromList [b, c, d])
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the array is 3"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = 3
+"""
+                        ]
+        , test "should replace Array.empty |> Array.length by 0" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.empty |> Array.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the array is 0"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = 0
+"""
+                        ]
+        , test "should replace Array.length (Array.repeat 1 x) by 1" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.repeat 1 x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the array is 1"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = 1
+"""
+                        ]
+        , test "should replace Array.length (Array.repeat 0 x) by 0" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.repeat 0 x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the array is 0"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = 0
+"""
+                        , Review.Test.error
+                            { message = "Array.repeat with length 0 will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.repeat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.length (Array.empty)
+"""
+                        ]
+        , test "should replace Array.length (Array.repeat -1 x) by 0" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.repeat -1 x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the array is 0"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = 0
+"""
+                        , Review.Test.error
+                            { message = "Array.repeat with negative length will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.repeat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.length (Array.empty)
+"""
+                        ]
+        , test "should replace Array.length (Array.initialize 1 f) by 1" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.initialize 1 f)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The length of the array is 1"
+                            , details = [ "The length of the array can be determined by looking at the code." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = 1
+"""
+                        ]
+        , test "should not replace Array.length (Array.initialize 0 f) by 0 directly" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.initialize 0 f)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.initialize with length 0 will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.initialize"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.length (Array.empty)
+"""
+                        ]
+        , test "should not replace Array.length (Array.initialize -1 f) by 0 directly" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.length (Array.initialize -1 f)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.initialize with negative length will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.initialize"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.length (Array.empty)
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15684,11 +15684,8 @@ a = Array.length (Array.repeat n x)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of this array is the argument given to Array.repeat"
-                            , details =
-                                [ "This is creating an array of a given size n, to then determine the size."
-                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
-                                ]
+                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15706,11 +15703,8 @@ a = Array.length (Array.repeat n x)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of this array is the argument given to Array.repeat"
-                            , details =
-                                [ "This is creating an array of a given size n, to then determine the size."
-                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
-                                ]
+                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15728,11 +15722,8 @@ a = Array.length <| Array.repeat n x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of this array is the argument given to Array.repeat"
-                            , details =
-                                [ "This is creating an array of a given size n, to then determine the size."
-                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
-                                ]
+                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15749,11 +15740,8 @@ a = Array.length <| Array.repeat n <| x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of this array is the argument given to Array.repeat"
-                            , details =
-                                [ "This is creating an array of a given size n, to then determine the size."
-                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
-                                ]
+                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15770,11 +15758,8 @@ a = Array.repeat n x |> Array.length
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of this array is the argument given to Array.repeat"
-                            , details =
-                                [ "This is creating an array of a given size n, to then determine the size."
-                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
-                                ]
+                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15791,11 +15776,8 @@ a = x |> Array.repeat n |> Array.length
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of this array is the argument given to Array.repeat"
-                            , details =
-                                [ "This is creating an array of a given size n, to then determine the size."
-                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
-                                ]
+                            { message = "Array.length on an array created by Array.repeat with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15902,11 +15884,8 @@ a = Array.length (Array.initialize n f)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "The length of this array is the argument given to Array.initialize"
-                            , details =
-                                [ "This is creating an array of a given size n, to then determine the size."
-                                , "You can replace this expression to max 0 n. Calling max is to handle the case where n might be negative."
-                                ]
+                            { message = "Array.length on an array created by Array.initialize with a given length will result in that length"
+                            , details = [ "You can replace this call by max 0 with the given length. max 0 makes sure that negative given lengths return 0." ]
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)


### PR DESCRIPTION
Adds simplifications for `Array.length` #174

- [x] `Array.length Array.empty` -> `0`
- [x] `Array.length (Array.fromList [ a, b, c ])` -> `3`
- [x] `Array.length (Array.repeat 1 x)` -> `1`
- [x] `Array.length (Array.initialize 1 f)` -> `1`
- [x]  `Array.length (Array.repeat n x)` to `max 0 n`
- [x]  `Array.length (Array.initialize n f)` to `max 0 n`

Can be reviewed commit by commit.