### PR TITLE
Add script to display the preview command using elm-review --template

### DIFF
--- a/.github/workflows/display-preview-command.yml
+++ b/.github/workflows/display-preview-command.yml
@@ -1,0 +1,20 @@
+name: Display preview command
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  comment-on-pull:
+    name: Comment On Pull
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: "The branch can be tried out by running:\n\n```elm-review --template " + github.repository + "/preview#" + github.ref_name + "```"
+            });


### PR DESCRIPTION
I'm trying to have an automatic comment showing me the following comment:

---

The branch can be tried out by running:
```
elm-review --template lue-bird/elm-review-simplify/preview#branch-name
```