### PR TITLE
Add compose into record access of known field checks

### DIFF
--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -25509,6 +25509,22 @@ a = .d << (\\x -> { b | d = f <| x, c = 1 })
 a = (\\x -> (f <| x))
 """
                         ]
+        , test "should replace constructing record update composition into unrelated field access function by contructing the unchanged record" <|
+            \() ->
+                """module A exposing (..)
+a = .e << (\\x -> { x | b = y })
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
+                            , under = ".e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (\\x -> x.e)
+"""
+                        ]
         , test "should simplify record accesses for let/in expressions" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5197,7 +5197,6 @@ a = { b | d = b.d, c = 1 }
 a = { b | c = 1 }
 """
                         ]
-        
         , test "should remove the update record syntax when it assigns the previous value of a field to itself and it is the only assignment" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
Completes #162 except the parenthesized composition which will be done together with #209 
```elm
.field << (\a -> { field = b, other = other })
--> (\a -> b)

.field << (\a -> { record | field = b, other = other })
--> (\a -> b)

.field << (\a -> { record | otherField = b })
--> (\a -> record.field)
```
Note that your original proposal was
```elm
.field << (\a -> { record | otherField = b })
--> .field << (\a -> record)
```
If you prefer that, I'll change it.