### PR TITLE
Add String.append simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The rule now simplifies:
 - `Array.append Array.empty array` to `array`
 - `Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])` to `Array.fromList [ a, b, c, d ]`
 - `String.append String.empty str` to `str`
+- `String.fromList [ a, b ] ++ String.fromList [ c, d ]` to `String.fromList [ a, b, c, d ]`
 - `String.append (String.fromList [ a, b ]) (String.fromList [ c, d ])` to `String.fromList [ a, b, c, d ]`
 - `Set.union (Set.fromList [ a, b ]) (Set.fromList [ c, d ])` to `Set.fromList [ a, b, c, d ]`
 - `Dict.union (Dict.fromList [ a, b ]) (Dict.fromList [ c, d ])` to `Dict.fromList [ c, d, a, b ]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The rule now simplifies:
 - `Array.length (Array.initialize n f)` to `max 0 n`
 - `Array.append Array.empty array` to `array`
 - `Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])` to `Array.fromList [ a, b, c, d ]`
+- `String.append String.empty str` to `str`
+- `String.append (String.fromList [ a, b ]) (String.fromList [ c, d ])` to `String.fromList [ a, b, c, d ]`
 - `Set.union (Set.fromList [ a, b ]) (Set.fromList [ c, d ])` to `Set.fromList [ a, b, c, d ]`
 - `Dict.union (Dict.fromList [ a, b ]) (Dict.fromList [ c, d ])` to `Dict.fromList [ c, d, a, b ]`
 - `List.singleton >> String.fromList` to `String.fromChar`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7416,6 +7416,7 @@ type alias FromListProperties otherProperties =
     TypeProperties
         { otherProperties
             | fromListLiteralRange : ModuleNameLookupTable -> Node Expression -> Maybe Range
+            , fromListLiteralDescription : String
             , literalUnionLeftElementsStayOnTheLeft : Bool
         }
 
@@ -7706,6 +7707,7 @@ listCollection =
         }
     , mapFnName = "map"
     , fromListLiteralRange = \_ expr -> AstHelpers.getListLiteralRange expr
+    , fromListLiteralDescription = "list literal"
     , literalUnionLeftElementsStayOnTheLeft = True
     }
 
@@ -7757,6 +7759,7 @@ stringCollection =
         \lookupTable expr ->
             AstHelpers.getSpecificFunctionCall ( [ "String" ], "fromList" ) lookupTable expr
                 |> Maybe.andThen (\{ firstArg } -> AstHelpers.getListLiteralRange firstArg)
+    , fromListLiteralDescription = "String.fromList call"
     , literalUnionLeftElementsStayOnTheLeft = True
     }
 
@@ -7790,6 +7793,7 @@ arrayCollection =
         \lookupTable expr ->
             AstHelpers.getSpecificFunctionCall ( [ "Array" ], "fromList" ) lookupTable expr
                 |> Maybe.andThen (\call -> AstHelpers.getListLiteralRange call.firstArg)
+    , fromListLiteralDescription = "Array.fromList call"
     , literalUnionLeftElementsStayOnTheLeft = True
     }
 
@@ -7860,6 +7864,7 @@ setCollection =
         \lookupTable expr ->
             AstHelpers.getSpecificFunctionCall ( [ "Set" ], "fromList" ) lookupTable expr
                 |> Maybe.andThen (\{ firstArg } -> AstHelpers.getListLiteralRange firstArg)
+    , fromListLiteralDescription = "Set.fromList call"
     , literalUnionLeftElementsStayOnTheLeft = True
     }
 
@@ -7930,6 +7935,7 @@ dictCollection =
         \lookupTable expr ->
             AstHelpers.getSpecificFunctionCall ( [ "Dict" ], "fromList" ) lookupTable expr
                 |> Maybe.andThen (\{ firstArg } -> AstHelpers.getListLiteralRange firstArg)
+    , fromListLiteralDescription = "Dict.fromList call"
     , literalUnionLeftElementsStayOnTheLeft = False
     }
 
@@ -9000,8 +9006,8 @@ collectionUnionWithLiteralsChecks collection checkInfo =
                 Just literalListRangeFirst ->
                     Just
                         (Rule.errorWithFix
-                            { message = checkInfo.operation ++ " on literal " ++ collection.represents ++ "s can be turned into a single literal " ++ collection.represents
-                            , details = [ "Try moving all the elements into a single " ++ collection.represents ++ "." ]
+                            { message = checkInfo.operation ++ " on " ++ collection.fromListLiteralDescription ++ "s can be turned into a single " ++ collection.fromListLiteralDescription
+                            , details = [ "Try moving all the elements into a single " ++ collection.fromListLiteralDescription ++ "." ]
                             }
                             checkInfo.operationRange
                             (if collection.literalUnionLeftElementsStayOnTheLeft then

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7777,7 +7777,7 @@ arrayCollection =
     , fromListLiteralRange =
         \lookupTable expr ->
             AstHelpers.getSpecificFunctionCall ( [ "Array" ], "fromList" ) lookupTable expr
-                |> Maybe.andThen (\{ firstArg } -> AstHelpers.getListLiteralRange firstArg)
+                |> Maybe.andThen (\call -> AstHelpers.getListLiteralRange call.firstArg)
     , literalUnionLeftElementsStayOnTheLeft = True
     }
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3271,27 +3271,15 @@ plusplusChecks checkInfo =
                 _ ->
                     Nothing
         , \() ->
-            case ( AstHelpers.getListLiteral checkInfo.left, AstHelpers.getListLiteral checkInfo.right ) of
-                ( Just _, Just _ ) ->
-                    Just
-                        (Rule.errorWithFix
-                            { message = "Expression could be simplified to be a single List"
-                            , details = [ "Try moving all the elements into a single list." ]
-                            }
-                            checkInfo.operatorRange
-                            [ Fix.replaceRangeBy
-                                { start = endWithoutBoundary checkInfo.leftRange
-                                , end = startWithoutBoundary checkInfo.rightRange
-                                }
-                                ","
-                            ]
-                        )
-
-                ( Nothing, _ ) ->
-                    Nothing
-
-                ( _, Nothing ) ->
-                    Nothing
+            collectionUnionWithLiteralsChecks listCollection
+                { lookupTable = checkInfo.lookupTable
+                , extractSourceCode = checkInfo.extractSourceCode
+                , parentRange = checkInfo.parentRange
+                , first = checkInfo.left
+                , second = checkInfo.right
+                , operationRange = checkInfo.operatorRange
+                , operation = "++"
+                }
         , \() ->
             collectionUnionWithLiteralsChecks stringCollection
                 { lookupTable = checkInfo.lookupTable

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -296,6 +296,12 @@ Destructuring using case expressions
     String.concat []
     --> ""
 
+    String.append "" str
+    --> str
+
+    String.append (String.fromList [ a, b ]) (String.fromList [ c, d ])
+    --> String.fromList [ a, b, c, d ]
+
     String.join str []
     --> ""
 
@@ -769,7 +775,7 @@ Destructuring using case expressions
     --> array
 
     Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])
-    --> (Array.fromList [ a, b, c, d ])
+    --> Array.fromList [ a, b, c, d ]
 
 
 ### Sets
@@ -2552,6 +2558,7 @@ functionCallChecks =
         , ( ( [ "String" ], "slice" ), stringSliceChecks )
         , ( ( [ "String" ], "left" ), stringLeftChecks )
         , ( ( [ "String" ], "right" ), stringRightChecks )
+        , ( ( [ "String" ], "append" ), collectionUnionChecks stringCollection )
         , ( ( [ "Platform", "Cmd" ], "batch" ), subAndCmdBatchChecks cmdCollection )
         , ( ( [ "Platform", "Cmd" ], "map" ), emptiableMapChecks cmdCollection )
         , ( ( [ "Platform", "Sub" ], "batch" ), subAndCmdBatchChecks subCollection )
@@ -7728,7 +7735,7 @@ listDetermineLength resources expressionNode =
             Nothing
 
 
-stringCollection : CollectionProperties (WrapperProperties {})
+stringCollection : CollectionProperties (WrapperProperties (FromListProperties {}))
 stringCollection =
     { moduleName = [ "String" ]
     , represents = "string"
@@ -7746,6 +7753,11 @@ stringCollection =
             \lookupTable expr ->
                 Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "String" ], "fromChar" ) lookupTable expr)
         }
+    , fromListLiteralRange =
+        \lookupTable expr ->
+            AstHelpers.getSpecificFunctionCall ( [ "String" ], "fromList" ) lookupTable expr
+                |> Maybe.andThen (\{ firstArg } -> AstHelpers.getListLiteralRange firstArg)
+    , literalUnionLeftElementsStayOnTheLeft = True
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2188,6 +2188,7 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                         in
                         checkFn
                             { lookupTable = context.lookupTable
+                            , extractSourceCode = context.extractSourceCode
                             , expectNaN = config.expectNaN
                             , importLookup = context.importLookup
                             , moduleBindings = context.moduleBindings
@@ -2586,6 +2587,7 @@ functionCallChecks =
 
 type alias OperatorCheckInfo =
     { lookupTable : ModuleNameLookupTable
+    , extractSourceCode : Range -> String
     , expectNaN : Bool
     , importLookup : ImportLookup
     , moduleBindings : Set String
@@ -3290,6 +3292,16 @@ plusplusChecks checkInfo =
 
                 ( _, Nothing ) ->
                     Nothing
+        , \() ->
+            collectionUnionWithLiteralsChecks stringCollection
+                { lookupTable = checkInfo.lookupTable
+                , extractSourceCode = checkInfo.extractSourceCode
+                , parentRange = checkInfo.parentRange
+                , first = checkInfo.left
+                , second = checkInfo.right
+                , operationRange = checkInfo.operatorRange
+                , operation = "++"
+                }
         , \() ->
             case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.left of
                 Just leftListSingleton ->

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5615,8 +5615,8 @@ a = [ 1 ] ++ [ 2, 3 ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "++ on literal lists can be turned into a single literal list"
-                            , details = [ "Try moving all the elements into a single list." ]
+                            { message = "++ on list literals can be turned into a single list literal"
+                            , details = [ "Try moving all the elements into a single list literal." ]
                             , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5631,8 +5631,8 @@ a = [ a, 1 ] ++ [ b, 2 ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "++ on literal lists can be turned into a single literal list"
-                            , details = [ "Try moving all the elements into a single list." ]
+                            { message = "++ on list literals can be turned into a single list literal"
+                            , details = [ "Try moving all the elements into a single list literal." ]
                             , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5725,8 +5725,8 @@ a = String.fromList [ b, c ] ++ String.fromList [ d, e ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "++ on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "++ on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6765,8 +6765,8 @@ a = String.append (String.fromList [b,c]) (String.fromList [d,e])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6781,8 +6781,8 @@ a = String.append (String.fromList [ b, z ]) (String.fromList [c,d,0])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6797,8 +6797,8 @@ a = String.append (String.fromList [b, c]) <| String.fromList [d,e]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6813,8 +6813,8 @@ a = String.fromList [d,e] |> String.append (String.fromList [b,c])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6829,8 +6829,8 @@ a = String.fromList [c,d,0] |> String.append (String.fromList [ b, z ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6845,8 +6845,8 @@ a = String.append ([ b, c ] |> String.fromList) (String.fromList [ d, e ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6861,8 +6861,8 @@ a = String.append ([ b, c ] |> String.fromList) (String.fromList <| [ d, e ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6877,8 +6877,8 @@ a = String.append (String.fromList <| [ b, c ]) ([ d, e ] |> String.fromList)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6893,8 +6893,8 @@ a = [ d, e ] |> String.fromList |> String.append (String.fromList <| [ b, c ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.append on literal strings can be turned into a single literal string"
-                            , details = [ "Try moving all the elements into a single string." ]
+                            { message = "String.append on String.fromList calls can be turned into a single String.fromList call"
+                            , details = [ "Try moving all the elements into a single String.fromList call." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7551,8 +7551,8 @@ a = List.append [b] [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append on literal lists can be turned into a single literal list"
-                            , details = [ "Try moving all the elements into a single list." ]
+                            { message = "List.append on list literals can be turned into a single list literal"
+                            , details = [ "Try moving all the elements into a single list literal." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7567,8 +7567,8 @@ a = List.append [ b, z ] [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append on literal lists can be turned into a single literal list"
-                            , details = [ "Try moving all the elements into a single list." ]
+                            { message = "List.append on list literals can be turned into a single list literal"
+                            , details = [ "Try moving all the elements into a single list literal." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7583,8 +7583,8 @@ a = List.append [b] <| [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append on literal lists can be turned into a single literal list"
-                            , details = [ "Try moving all the elements into a single list." ]
+                            { message = "List.append on list literals can be turned into a single list literal"
+                            , details = [ "Try moving all the elements into a single list literal." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7599,8 +7599,8 @@ a = [c,d,0] |> List.append [b]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append on literal lists can be turned into a single literal list"
-                            , details = [ "Try moving all the elements into a single list." ]
+                            { message = "List.append on list literals can be turned into a single list literal"
+                            , details = [ "Try moving all the elements into a single list literal." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7615,8 +7615,8 @@ a = [c,d,0] |> List.append [ b, z ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.append on literal lists can be turned into a single literal list"
-                            , details = [ "Try moving all the elements into a single list." ]
+                            { message = "List.append on list literals can be turned into a single list literal"
+                            , details = [ "Try moving all the elements into a single list literal." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16435,8 +16435,8 @@ a = Array.append (Array.fromList [b]) (Array.fromList [c,d,0])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16453,8 +16453,8 @@ a = Array.append (Array.fromList [ b, z ]) (Array.fromList [c,d,0])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16471,8 +16471,8 @@ a = Array.append (Array.fromList [b]) <| Array.fromList [c,d,0]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16489,8 +16489,8 @@ a = Array.fromList [c,d,0] |> Array.append (Array.fromList [b])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16507,8 +16507,8 @@ a = Array.fromList [c,d,0] |> Array.append (Array.fromList [ b, z ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16525,8 +16525,8 @@ a = Array.append ([ b, c ] |> Array.fromList) (Array.fromList [ d, e ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16543,8 +16543,8 @@ a = Array.append ([ b, c ] |> Array.fromList) (Array.fromList <| [ d, e ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16561,8 +16561,8 @@ a = Array.append (Array.fromList <| [ b, c ]) ([ d, e ] |> Array.fromList)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -16579,8 +16579,8 @@ a = [ d, e ] |> Array.fromList |> Array.append (Array.fromList <| [ b, c ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.append on literal arrays can be turned into a single literal array"
-                            , details = [ "Try moving all the elements into a single array." ]
+                            { message = "Array.append on Array.fromList calls can be turned into a single Array.fromList call"
+                            , details = [ "Try moving all the elements into a single Array.fromList call." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20091,8 +20091,8 @@ a = Set.union (Set.fromList [b,c]) (Set.fromList [d,e])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20109,8 +20109,8 @@ a = Set.union (Set.fromList [ b, z ]) (Set.fromList [c,d,0])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20127,8 +20127,8 @@ a = Set.union (Set.fromList [b, c]) <| Set.fromList [d,e]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20145,8 +20145,8 @@ a = Set.fromList [d,e] |> Set.union (Set.fromList [b,c])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20163,8 +20163,8 @@ a = Set.fromList [c,d,0] |> Set.union (Set.fromList [ b, z ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20181,8 +20181,8 @@ a = Set.union ([ b, c ] |> Set.fromList) (Set.fromList [ d, e ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20199,8 +20199,8 @@ a = Set.union ([ b, c ] |> Set.fromList) (Set.fromList <| [ d, e ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20217,8 +20217,8 @@ a = Set.union (Set.fromList <| [ b, c ]) ([ d, e ] |> Set.fromList)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -20235,8 +20235,8 @@ a = [ d, e ] |> Set.fromList |> Set.union (Set.fromList <| [ b, c ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union on literal sets can be turned into a single literal set"
-                            , details = [ "Try moving all the elements into a single set." ]
+                            { message = "Set.union on Set.fromList calls can be turned into a single Set.fromList call"
+                            , details = [ "Try moving all the elements into a single Set.fromList call." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21256,8 +21256,8 @@ a = Dict.union (Dict.fromList [b,c]) (Dict.fromList [d,e])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21274,8 +21274,8 @@ a = Dict.union (Dict.fromList [ b, c ]) (Dict.fromList [d,e])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21292,8 +21292,8 @@ a = Dict.union (Dict.fromList [b,c]) <| Dict.fromList [d,e]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21310,8 +21310,8 @@ a = Dict.fromList [d,e] |> Dict.union (Dict.fromList [b, c])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21328,8 +21328,8 @@ a = Dict.fromList [b,c] |> Dict.union (Dict.fromList [d,e])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21656,8 +21656,8 @@ a = Dict.union ([ b, c ] |> Dict.fromList) (Dict.fromList [ d, e ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21674,8 +21674,8 @@ a = Dict.union ([ b, c ] |> Dict.fromList) (Dict.fromList <| [ d, e ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21692,8 +21692,8 @@ a = Dict.union (Dict.fromList <| [ b, c ]) ([ d, e ] |> Dict.fromList)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21710,8 +21710,8 @@ a = [ d, e ] |> Dict.fromList |> Dict.union (Dict.fromList <| [ b, c ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union on literal dicts can be turned into a single literal dict"
-                            , details = [ "Try moving all the elements into a single dict." ]
+                            { message = "Dict.union on Dict.fromList calls can be turned into a single Dict.fromList call"
+                            , details = [ "Try moving all the elements into a single Dict.fromList call." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5615,7 +5615,7 @@ a = [ 1 ] ++ [ 2, 3 ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Expression could be simplified to be a single List"
+                            { message = "++ on literal lists can be turned into a single literal list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "++"
                             }
@@ -5631,7 +5631,7 @@ a = [ a, 1 ] ++ [ b, 2 ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Expression could be simplified to be a single List"
+                            { message = "++ on literal lists can be turned into a single literal list"
                             , details = [ "Try moving all the elements into a single list." ]
                             , under = "++"
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5717,6 +5717,22 @@ a = left ++ ([ b ] ++ c)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+        , test "should replace String.fromList [ b, c ] ++ String.fromList [ d, e ] by String.fromList [ b, c , d, e ]" <|
+            \() ->
+                """module A exposing (..)
+a = String.fromList [ b, c ] ++ String.fromList [ d, e ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "++ on literal strings can be turned into a single literal string"
+                            , details = [ "Try moving all the elements into a single string." ]
+                            , under = "++"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.fromList [ b, c , d, e ]
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Same as #199 but for Strings.

I also made
```elm
String.append "" str
--> str

String.append (String.fromList [ a, b ]) (String.fromList [ c, d ])
--> String.fromList [ a, b, c, d ]
```

The same simplification now also works with `++`:

```elm
String.fromList [ a, b ] ++ String.fromList [ c, d ]
--> String.fromList [ a, b, c, d ]
```
and `++` with regular lists now (partially) uses the same check.