### PR TITLE
Add Array.slice simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The rule now simplifies:
 - `Array.length (Array.initialize n f)` to `max 0 n`
 - `Array.append Array.empty array` to `array`
 - `Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])` to `Array.fromList [ a, b, c, d ]`
+- `Array.slice n n array` to `Array.empty`
+- `Array.slice n 0 array` to `Array.empty`
+- `Array.slice a z Array.empty` to `Array.empty`
+- `Array.slice 2 1 array` to `Array.empty`
+- `Array.slice -1 -2 array` to `Array.empty`
 - `Array.get n Array.empty` to `Nothing`
 - `Array.get 1 (Array.fromList [ a, b, c ])` to `Just b`
 - `Array.get 100 (Array.fromList [ a, b, c ])` to `Nothing`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2606,7 +2606,7 @@ functionCallChecks =
         , ( ( [ "String" ], "words" ), ( 1, stringWordsChecks ) )
         , ( ( [ "String" ], "lines" ), ( 1, stringLinesChecks ) )
         , ( ( [ "String" ], "reverse" ), ( 1, stringReverseChecks ) )
-        , ( ( [ "String" ], "slice" ), ( 3, stringSliceChecks ) )
+        , ( ( [ "String" ], "slice" ), ( 3, collectionSliceChecks stringCollection ) )
         , ( ( [ "String" ], "left" ), ( 2, stringLeftChecks ) )
         , ( ( [ "String" ], "right" ), ( 2, stringRightChecks ) )
         , ( ( [ "String" ], "append" ), ( 2, collectionUnionChecks stringCollection ) )
@@ -4541,13 +4541,13 @@ stringReverseCompositionChecks checkInfo =
     compositionAfterWrapIsUnnecessaryCheck stringCollection checkInfo
 
 
-stringSliceChecks : CheckInfo -> Maybe (Error {})
-stringSliceChecks checkInfo =
+collectionSliceChecks : CollectionProperties otherProperties -> CheckInfo -> Maybe (Error {})
+collectionSliceChecks collection checkInfo =
     firstThatConstructsJust
         [ \() ->
             Maybe.andThen
                 (\stringArg ->
-                    callOnEmptyReturnsEmptyCheck stringArg stringCollection checkInfo
+                    callOnEmptyReturnsEmptyCheck stringArg collection checkInfo
                 )
                 (thirdArg checkInfo)
         , \() ->
@@ -4557,8 +4557,8 @@ stringSliceChecks checkInfo =
                         [ \() ->
                             if Normalize.areAllTheSame checkInfo checkInfo.firstArg [ endArg ] then
                                 Just
-                                    (alwaysResultsInUnparenthesizedConstantError "String.slice with equal start and end index"
-                                        { replacement = \_ -> emptyStringAsString, lastArg = thirdArg checkInfo }
+                                    (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with equal start and end index")
+                                        { replacement = collection.empty.asString, lastArg = thirdArg checkInfo }
                                         checkInfo
                                     )
 
@@ -4572,8 +4572,8 @@ stringSliceChecks checkInfo =
                                             case endInt of
                                                 0 ->
                                                     Just
-                                                        (alwaysResultsInUnparenthesizedConstantError "String.slice with end index 0"
-                                                            { replacement = \_ -> emptyStringAsString, lastArg = thirdArg checkInfo }
+                                                        (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with end index 0")
+                                                            { replacement = collection.empty.asString, lastArg = thirdArg checkInfo }
                                                             checkInfo
                                                         )
 
@@ -4585,15 +4585,15 @@ stringSliceChecks checkInfo =
                                                     if startInt > endInt then
                                                         if startInt >= 0 && endInt >= 0 then
                                                             Just
-                                                                (alwaysResultsInUnparenthesizedConstantError "String.slice with a start index greater than the end index"
-                                                                    { replacement = \_ -> emptyStringAsString, lastArg = thirdArg checkInfo }
+                                                                (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with a start index greater than the end index")
+                                                                    { replacement = collection.empty.asString, lastArg = thirdArg checkInfo }
                                                                     checkInfo
                                                                 )
 
                                                         else if startInt <= -1 && endInt <= -1 then
                                                             Just
-                                                                (alwaysResultsInUnparenthesizedConstantError "String.slice with a negative start index closer to the right than the negative end index"
-                                                                    { replacement = \_ -> emptyStringAsString, lastArg = thirdArg checkInfo }
+                                                                (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with a negative start index closer to the right than the negative end index")
+                                                                    { replacement = collection.empty.asString, lastArg = thirdArg checkInfo }
                                                                     checkInfo
                                                                 )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -777,6 +777,21 @@ Destructuring using case expressions
     Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])
     --> Array.fromList [ a, b, c, d ]
 
+    Array.slice n n array
+    --> Array.empty
+
+    Array.slice n 0 array
+    --> Array.empty
+
+    Array.slice a z Array.empty
+    --> Array.empty
+
+    Array.slice 2 1 array
+    --> Array.empty
+
+    Array.slice -1 -2 array
+    --> Array.empty
+
     Array.get n Array.empty
     --> Nothing
 
@@ -2572,6 +2587,7 @@ functionCallChecks =
         , ( ( [ "Array" ], "repeat" ), ( 2, arrayRepeatChecks ) )
         , ( ( [ "Array" ], "initialize" ), ( 2, arrayInitializeChecks ) )
         , ( ( [ "Array" ], "append" ), ( 2, collectionUnionChecks arrayCollection ) )
+        , ( ( [ "Array" ], "slice" ), ( 3, collectionSliceChecks arrayCollection ) )
         , ( ( [ "Array" ], "get" ), ( 2, getChecks arrayCollection ) )
         , ( ( [ "Set" ], "map" ), ( 2, emptiableMapChecks setCollection ) )
         , ( ( [ "Set" ], "filter" ), ( 2, emptiableFilterChecks setCollection ) )


### PR DESCRIPTION
Same simplifications as for `String.slice` but for `Array.slice` (part of #174)