### PR TITLE
Combine literals when using Dict/Set.union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The rule now simplifies:
 - `Array.length (Array.initialize n f)` to `max 0 n`
 - `Array.append Array.empty array` to `array`
 - `Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])` to `Array.fromList [ a, b, c, d ]`
+- `Set.union (Set.fromList [ a, b ]) (Set.fromList [ c, d ])` to `Set.fromList [ a, b, c, d ]`
+- `Dict.union (Dict.fromList [ a, b ]) (Dict.fromList [ c, d ])` to `Dict.fromList [ c, d, a, b ]`
 - `List.singleton >> String.fromList` to `String.fromChar`
 
 ## [2.1.1] - 2023-09-18


### PR DESCRIPTION
Adds simplifications made possible in #199 for `Array.append` for `Dict.union` and `Set.union`.

```elm
Set.union (Set.fromList [ a, b ]) (Set.fromList [ c, d ])
--> Set.fromList [ a, b, c, d ]

-- Note: Order is reversed
Dict.union (Dict.fromList [ a, b ]) (Dict.fromList [ c, d ])
--> Dict.fromList [ a, b, c, d ]
```