### PR TITLE
Add Array.append simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The rule now simplifies:
 - `Array.length (Array.initialize 3 f)` to `3`
 - `Array.length (Array.repeat n x)` to `max 0 n`
 - `Array.length (Array.initialize n f)` to `max 0 n`
+- `Array.append Array.empty array` to `array`
+- `Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])` to `Array.fromList [ a, b, c, d ]`
 - `List.singleton >> String.fromList` to `String.fromChar`
 
 ## [2.1.1] - 2023-09-18

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -765,6 +765,12 @@ Destructuring using case expressions
     Array.length (Array.initialize n f)
     --> max 0 n
 
+    Array.append Array.empty array
+    --> array
+
+    Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])
+    --> (Array.fromList [ a, b, c, d ])
+
 
 ### Sets
 
@@ -2503,6 +2509,7 @@ functionCallChecks =
         , ( ( [ "Array" ], "length" ), arrayLengthChecks )
         , ( ( [ "Array" ], "repeat" ), arrayRepeatChecks )
         , ( ( [ "Array" ], "initialize" ), arrayInitializeChecks )
+        , ( ( [ "Array" ], "append" ), collectionAppendChecks arrayCollection )
         , ( ( [ "Set" ], "map" ), emptiableMapChecks setCollection )
         , ( ( [ "Set" ], "filter" ), emptiableFilterChecks setCollection )
         , ( ( [ "Set" ], "remove" ), collectionRemoveChecks setCollection )
@@ -7804,7 +7811,7 @@ stringDetermineLength expression =
             Nothing
 
 
-arrayCollection : CollectionProperties {}
+arrayCollection : CollectionProperties (FromListProperties {})
 arrayCollection =
     { moduleName = [ "Array" ]
     , represents = "array"
@@ -7819,6 +7826,10 @@ arrayCollection =
         }
     , nameForSize = "length"
     , determineSize = arrayDetermineSize
+    , fromListLiteralRange =
+        \lookupTable expr ->
+            AstHelpers.getSpecificFunctionCall ( [ "Array" ], "fromList" ) lookupTable expr
+                |> Maybe.andThen (\{ firstArg } -> AstHelpers.getListLiteralRange firstArg)
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5192,7 +5192,7 @@ collectionAppendChecks collection checkInfo =
                                     Just literalListRangeFirst ->
                                         Just
                                             (Rule.errorWithFix
-                                                { message = "Appending literal " ++ collection.represents ++ "s could be simplified to be a single " ++ collection.represents
+                                                { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on literal " ++ collection.represents ++ "s can be turned into a single literal " ++ collection.represents
                                                 , details = [ "Try moving all the elements into a single " ++ collection.represents ++ "." ]
                                                 }
                                                 checkInfo.fnRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5163,9 +5163,9 @@ collectionAppendChecks collection checkInfo =
             if collection.empty.is checkInfo.lookupTable checkInfo.firstArg then
                 Just
                     (alwaysReturnsLastArgError
-                        (qualifiedToString checkInfo.fn ++ " with " ++ descriptionForIndefinite collection.empty.description ++ " as the first argument")
+                        (qualifiedToString checkInfo.fn ++ " " ++ descriptionForIndefinite collection.empty.description)
                         { lastArg = secondArg checkInfo
-                        , lastArgRepresents = "second " ++ collection.represents ++ " argument"
+                        , lastArgRepresents = collection.represents
                         }
                         checkInfo
                     )
@@ -5177,12 +5177,12 @@ collectionAppendChecks collection checkInfo =
                 Just secondArg_ ->
                     if collection.empty.is checkInfo.lookupTable secondArg_ then
                         Just
-                            (alwaysReturnsLastArgError
-                                (qualifiedToString checkInfo.fn ++ " with " ++ descriptionForIndefinite collection.empty.description ++ " as the second argument")
-                                { lastArg = Just checkInfo.firstArg
-                                , lastArgRepresents = "first " ++ collection.represents ++ " argument"
+                            (Rule.errorWithFix
+                                { message = "Unnecessary " ++ qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " with " ++ descriptionForIndefinite collection.empty.description
+                                , details = [ "You can replace this call by the " ++ collection.represents ++ " itself." ]
                                 }
-                                checkInfo
+                                checkInfo.fnRange
+                                (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg })
                             )
 
                     else

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -5,7 +5,7 @@ module Simplify.AstHelpers exposing
     , isIdentity, getAlwaysResult, isSpecificUnappliedBinaryOperation
     , isTupleFirstAccess, isTupleSecondAccess
     , getOrder, getSpecificBool, getBool, getBoolPattern, getUncomputedNumberValue
-    , getCollapsedCons, getListLiteral, getListSingleton
+    , getCollapsedCons, getListLiteral, getListLiteralRange, getListSingleton
     , getTuple2, getTuple2Literal
     , boolToString, orderToString, emptyStringAsString
     , moduleNameFromString, qualifiedName, qualifiedModuleName, qualifiedToString
@@ -32,7 +32,7 @@ module Simplify.AstHelpers exposing
 @docs isIdentity, getAlwaysResult, isSpecificUnappliedBinaryOperation
 @docs isTupleFirstAccess, isTupleSecondAccess
 @docs getOrder, getSpecificBool, getBool, getBoolPattern, getUncomputedNumberValue
-@docs getCollapsedCons, getListLiteral, getListSingleton
+@docs getCollapsedCons, getListLiteral, getListLiteralRange, getListSingleton
 @docs getTuple2, getTuple2Literal
 
 
@@ -688,6 +688,16 @@ getListLiteral expressionNode =
     case removeParens expressionNode of
         Node _ (Expression.ListExpr list) ->
             Just list
+
+        _ ->
+            Nothing
+
+
+getListLiteralRange : Node Expression -> Maybe Range
+getListLiteralRange expressionNode =
+    case removeParens expressionNode of
+        Node range (Expression.ListExpr _) ->
+            Just range
 
         _ ->
             Nothing

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7313,7 +7313,7 @@ a = List.append [b] [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single List"
+                            { message = "Appending literal lists could be simplified to be a single list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }
@@ -7329,7 +7329,7 @@ a = List.append [ b, z ] [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single List"
+                            { message = "Appending literal lists could be simplified to be a single list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }
@@ -7345,7 +7345,7 @@ a = List.append [b] <| [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single List"
+                            { message = "Appending literal lists could be simplified to be a single list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }
@@ -7361,7 +7361,7 @@ a = [c,d,0] |> List.append [b]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single List"
+                            { message = "Appending literal lists could be simplified to be a single list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }
@@ -7377,7 +7377,7 @@ a = [c,d,0] |> List.append [ b, z ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single List"
+                            { message = "Appending literal lists could be simplified to be a single list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7313,7 +7313,7 @@ a = List.append [b] [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single list"
+                            { message = "List.append on literal lists can be turned into a single literal list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }
@@ -7329,7 +7329,7 @@ a = List.append [ b, z ] [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single list"
+                            { message = "List.append on literal lists can be turned into a single literal list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }
@@ -7345,7 +7345,7 @@ a = List.append [b] <| [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single list"
+                            { message = "List.append on literal lists can be turned into a single literal list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }
@@ -7361,7 +7361,7 @@ a = [c,d,0] |> List.append [b]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single list"
+                            { message = "List.append on literal lists can be turned into a single literal list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }
@@ -7377,7 +7377,7 @@ a = [c,d,0] |> List.append [ b, z ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Appending literal lists could be simplified to be a single list"
+                            { message = "List.append on literal lists can be turned into a single literal list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "List.append"
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7393,8 +7393,8 @@ a = List.append [] list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append with [] as the first argument will always return the same given second list argument"
-                            , details = [ "You can replace this call by the second list argument itself." ]
+                            { message = "List.append [] will always return the same given list"
+                            , details = [ "You can replace this call by the list itself." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7409,8 +7409,8 @@ a = List.append [] <| list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append with [] as the first argument will always return the same given second list argument"
-                            , details = [ "You can replace this call by the second list argument itself." ]
+                            { message = "List.append [] will always return the same given list"
+                            , details = [ "You can replace this call by the list itself." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7425,8 +7425,8 @@ a = list |> List.append []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append with [] as the first argument will always return the same given second list argument"
-                            , details = [ "You can replace this call by the second list argument itself." ]
+                            { message = "List.append [] will always return the same given list"
+                            , details = [ "You can replace this call by the list itself." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7441,7 +7441,7 @@ a = List.append []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append with [] as the first argument will always return the same given second list argument"
+                            { message = "List.append [] will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.append"
                             }
@@ -7457,8 +7457,8 @@ a = List.append list []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append with [] as the second argument will always return the same given first list argument"
-                            , details = [ "You can replace this call by the first list argument itself." ]
+                            { message = "Unnecessary List.append with []"
+                            , details = [ "You can replace this call by the list itself." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7473,8 +7473,8 @@ a = List.append list <| []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append with [] as the second argument will always return the same given first list argument"
-                            , details = [ "You can replace this call by the first list argument itself." ]
+                            { message = "Unnecessary List.append with []"
+                            , details = [ "You can replace this call by the list itself." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7489,8 +7489,8 @@ a = [] |> List.append list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append with [] as the second argument will always return the same given first list argument"
-                            , details = [ "You can replace this call by the first list argument itself." ]
+                            { message = "Unnecessary List.append with []"
+                            , details = [ "You can replace this call by the list itself." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7297,9 +7297,11 @@ listAppendTests =
             \() ->
                 """module A exposing (..)
 a = List.append
-b = List.append [ 1 ]
-c = List.append [ 1 ] ys
-d = List.append xs [ 1 ]
+b = List.append list
+c = List.append [ 1 ]
+d = List.append [ 1 ] list
+e = List.append list [ 1 ]
+f = List.append list1 list2
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -7383,10 +7385,10 @@ a = [c,d,0] |> List.append [ b, z ]
 a = [ b, z ,c,d,0]
 """
                         ]
-        , test "should replace List.append [] ys by ys" <|
+        , test "should replace List.append [] list by list" <|
             \() ->
                 """module A exposing (..)
-a = List.append [] ys
+a = List.append [] list
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -7396,13 +7398,13 @@ a = List.append [] ys
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ys
+a = list
 """
                         ]
-        , test "should replace List.append [] <| ys by ys" <|
+        , test "should replace List.append [] <| list by list" <|
             \() ->
                 """module A exposing (..)
-a = List.append [] <| ys
+a = List.append [] <| list
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -7412,13 +7414,13 @@ a = List.append [] <| ys
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ys
+a = list
 """
                         ]
-        , test "should replace ys |> List.append [] by ys" <|
+        , test "should replace list |> List.append [] by list" <|
             \() ->
                 """module A exposing (..)
-a = ys |> List.append []
+a = list |> List.append []
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -7428,7 +7430,7 @@ a = ys |> List.append []
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = ys
+a = list
 """
                         ]
         , test "should replace List.append [] by identity" <|
@@ -7447,10 +7449,10 @@ a = List.append []
 a = identity
 """
                         ]
-        , test "should replace List.append xs [] by xs" <|
+        , test "should replace List.append list [] by list" <|
             \() ->
                 """module A exposing (..)
-a = List.append xs []
+a = List.append list []
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -7460,13 +7462,13 @@ a = List.append xs []
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = xs
+a = list
 """
                         ]
-        , test "should replace List.append xs <| [] by xs" <|
+        , test "should replace List.append list <| [] by list" <|
             \() ->
                 """module A exposing (..)
-a = List.append xs <| []
+a = List.append list <| []
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -7476,13 +7478,13 @@ a = List.append xs <| []
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = xs
+a = list
 """
                         ]
-        , test "should replace [] |> List.append xs by xs" <|
+        , test "should replace [] |> List.append list by list" <|
             \() ->
                 """module A exposing (..)
-a = [] |> List.append xs
+a = [] |> List.append list
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -7492,7 +7494,7 @@ a = [] |> List.append xs
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = xs
+a = list
 """
                         ]
         ]
@@ -21119,7 +21121,7 @@ taskMapNTests : Test
 taskMapNTests =
     -- testing behavior only with representatives for 2-5
     describe "Task.mapN"
-        [ test "should not report Task.map3 with task.succeeday arguments" <|
+        [ test "should not report Task.map3 with okay arguments" <|
             \() ->
                 """module A exposing (..)
 import Task


### PR DESCRIPTION
Adds Array.append simplifications #174 

- [x] `Array.append Array.empty array` -> `array`
- [x] `Array.append array Array.empty` -> `array`
- [x] `Array.append (Array.fromList [ a, b, c ]) (Array.fromList [ d, e, f ])` -> `Array.fromList [ a, b, c, d, e, f ]`

I extracted `listAppendChecks` into a generic `collectionAppendChecks`. I noticed it got very close to `collectionUnionChecks` and changed the error messages to match `collectionUnionChecks` because they were nicer.

Now `collectionAppendChecks` and `collectionUnionChecks` are pretty much the same check, except that the former tries to combine `append [ a ] [ b ]` into `[ a, b ]`.

I think we can make that work for dict/set as well in a next step, completely fusing the 2 collection checks.
The only difference is that sets and dict need to have the elements added to the end rather than at the beginning, so `union (fromList [ a ]) (fromList [ b ])` into `fromList [ b, a ]`. I'll do that in a follow-up PR.

Can be reviewed commit by commit.