### PR TITLE
Limit the number of args to what each check expects

### DIFF
--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -11593,6 +11593,22 @@ a = List.foldr (always identity) x
 a = always x
 """
                         ]
+        , test "should replace List.foldr (always identity) initial data extraData by initial extraArgument" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr (always identity) initial data extraArgument
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.foldr with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by the initial accumulator." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = initial extraArgument
+"""
+                        ]
         , test "should replace List.foldr f x (Set.toList set) by Set.foldl f x set" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
This will help avoid fixes from removing too many arguments which often happens for instance when replacing the entire expression.

I noticed this could be a problem for instance when dealing with `List.foldl f initial [] unexpectedArgument` which we would fix as `initial` instead as of `initial unexpectedArgument` (because the result of the fold function could be a new function).

I'm limiting the number of args each check expects to what the function to check expects.