### PR TITLE
Add simplifications for Array.get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The rule now simplifies:
 - `Array.append Array.empty array` to `array`
 - `Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])` to `Array.fromList [ a, b, c, d ]`
 - `Array.get n Array.empty` to `Nothing`
+- `Array.get 1 (Array.fromList [ a, b, c ])` to `Just b`
 - `Array.get -1 array` to `Nothing`
 - `String.append String.empty str` to `str`
 - `String.fromList [ a, b ] ++ String.fromList [ c, d ]` to `String.fromList [ a, b, c, d ]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The rule now simplifies:
 - `Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])` to `Array.fromList [ a, b, c, d ]`
 - `Array.get n Array.empty` to `Nothing`
 - `Array.get 1 (Array.fromList [ a, b, c ])` to `Just b`
+- `Array.get 100 (Array.fromList [ a, b, c ])` to `Nothing`
 - `Array.get -1 array` to `Nothing`
 - `String.append String.empty str` to `str`
 - `String.fromList [ a, b ] ++ String.fromList [ c, d ]` to `String.fromList [ a, b, c, d ]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The rule now simplifies:
 - `Array.length (Array.initialize n f)` to `max 0 n`
 - `Array.append Array.empty array` to `array`
 - `Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])` to `Array.fromList [ a, b, c, d ]`
+- `Array.get n Array.empty` to `Nothing`
+- `Array.get -1 array` to `Nothing`
 - `String.append String.empty str` to `str`
 - `String.fromList [ a, b ] ++ String.fromList [ c, d ]` to `String.fromList [ a, b, c, d ]`
 - `String.append (String.fromList [ a, b ]) (String.fromList [ c, d ])` to `String.fromList [ a, b, c, d ]`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -783,6 +783,9 @@ Destructuring using case expressions
     Array.get 1 (Array.fromList [ a, b, c ])
     --> Just b
 
+    Array.get 100 (Array.fromList [ a, b, c ])
+    --> Nothing
+
     Array.get -1 array
     --> Nothing
 
@@ -6312,7 +6315,14 @@ indexAccessChecks collection checkInfo n =
                                     )
 
                             Nothing ->
-                                Nothing
+                                Just
+                                    (Rule.errorWithFix
+                                        { message = qualifiedToString checkInfo.fn ++ " with an index out of bounds of the given " ++ collection.represents ++ " will always return " ++ qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) checkInfo)
+                                        , details = [ "You can replace this call by Nothing." ]
+                                        }
+                                        checkInfo.fnRange
+                                        [ Fix.replaceRangeBy checkInfo.parentRange (qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) checkInfo)) ]
+                                    )
 
                     Nothing ->
                         Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2535,7 +2535,7 @@ functionCallChecks =
         , ( ( [ "Array" ], "repeat" ), arrayRepeatChecks )
         , ( ( [ "Array" ], "initialize" ), arrayInitializeChecks )
         , ( ( [ "Array" ], "append" ), collectionUnionChecks arrayCollection )
-        , ( ( [ "Array" ], "get" ), arrayGetChecks )
+        , ( ( [ "Array" ], "get" ), getChecks arrayCollection )
         , ( ( [ "Set" ], "map" ), emptiableMapChecks setCollection )
         , ( ( [ "Set" ], "filter" ), emptiableFilterChecks setCollection )
         , ( ( [ "Set" ], "remove" ), collectionRemoveChecks setCollection )
@@ -6266,21 +6266,21 @@ arrayLengthOnArrayRepeatOrInitializeChecks checkInfo =
             Nothing
 
 
-arrayGetChecks : CheckInfo -> Maybe (Error {})
-arrayGetChecks checkInfo =
+getChecks : EmptiableProperties (IndexableProperties otherProperties) -> CheckInfo -> Maybe (Error {})
+getChecks collection checkInfo =
     firstThatConstructsJust
         [ \() ->
             case checkInfo.secondArg of
                 Just arg ->
                     callOnEmptyReturnsCheck { on = arg, resultAsString = maybeWithJustAsWrap.empty.asString }
-                        arrayCollection
+                        collection
                         checkInfo
 
                 Nothing ->
                     Nothing
         , \() ->
             Evaluate.getInt checkInfo checkInfo.firstArg
-                |> Maybe.andThen (indexAccessChecks arrayCollection checkInfo)
+                |> Maybe.andThen (indexAccessChecks collection checkInfo)
         ]
         ()
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -777,6 +777,12 @@ Destructuring using case expressions
     Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])
     --> Array.fromList [ a, b, c, d ]
 
+    Array.get n Array.empty
+    --> Nothing
+
+    Array.get -1 array
+    --> Nothing
+
 
 ### Sets
 
@@ -2523,6 +2529,7 @@ functionCallChecks =
         , ( ( [ "Array" ], "repeat" ), arrayRepeatChecks )
         , ( ( [ "Array" ], "initialize" ), arrayInitializeChecks )
         , ( ( [ "Array" ], "append" ), collectionUnionChecks arrayCollection )
+        , ( ( [ "Array" ], "get" ), arrayGetChecks )
         , ( ( [ "Set" ], "map" ), emptiableMapChecks setCollection )
         , ( ( [ "Set" ], "filter" ), emptiableFilterChecks setCollection )
         , ( ( [ "Set" ], "remove" ), collectionRemoveChecks setCollection )
@@ -6251,6 +6258,38 @@ arrayLengthOnArrayRepeatOrInitializeChecks checkInfo =
 
         Nothing ->
             Nothing
+
+
+arrayGetChecks : CheckInfo -> Maybe (Error {})
+arrayGetChecks checkInfo =
+    firstThatConstructsJust
+        [ \() ->
+            case checkInfo.secondArg of
+                Just arg ->
+                    callOnEmptyReturnsCheck { on = arg, resultAsString = maybeWithJustAsWrap.empty.asString }
+                        arrayCollection
+                        checkInfo
+
+                Nothing ->
+                    Nothing
+        , \() ->
+            case Evaluate.getInt checkInfo checkInfo.firstArg of
+                Just 0 ->
+                    Nothing
+
+                Just intValue ->
+                    callWithNonPositiveIntCanBeReplacedByCheck
+                        { int = intValue
+                        , intDescription = "index"
+                        , replacement = maybeWithJustAsWrap.empty.asString
+                        , lastArg = secondArg checkInfo
+                        }
+                        checkInfo
+
+                _ ->
+                    Nothing
+        ]
+        ()
 
 
 emptiableReverseChecks : EmptiableProperties otherProperties -> CheckInfo -> Maybe (Error {})

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -16647,6 +16647,114 @@ import Array
 a = Nothing
 """
                         ]
+        , test "should replace Array.get 1 (Array.fromList [ b, c, d ]) by Just c" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.get 1 (Array.fromList [ b, c, d ])
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The element returned by Array.get is known"
+                            , details = [ "You can replace this call by Just the targeted element." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Just c
+"""
+                        ]
+        , test "should replace Array.get 1 (Array.fromList [ b 0, c 0, d 0 ]) by Just (c 0)" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.get 1 (Array.fromList [ b 0, c 0, d 0 ])
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The element returned by Array.get is known"
+                            , details = [ "You can replace this call by Just the targeted element." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Just (c 0)
+"""
+                        ]
+        , test "should replace Array.fromList [ b, c, d ] |> Array.get 1 |> f by c |> Just |> f" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.fromList [ b, c, d ] |> Array.get 1 |> f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The element returned by Array.get is known"
+                            , details = [ "You can replace this call by Just the targeted element." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = c |> Just |> f
+"""
+                        ]
+        , test "should replace Array.fromList [ b, g <| c, d ] |> Array.get 1 |> f by (g <| c) |> Just |> f" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.fromList [ b, g <| c, d ] |> Array.get 1 |> f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The element returned by Array.get is known"
+                            , details = [ "You can replace this call by Just the targeted element." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = (g <| c) |> Just |> f
+"""
+                        ]
+        , test "should replace f <| Array.get 1 <| Array.fromList [ b, c, d ] by f <| Just <| c" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = f <| Array.get 1 <| Array.fromList [ b, c, d ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The element returned by Array.get is known"
+                            , details = [ "You can replace this call by Just the targeted element." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = f <| Just <| c
+"""
+                        ]
+        , test "should replace f <| Array.get 1 <| Array.fromList [ b, c |> g, d ] by f <| Just <| (c |> g)" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = f <| Array.get 1 <| Array.fromList [ b, c |> g, d ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The element returned by Array.get is known"
+                            , details = [ "You can replace this call by Just the targeted element." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = f <| Just <| (c |> g)
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -16755,6 +16755,24 @@ import Array
 a = f <| Just <| (c |> g)
 """
                         ]
+        , test "should replace Array.get 100 (Array.fromList [ b, c, d ]) by Nothing" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.get 100 (Array.fromList [ b, c, d ])
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.get with an index out of bounds of the given array will always return Nothing"
+                            , details = [ "You can replace this call by Nothing." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Nothing
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14676,6 +14676,7 @@ arrayTests =
         , arrayInitializeTests
         , arrayLengthTests
         , arrayAppendTests
+        , arrayGetTests
         ]
 
 
@@ -16592,6 +16593,58 @@ a = [ d, e ] |> Array.fromList |> Array.append (Array.fromList <| [ b, c ])
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
 a = [ b, c , d, e ] |> Array.fromList
+"""
+                        ]
+        ]
+
+
+arrayGetTests : Test
+arrayGetTests =
+    describe "Array.get"
+        [ test "should not report Array.get with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.get n array
+b = Array.get 0 array
+c = Array.get n (Array.fromList [ 1 ])
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Array.get n Array.empty by Nothing" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.get n Array.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.get on Array.empty will result in Nothing"
+                            , details = [ "You can replace this call by Nothing." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Nothing
+"""
+                        ]
+        , test "should replace Array.get -1 array by Nothing" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.get -1 array
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.get with negative index will always result in Nothing"
+                            , details = [ "You can replace this call by Nothing." ]
+                            , under = "Array.get"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Nothing
 """
                         ]
         ]


### PR DESCRIPTION
Adds the following simplifications:

- [x] `Array.get n Array.empty` -> `Nothing`
- [x] `Array.get -3 array` -> `Nothing`
- [x] `Array.get 2 (Array.fromList [ 1, 2, 3 ])` -> `Just 3`
- [x] `Array.get 200 (Array.fromList [ 1, 2, 3 ])` -> `Nothing`

Can be reviewed commit by commit