### PR TITLE
Add record access simplifications for application of record access function

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2005,7 +2005,12 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                     otherApplied ->
                         case AstHelpers.getRecordAccessFunction otherApplied of
                             Just fieldName ->
-                                accessingRecordChecks { parentRange = expressionRange, record = firstArg, fieldRange = Node.range otherApplied, fieldName = fieldName }
+                                accessingRecordChecks
+                                    { parentRange = Range.combine [ Node.range applied, Node.range firstArg ]
+                                    , record = firstArg
+                                    , fieldRange = Node.range otherApplied
+                                    , fieldName = fieldName
+                                    }
                                     |> Maybe.map (\e -> Rule.errorWithFix e.info (Node.range otherApplied) e.fix)
 
                             Nothing ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2247,45 +2247,9 @@ expressionVisitorHelp (Node expressionRange expression) config context =
         -- RECORD ACCESS --
         -------------------
         Expression.RecordAccess record (Node fieldRange fieldName) ->
-            let
-                dotFieldRange : Range
-                dotFieldRange =
-                    { start = (Node.range record).end, end = fieldRange.end }
-
-                maybeErrorInfoAndFix : Maybe ErrorInfoAndFix
-                maybeErrorInfoAndFix =
-                    case Node.value (AstHelpers.removeParens record) of
-                        Expression.RecordExpr setters ->
-                            recordAccessChecks
-                                { nodeRange = expressionRange
-                                , maybeRecordNameRange = Nothing
-                                , fieldName = fieldName
-                                , setters = setters
-                                }
-
-                        Expression.RecordUpdateExpression (Node recordNameRange _) setters ->
-                            recordAccessChecks
-                                { nodeRange = expressionRange
-                                , maybeRecordNameRange = Just recordNameRange
-                                , fieldName = fieldName
-                                , setters = setters
-                                }
-
-                        Expression.LetExpression letIn ->
-                            Just (injectRecordAccessIntoLetExpression dotFieldRange letIn.expression fieldName)
-
-                        Expression.IfBlock _ thenBranch elseBranch ->
-                            distributeFieldAccess "an if/then/else" dotFieldRange [ thenBranch, elseBranch ] fieldName
-
-                        Expression.CaseExpression caseOf ->
-                            distributeFieldAccess "a case/of" dotFieldRange (List.map Tuple.second caseOf.cases) fieldName
-
-                        _ ->
-                            Nothing
-            in
             onlyMaybeError
-                (maybeErrorInfoAndFix
-                    |> Maybe.map (\e -> Rule.errorWithFix e.info dotFieldRange e.fix)
+                (accessingRecordChecks { parentRange = expressionRange, record = record, fieldRange = fieldRange, fieldName = fieldName }
+                    |> Maybe.map (\e -> Rule.errorWithFix e.info { start = (Node.range record).end, end = fieldRange.end } e.fix)
                 )
 
         --------
@@ -9899,6 +9863,43 @@ letKeyWordRange range =
 
 
 -- RECORD ACCESS
+
+
+accessingRecordChecks : { parentRange : Range, fieldName : String, fieldRange : Range, record : Node Expression } -> Maybe ErrorInfoAndFix
+accessingRecordChecks checkInfo =
+    let
+        dotFieldRange : Range
+        dotFieldRange =
+            { start = (Node.range checkInfo.record).end, end = checkInfo.fieldRange.end }
+    in
+    case Node.value (AstHelpers.removeParens checkInfo.record) of
+        Expression.RecordExpr setters ->
+            recordAccessChecks
+                { nodeRange = checkInfo.parentRange
+                , maybeRecordNameRange = Nothing
+                , fieldName = checkInfo.fieldName
+                , setters = setters
+                }
+
+        Expression.RecordUpdateExpression (Node recordNameRange _) setters ->
+            recordAccessChecks
+                { nodeRange = checkInfo.parentRange
+                , maybeRecordNameRange = Just recordNameRange
+                , fieldName = checkInfo.fieldName
+                , setters = setters
+                }
+
+        Expression.LetExpression letIn ->
+            Just (injectRecordAccessIntoLetExpression dotFieldRange letIn.expression checkInfo.fieldName)
+
+        Expression.IfBlock _ thenBranch elseBranch ->
+            distributeFieldAccess "an if/then/else" dotFieldRange [ thenBranch, elseBranch ] checkInfo.fieldName
+
+        Expression.CaseExpression caseOf ->
+            distributeFieldAccess "a case/of" dotFieldRange (List.map Tuple.second caseOf.cases) checkInfo.fieldName
+
+        _ ->
+            Nothing
 
 
 recordAccessChecks :

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9942,7 +9942,7 @@ recordAccessChecks checkInfo =
                             , details = [ "Accessing the field of an unrelated record update can be simplified to just the original field's value" ]
                             }
                         , fix =
-                            [ Fix.replaceRangeBy { start = checkInfo.nodeRange.start, end = recordNameRange.start } ""
+                            [ Fix.removeRange { start = checkInfo.nodeRange.start, end = recordNameRange.start }
                             , Fix.replaceRangeBy { start = recordNameRange.end, end = checkInfo.nodeRange.end } ("." ++ checkInfo.fieldName)
                             ]
                         }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9890,7 +9890,15 @@ accessingRecordChecks checkInfo =
                 }
 
         Expression.LetExpression letIn ->
-            Just (injectRecordAccessIntoLetExpression dotFieldRange letIn.expression checkInfo.fieldName)
+            Just
+                { info =
+                    { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                    , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
+                    }
+                , fix =
+                    Fix.removeRange dotFieldRange
+                        :: replaceSubExpressionByRecordAccessFix checkInfo.fieldName letIn.expression
+                }
 
         Expression.IfBlock _ thenBranch elseBranch ->
             distributeFieldAccess "an if...then...else" dotFieldRange [ thenBranch, elseBranch ] checkInfo.fieldName
@@ -9967,18 +9975,6 @@ distributeFieldAccess kind dotFieldRange branches fieldName =
 
         Nothing ->
             Nothing
-
-
-injectRecordAccessIntoLetExpression : Range -> Node Expression -> String -> ErrorInfoAndFix
-injectRecordAccessIntoLetExpression dotFieldRange letBody fieldName =
-    { info =
-        { message = "Accessing a field outside a let...in will result in accessing it in its result"
-        , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
-        }
-    , fix =
-        Fix.removeRange dotFieldRange
-            :: replaceSubExpressionByRecordAccessFix fieldName letBody
-    }
 
 
 returnsRecordInAllBranches : List (Node Expression) -> Maybe (List (Node Expression))

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9867,11 +9867,6 @@ letKeyWordRange range =
 
 accessingRecordChecks : { parentRange : Range, fieldName : String, fieldRange : Range, record : Node Expression } -> Maybe ErrorInfoAndFix
 accessingRecordChecks checkInfo =
-    let
-        dotFieldRange : Range
-        dotFieldRange =
-            { start = (Node.range checkInfo.record).end, end = checkInfo.fieldRange.end }
-    in
     case Node.value (AstHelpers.removeParens checkInfo.record) of
         Expression.RecordExpr setters ->
             recordAccessChecks
@@ -9896,15 +9891,15 @@ accessingRecordChecks checkInfo =
                     , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                     }
                 , fix =
-                    Fix.removeRange dotFieldRange
-                        :: replaceSubExpressionByRecordAccessFix checkInfo.fieldName letIn.expression
+                    keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.record }
+                        ++ replaceSubExpressionByRecordAccessFix checkInfo.fieldName letIn.expression
                 }
 
         Expression.IfBlock _ thenBranch elseBranch ->
-            distributeFieldAccess "an if...then...else" dotFieldRange [ thenBranch, elseBranch ] checkInfo.fieldName
+            distributeFieldAccess "an if...then...else" [ thenBranch, elseBranch ] checkInfo
 
         Expression.CaseExpression caseOf ->
-            distributeFieldAccess "a case...of" dotFieldRange (List.map Tuple.second caseOf.cases) checkInfo.fieldName
+            distributeFieldAccess "a case...of" (List.map Tuple.second caseOf.cases) checkInfo
 
         _ ->
             Nothing
@@ -9959,8 +9954,8 @@ recordAccessChecks checkInfo =
                     Nothing
 
 
-distributeFieldAccess : String -> Range -> List (Node Expression) -> String -> Maybe ErrorInfoAndFix
-distributeFieldAccess kind dotFieldRange branches fieldName =
+distributeFieldAccess : String -> List (Node Expression) -> { checkInfo | parentRange : Range, record : Node Expression, fieldName : String } -> Maybe ErrorInfoAndFix
+distributeFieldAccess kind branches checkInfo =
     case returnsRecordInAllBranches branches of
         Just records ->
             Just
@@ -9969,8 +9964,8 @@ distributeFieldAccess kind dotFieldRange branches fieldName =
                     , details = [ "You can replace accessing this record outside " ++ kind ++ " by accessing the record inside each branch." ]
                     }
                 , fix =
-                    Fix.removeRange dotFieldRange
-                        :: List.concatMap (\leaf -> replaceSubExpressionByRecordAccessFix fieldName leaf) records
+                    keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.record }
+                        ++ List.concatMap (\leaf -> replaceSubExpressionByRecordAccessFix checkInfo.fieldName leaf) records
                 }
 
         Nothing ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9412,32 +9412,37 @@ recordUpdateChecks recordUpdateRange recordVariable fields =
 
 getUnnecessaryRecordUpdateSetter : String -> Node ( Node String, Node Expression ) -> Maybe { valueAccessRange : Range, setterRange : Range }
 getUnnecessaryRecordUpdateSetter recordVariableName (Node setterRange ( Node _ field, valueNode )) =
-    case getRecordVariableAccess valueNode of
-        Just recordVariableAccess ->
-            if field == recordVariableAccess.field && recordVariableName == recordVariableAccess.recordVariable then
-                Just { setterRange = setterRange, valueAccessRange = recordVariableAccess.range }
+    case getAccessingRecord valueNode of
+        Just accessingRecord ->
+            case accessingRecord.record of
+                Node _ (Expression.FunctionOrValue [] recordVariable) ->
+                    if field == accessingRecord.field && recordVariableName == recordVariable then
+                        Just { setterRange = setterRange, valueAccessRange = accessingRecord.range }
 
-            else
-                Nothing
+                    else
+                        Nothing
+
+                _ ->
+                    Nothing
 
         Nothing ->
             Nothing
 
 
-getRecordVariableAccess : Node Expression -> Maybe { range : Range, recordVariable : String, field : String }
-getRecordVariableAccess expressionNode =
+getAccessingRecord : Node Expression -> Maybe { range : Range, record : Node Expression, field : String }
+getAccessingRecord expressionNode =
     case AstHelpers.removeParens expressionNode of
-        Node valueAccessRange (Expression.RecordAccess (Node _ (Expression.FunctionOrValue [] recordVariable)) (Node _ fieldName)) ->
-            Just { field = fieldName, recordVariable = recordVariable, range = valueAccessRange }
+        Node range (Expression.RecordAccess record (Node _ fieldName)) ->
+            Just { field = fieldName, record = record, range = range }
 
-        Node valueAccessRange (Expression.Application ((Node _ (Expression.RecordAccessFunction fieldName)) :: (Node _ (Expression.FunctionOrValue [] recordVariable)) :: [])) ->
-            Just { field = String.replace "." "" fieldName, recordVariable = recordVariable, range = valueAccessRange }
+        Node range (Expression.Application ((Node _ (Expression.RecordAccessFunction fieldName)) :: record :: [])) ->
+            Just { field = String.replace "." "" fieldName, record = record, range = range }
 
-        Node valueAccessRange (Expression.OperatorApplication "|>" _ (Node _ (Expression.FunctionOrValue [] recordVariable)) (Node _ (Expression.RecordAccessFunction fieldName))) ->
-            Just { field = String.replace "." "" fieldName, recordVariable = recordVariable, range = valueAccessRange }
+        Node range (Expression.OperatorApplication "|>" _ record (Node _ (Expression.RecordAccessFunction fieldName))) ->
+            Just { field = String.replace "." "" fieldName, record = record, range = range }
 
-        Node valueAccessRange (Expression.OperatorApplication "<|" _ (Node _ (Expression.RecordAccessFunction fieldName)) (Node _ (Expression.FunctionOrValue [] recordVariable))) ->
-            Just { field = String.replace "." "" fieldName, recordVariable = recordVariable, range = valueAccessRange }
+        Node range (Expression.OperatorApplication "<|" _ (Node _ (Expression.RecordAccessFunction fieldName)) record) ->
+            Just { field = String.replace "." "" fieldName, record = record, range = range }
 
         _ ->
             Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9869,7 +9869,7 @@ accessingRecordChecks : { parentRange : Range, fieldName : String, fieldRange : 
 accessingRecordChecks checkInfo =
     case Node.value (AstHelpers.removeParens checkInfo.record) of
         Expression.RecordExpr fields ->
-            recordAccessChecks
+            accessingRecordWithKnownFieldsChecks
                 { nodeRange = checkInfo.parentRange
                 , maybeRecordNameRange = Nothing
                 , fieldName = checkInfo.fieldName
@@ -9877,7 +9877,7 @@ accessingRecordChecks checkInfo =
                 }
 
         Expression.RecordUpdateExpression (Node recordNameRange _) setFields ->
-            recordAccessChecks
+            accessingRecordWithKnownFieldsChecks
                 { nodeRange = checkInfo.parentRange
                 , maybeRecordNameRange = Just recordNameRange
                 , fieldName = checkInfo.fieldName
@@ -9905,14 +9905,14 @@ accessingRecordChecks checkInfo =
             Nothing
 
 
-recordAccessChecks :
+accessingRecordWithKnownFieldsChecks :
     { nodeRange : Range
     , maybeRecordNameRange : Maybe Range
     , fieldName : String
     , knownFields : List (Node Expression.RecordSetter)
     }
     -> Maybe ErrorInfoAndFix
-recordAccessChecks checkInfo =
+accessingRecordWithKnownFieldsChecks checkInfo =
     let
         maybeMatchingSetterValue : Maybe (Node Expression)
         maybeMatchingSetterValue =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9412,7 +9412,7 @@ recordUpdateChecks recordUpdateRange recordVariable fields =
 
 getUnnecessaryRecordUpdateSetter : String -> Node ( Node String, Node Expression ) -> Maybe { valueAccessRange : Range, setterRange : Range }
 getUnnecessaryRecordUpdateSetter recordVariableName (Node setterRange ( Node _ field, valueNode )) =
-    case getAccessingRecord valueNode of
+    case AstHelpers.getAccessingRecord valueNode of
         Just accessingRecord ->
             case accessingRecord.record of
                 Node _ (Expression.FunctionOrValue [] recordVariable) ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9868,20 +9868,20 @@ letKeyWordRange range =
 accessingRecordChecks : { parentRange : Range, fieldName : String, fieldRange : Range, record : Node Expression } -> Maybe ErrorInfoAndFix
 accessingRecordChecks checkInfo =
     case Node.value (AstHelpers.removeParens checkInfo.record) of
-        Expression.RecordExpr setters ->
+        Expression.RecordExpr fields ->
             recordAccessChecks
                 { nodeRange = checkInfo.parentRange
                 , maybeRecordNameRange = Nothing
                 , fieldName = checkInfo.fieldName
-                , setters = setters
+                , knownFields = fields
                 }
 
-        Expression.RecordUpdateExpression (Node recordNameRange _) setters ->
+        Expression.RecordUpdateExpression (Node recordNameRange _) setFields ->
             recordAccessChecks
                 { nodeRange = checkInfo.parentRange
                 , maybeRecordNameRange = Just recordNameRange
                 , fieldName = checkInfo.fieldName
-                , setters = setters
+                , knownFields = setFields
                 }
 
         Expression.LetExpression letIn ->
@@ -9909,7 +9909,7 @@ recordAccessChecks :
     { nodeRange : Range
     , maybeRecordNameRange : Maybe Range
     , fieldName : String
-    , setters : List (Node Expression.RecordSetter)
+    , knownFields : List (Node Expression.RecordSetter)
     }
     -> Maybe ErrorInfoAndFix
 recordAccessChecks checkInfo =
@@ -9924,7 +9924,7 @@ recordAccessChecks checkInfo =
                     else
                         Nothing
                 )
-                checkInfo.setters
+                checkInfo.knownFields
     in
     case maybeMatchingSetterValue of
         Just setter ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9893,10 +9893,10 @@ accessingRecordChecks checkInfo =
             Just (injectRecordAccessIntoLetExpression dotFieldRange letIn.expression checkInfo.fieldName)
 
         Expression.IfBlock _ thenBranch elseBranch ->
-            distributeFieldAccess "an if/then/else" dotFieldRange [ thenBranch, elseBranch ] checkInfo.fieldName
+            distributeFieldAccess "an if...then...else" dotFieldRange [ thenBranch, elseBranch ] checkInfo.fieldName
 
         Expression.CaseExpression caseOf ->
-            distributeFieldAccess "a case/of" dotFieldRange (List.map Tuple.second caseOf.cases) checkInfo.fieldName
+            distributeFieldAccess "a case...of" dotFieldRange (List.map Tuple.second caseOf.cases) checkInfo.fieldName
 
         _ ->
             Nothing
@@ -9927,8 +9927,8 @@ recordAccessChecks checkInfo =
         Just setter ->
             Just
                 { info =
-                    { message = "Field access can be simplified"
-                    , details = [ "Accessing the field of a record or record update can be simplified to just that field's value" ]
+                    { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
                     }
                 , fix = replaceBySubExpressionFix checkInfo.nodeRange setter
                 }
@@ -9938,8 +9938,8 @@ recordAccessChecks checkInfo =
                 Just recordNameRange ->
                     Just
                         { info =
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of an unrelated record update can be simplified to just the original field's value" ]
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
                             }
                         , fix =
                             [ Fix.removeRange { start = checkInfo.nodeRange.start, end = recordNameRange.start }
@@ -9957,8 +9957,8 @@ distributeFieldAccess kind dotFieldRange branches fieldName =
         Just records ->
             Just
                 { info =
-                    { message = "Field access can be simplified"
-                    , details = [ "Accessing the field outside " ++ kind ++ " expression can be simplified to access the field inside it" ]
+                    { message = "Accessing a field outside " ++ kind ++ " will result in accessing it in each branch"
+                    , details = [ "You can replace accessing this record outside " ++ kind ++ " by accessing the record inside each branch." ]
                     }
                 , fix =
                     Fix.removeRange dotFieldRange
@@ -9972,8 +9972,8 @@ distributeFieldAccess kind dotFieldRange branches fieldName =
 injectRecordAccessIntoLetExpression : Range -> Node Expression -> String -> ErrorInfoAndFix
 injectRecordAccessIntoLetExpression dotFieldRange letBody fieldName =
     { info =
-        { message = "Field access can be simplified"
-        , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it" ]
+        { message = "Accessing a field outside a let...in will result in accessing it in its result"
+        , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
         }
     , fix =
         Fix.removeRange dotFieldRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9429,25 +9429,6 @@ getUnnecessaryRecordUpdateSetter recordVariableName (Node setterRange ( Node _ f
             Nothing
 
 
-getAccessingRecord : Node Expression -> Maybe { range : Range, record : Node Expression, field : String }
-getAccessingRecord expressionNode =
-    case AstHelpers.removeParens expressionNode of
-        Node range (Expression.RecordAccess record (Node _ fieldName)) ->
-            Just { field = fieldName, record = record, range = range }
-
-        Node range (Expression.Application ((Node _ (Expression.RecordAccessFunction fieldName)) :: record :: [])) ->
-            Just { field = String.replace "." "" fieldName, record = record, range = range }
-
-        Node range (Expression.OperatorApplication "|>" _ record (Node _ (Expression.RecordAccessFunction fieldName))) ->
-            Just { field = String.replace "." "" fieldName, record = record, range = range }
-
-        Node range (Expression.OperatorApplication "<|" _ (Node _ (Expression.RecordAccessFunction fieldName)) record) ->
-            Just { field = String.replace "." "" fieldName, record = record, range = range }
-
-        _ ->
-            Nothing
-
-
 
 -- IF
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5238,6 +5238,86 @@ a = { b | c = 1, d = (b.d) }
 a = { b | c = 1}
 """
                         ]
+        , test "should remove the update record syntax when it assigns the previous value of a field to itself and it is the only assignment (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | d = .d b }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = ".d b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b
+"""
+                        ]
+        , test "should remove the update record syntax when it assigns the previous value of a field to itself and it is the only assignment (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | d = .d <| b }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = ".d <| b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b
+"""
+                        ]
+        , test "should remove the update record syntax when it assigns the previous value of a field to itself and it is the only assignment (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | d = b |> .d }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = "b |> .d"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b
+"""
+                        ]
+        , test "should remove the updates that assigns the previous value of a field to itself (not first and using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | c = 1, d = .d b }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = ".d b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = { b | c = 1}
+"""
+                        ]
+        , test "should remove the updates that assigns the previous value of a field to itself (using parens and access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | c = 1, d = (.d b) }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = ".d b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = { b | c = 1}
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -39,7 +39,7 @@ all =
         , jsonDecodeTests
         , htmlAttributesTests
         , randomTests
-        , recordAccessTests
+        , accessingRecordTests
         , letTests
         , pipelineTests
         ]
@@ -25171,9 +25171,9 @@ a = (always (f x))
 -- Record access
 
 
-recordAccessTests : Test
-recordAccessTests =
-    describe "Simplify.RecordAccess"
+accessingRecordTests : Test
+accessingRecordTests =
+    describe "accessing record"
         [ test "should simplify record accesses for explicit records" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -3997,8 +3997,8 @@ a = True
 """
                         , Review.Test.error
                             { message = "Accessing a field of a record where we know that field's value will return that field's value"
-                    , details = [ "You can replace accessing this record by just that field's value." ]
-                     , under = ".a"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".a"
                             }
                             |> Review.Test.atExactly { start = { row = 2, column = 37 }, end = { row = 2, column = 39 } }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -4006,8 +4006,8 @@ a = ({ a = 1 }).a == (2 - 1)
 """
                         , Review.Test.error
                             { message = "Accessing a field of a record where we know that field's value will return that field's value"
-                    , details = [ "You can replace accessing this record by just that field's value." ]
-                     , under = ".a"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".a"
                             }
                             |> Review.Test.atExactly { start = { row = 2, column = 16 }, end = { row = 2, column = 18 } }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -4039,8 +4039,8 @@ a = ({ a = 1 }).a == ({ a = 1 }).b
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Accessing a field of a record where we know that field's value will return that field's value"
-                        , details = [ "You can replace accessing this record by just that field's value." ]
-                        , under = ".a"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".a"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 1 == ({ a = 1 }).b
@@ -25183,8 +25183,56 @@ a = { b = 3 }.b
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Accessing a field of a record where we know that field's value will return that field's value"
-                    , details = [ "You can replace accessing this record by just that field's value." ]
-                    , under = ".b"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 3
+"""
+                        ]
+        , test "should simplify record accesses for explicit records (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = .b { b = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 3
+"""
+                        ]
+        , test "should simplify record accesses for explicit records (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = .b <| { b = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 3
+"""
+                        ]
+        , test "should simplify record accesses for explicit records (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = { b = 3 } |> .b
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 3
@@ -25199,8 +25247,8 @@ a = { b = f n }.b
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Accessing a field of a record where we know that field's value will return that field's value"
-                    , details = [ "You can replace accessing this record by just that field's value." ]
-                    , under = ".b"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (f n)
@@ -25215,8 +25263,8 @@ a = (({ b = 3 })).b
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Accessing a field of a record where we know that field's value will return that field's value"
-                    , details = [ "You can replace accessing this record by just that field's value." ]
-                    , under = ".b"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 3
@@ -25238,11 +25286,59 @@ a = foo { d | b = f x y }.b
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Accessing a field of a record where we know that field's value will return that field's value"
-                    , details = [ "You can replace accessing this record by just that field's value." ]
-                    , under = ".b"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = foo (f x y)
+"""
+                        ]
+        , test "should simplify record accesses for record updates (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = foo <| .b { d | b = f x y }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = foo <| (f x y)
+"""
+                        ]
+        , test "should simplify record accesses for record updates (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = foo <| .b <| { d | b = f x y }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = foo <| (f x y)
+"""
+                        ]
+        , test "should simplify record accesses for record updates (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = { d | b = f x y } |> .b |> foo
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (f x y) |> foo
 """
                         ]
         , test "should simplify record accesses for record updates in parentheses" <|
@@ -25254,8 +25350,8 @@ a = foo (({ d | b = f x y })).b
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Accessing a field of a record where we know that field's value will return that field's value"
-                    , details = [ "You can replace accessing this record by just that field's value." ]
-                    , under = ".b"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = foo (f x y)
@@ -25265,6 +25361,54 @@ a = foo (f x y)
             \() ->
                 """module A exposing (..)
 a = { d | b = 3 }.c
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
+                            , under = ".c"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = d.c
+"""
+                        ]
+        , test "should simplify record accesses for record updates if it can't find the field (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = .c { d | b = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
+                            , under = ".c"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = d.c
+"""
+                        ]
+        , test "should simplify record accesses for record updates if it can't find the field (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = .c <| { d | b = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
+                            , under = ".c"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = d.c
+"""
+                        ]
+        , test "should simplify record accesses for record updates if it can't find the field (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = { d | b = 3 } |> .c
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -25297,6 +25441,54 @@ a = (let b = c in { e = 3 }.e)
             \() ->
                 """module A exposing (..)
 a = (let b = c in f x).e
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
+                            , under = ".e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (let b = c in (f x).e)
+"""
+                        ]
+        , test "should simplify record accesses for let/in expressions, even if the leaf is not a record expression (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = .e (let b = c in f x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
+                            , under = ".e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (let b = c in (f x).e)
+"""
+                        ]
+        , test "should simplify record accesses for let/in expressions, even if the leaf is not a record expression (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = .e <| let b = c in f x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
+                            , under = ".e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = let b = c in (f x).e
+"""
+                        ]
+        , test "should simplify record accesses for let/in expressions, even if the leaf is not a record expression (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = (let b = c in f x) |> .e
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -25377,6 +25569,54 @@ a = (let b = c in (f x).e.f)
             \() ->
                 """module A exposing (..)
 a = (if x then { f = 3 } else { z | f = 3 }).f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
+                            , under = ".f"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (if x then { f = 3 }.f else { z | f = 3 }.f)
+"""
+                        ]
+        , test "should simplify record accesses for if/then/else expressions (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = .f (if x then { f = 3 } else { z | f = 3 })
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
+                            , under = ".f"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (if x then { f = 3 }.f else { z | f = 3 }.f)
+"""
+                        ]
+        , test "should simplify record accesses for if/then/else expressions (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = .f <| if x then { f = 3 } else { z | f = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
+                            , under = ".f"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = if x then { f = 3 }.f else { z | f = 3 }.f
+"""
+                        ]
+        , test "should simplify record accesses for if/then/else expressions (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = (if x then { f = 3 } else { z | f = 3 }) |> .f
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -3996,18 +3996,18 @@ a = ({ a = 1 }).a == ({ a = 2 - 1 }).a
 a = True
 """
                         , Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value" ]
-                            , under = ".a"
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
+                     , under = ".a"
                             }
                             |> Review.Test.atExactly { start = { row = 2, column = 37 }, end = { row = 2, column = 39 } }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = ({ a = 1 }).a == (2 - 1)
 """
                         , Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value" ]
-                            , under = ".a"
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
+                     , under = ".a"
                             }
                             |> Review.Test.atExactly { start = { row = 2, column = 16 }, end = { row = 2, column = 18 } }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -4038,9 +4038,9 @@ a = ({ a = 1 }).a == ({ a = 1 }).b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value" ]
-                            , under = ".a"
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                        , details = [ "You can replace accessing this record by just that field's value." ]
+                        , under = ".a"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 1 == ({ a = 1 }).b
@@ -25173,12 +25173,6 @@ a = (always (f x))
 
 recordAccessTests : Test
 recordAccessTests =
-    let
-        details : List String
-        details =
-            [ "Accessing the field of a record or record update can be simplified to just that field's value"
-            ]
-    in
     describe "Simplify.RecordAccess"
         [ test "should simplify record accesses for explicit records" <|
             \() ->
@@ -25188,9 +25182,9 @@ a = { b = 3 }.b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = details
-                            , under = ".b"
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
+                    , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 3
@@ -25204,9 +25198,9 @@ a = { b = f n }.b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = details
-                            , under = ".b"
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
+                    , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (f n)
@@ -25220,9 +25214,9 @@ a = (({ b = 3 })).b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = details
-                            , under = ".b"
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
+                    , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 3
@@ -25243,9 +25237,9 @@ a = foo { d | b = f x y }.b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = details
-                            , under = ".b"
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
+                    , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = foo (f x y)
@@ -25259,9 +25253,9 @@ a = foo (({ d | b = f x y })).b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = details
-                            , under = ".b"
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
+                    , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = foo (f x y)
@@ -25275,8 +25269,8 @@ a = { d | b = 3 }.c
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of an unrelated record update can be simplified to just the original field's value" ]
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
                             , under = ".c"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25291,8 +25285,8 @@ a = (let b = c in { e = 3 }).e
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25307,8 +25301,8 @@ a = (let b = c in f x).e
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25323,8 +25317,8 @@ a = (let b = c in x).e
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25339,8 +25333,8 @@ a = (((let b = c in {e = 2}))).e
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25355,8 +25349,8 @@ a = (let b = c in { e = { f = 2 } }).e.f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25371,8 +25365,8 @@ a = (let b = c in (f x).e).f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".f"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25387,8 +25381,8 @@ a = (if x then { f = 3 } else { z | f = 3 }).f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside an if/then/else expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
                             , under = ".f"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25410,8 +25404,8 @@ a = (if x then { f = 3 } else if y then { z | f = 4 } else { z | f = 3 }).f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside an if/then/else expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
                             , under = ".f"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -25428,8 +25422,8 @@ a = (if x then { f = 3 } else if y then {f = 2} else
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside an if/then/else expression can be simplified to access the field inside it" ]
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
                             , under = ".f"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)


### PR DESCRIPTION
Detect applying or piping into `.field` as record access (in the following only showing application) as part of #162 and a few more.
```elm
{ record | field = .field record }
--> record

{ record | field = .field record, other = x }
--> { record | other = x }

.field { field = a }
--> a

.field { record | field = a }
--> a

.field { record | otherField = a }
--> record.field

.field (if c then yay else nay)
--> if c then yay.field else nay.field

.field (let x = y in z)
--> let x = y in z.field
```