### PR TITLE
Add List.map on singleton simplifications

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5336,12 +5336,7 @@ listMapOnSingletonCheck checkInfo =
                                 , keep = mappingArgRange
                                 }
                                 ++ List.concatMap
-                                    (\wrap ->
-                                        keepOnlyFix
-                                            { parentRange = wrap.nodeRange
-                                            , keep = Node.range wrap.value
-                                            }
-                                    )
+                                    (\wrap -> replaceBySubExpressionFix wrap.nodeRange wrap.value)
                                     wraps
                                 ++ [ Fix.insertAt checkInfo.parentRange.start "[ "
                                    , Fix.insertAt checkInfo.parentRange.end " ]"

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8741,6 +8741,86 @@ a = identity |> List.map
 a = identity
 """
                         ]
+        , test "should replace List.map f [ x ] by [ f x ]" <|
+            \() ->
+                """module A exposing (..)
+a = List.map f [ x ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map on a singleton list will result in a singleton list with the function applied to the value inside"
+                            , details = [ "You can replace this call by a singleton list containing the function directly applied to the value inside the given singleton list." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ f x ]
+"""
+                        ]
+        , test "should replace List.map f (List.singleton x) by [ f x ]" <|
+            \() ->
+                """module A exposing (..)
+a = List.map f (List.singleton x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map on a singleton list will result in a singleton list with the function applied to the value inside"
+                            , details = [ "You can replace this call by a singleton list containing the function directly applied to the value inside the given singleton list." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ f x ]
+"""
+                        ]
+        , test "should replace List.map f <| [ x ] by [ f <| x ]" <|
+            \() ->
+                """module A exposing (..)
+a = List.map f <| [ x ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map on a singleton list will result in a singleton list with the function applied to the value inside"
+                            , details = [ "You can replace this call by a singleton list containing the function directly applied to the value inside the given singleton list." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ f <| x ]
+"""
+                        ]
+        , test "should replace [ x ] |> List.map f by [ x |> f ]" <|
+            \() ->
+                """module A exposing (..)
+a = [ x ] |> List.map f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map on a singleton list will result in a singleton list with the function applied to the value inside"
+                            , details = [ "You can replace this call by a singleton list containing the function directly applied to the value inside the given singleton list." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ x |> f ]
+"""
+                        ]
+        , test "should replace List.map f << List.singleton by List.singleton << f" <|
+            \() ->
+                """module A exposing (..)
+a = List.map f << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map on a singleton list will result in List.singleton with the function applied to the value inside"
+                            , details = [ "You can replace this call by List.singleton with the function directly applied to the value inside the singleton list itself." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.singleton << f
+"""
+                        ]
         , test "should replace Dict.toList >> List.map Tuple.first by Dict.keys" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8773,6 +8773,22 @@ a = List.map f [ g x ]
 a = [ f (g x) ]
 """
                         ]
+        , test "should replace List.map f (if cond then [ x ] else [ y ]) by [ f (if cond then x else y) ]" <|
+            \() ->
+                """module A exposing (..)
+a = List.map f (if cond then [ x ] else [ y ])
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map on a singleton list will result in a singleton list with the function applied to the value inside"
+                            , details = [ "You can replace this call by a singleton list containing the function directly applied to the value inside the given singleton list." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ f (if cond then x else y) ]
+"""
+                        ]
         , test "should replace List.map f (List.singleton x) by [ f x ]" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8757,6 +8757,22 @@ a = List.map f [ x ]
 a = [ f x ]
 """
                         ]
+        , test "should replace List.map f [ g x ] by [ f (g x) ]" <|
+            \() ->
+                """module A exposing (..)
+a = List.map f [ g x ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map on a singleton list will result in a singleton list with the function applied to the value inside"
+                            , details = [ "You can replace this call by a singleton list containing the function directly applied to the value inside the given singleton list." ]
+                            , under = "List.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [ f (g x) ]
+"""
+                        ]
         , test "should replace List.map f (List.singleton x) by [ f x ]" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
The last unimplemented simplification from https://github.com/jfmengels/elm-review-simplify/issues/188
```elm
List.map f [ a ]
--> [ f a ]

-- below are not shown in summary for example
List.map f (if cond then [ x ] else [ y ])
--> [ f (if cond then x else y) ]

List.map f << List.singleton
--> List.singleton << f
```
