### PR TITLE
Add sort on equivalent sort call simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - composition checks now also detect function pairs across nested compositions like `(here << ...) >> (... << there)`
 - `List.sort (List.sort list)` to `List.sort list`
+- `List.sortBy f (List.sortBy f list)` to `List.sortBy f list`
+- `List.sortWith f (List.sortWith f list)` to `List.sortWith f list`
 
 ## [2.1.2] - 2023-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - composition checks now also detect function pairs across nested compositions like `(here << ...) >> (... << there)`
+- `List.sort (List.sort list)` to `List.sort list`
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2794,6 +2794,8 @@ compositionIntoChecks =
         , ( ( [ "Result" ], "toMaybe" ), resultToMaybeCompositionChecks )
         , ( ( [ "List" ], "reverse" ), listReverseCompositionChecks )
         , ( ( [ "List" ], "sort" ), listSortCompositionChecks )
+        , ( ( [ "List" ], "sortBy" ), listSortByCompositionChecks )
+        , ( ( [ "List" ], "sortWith" ), listSortWithCompositionChecks )
         , ( ( [ "List" ], "map" ), listMapCompositionChecks )
         , ( ( [ "List" ], "filterMap" ), listFilterMapCompositionChecks )
         , ( ( [ "List" ], "intersperse" ), listIntersperseCompositionChecks )
@@ -6585,8 +6587,14 @@ listSortByChecks checkInfo =
                     Nothing
         , \() ->
             operationWithIdentityCanBeReplacedChecks { replacementFn = ( [ "List" ], "sort" ) } checkInfo
+        , \() -> operationDoesNotChangeResultOfOperationCheck checkInfo
         ]
         ()
+
+
+listSortByCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+listSortByCompositionChecks checkInfo =
+    operationDoesNotChangeResultOfOperationCompositionCheck { argCount = 2 } checkInfo
 
 
 listSortWithChecks : CheckInfo -> Maybe (Error {})
@@ -6645,8 +6653,14 @@ listSortWithChecks checkInfo =
 
                 Nothing ->
                     Nothing
+        , \() -> operationDoesNotChangeResultOfOperationCheck checkInfo
         ]
         ()
+
+
+listSortWithCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+listSortWithCompositionChecks checkInfo =
+    operationDoesNotChangeResultOfOperationCompositionCheck { argCount = 2 } checkInfo
 
 
 listTakeChecks : CheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10747,11 +10747,6 @@ listFilledLast ( head, tail ) =
             listFilledLast ( tailHead, tailTail )
 
 
-listFilledToList : ( a, List a ) -> List a
-listFilledToList ( head, tail ) =
-    head :: tail
-
-
 listFilledInit : ( a, List a ) -> List a
 listFilledInit ( head, tail ) =
     case tail of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6471,7 +6471,7 @@ This applies to functions that are equivalent to identity when operating on the 
 Examples of such functions:
 
   - one argument: `Simplify.expectNaN`, `Review.Rule.providesFixesForModuleRule`, `List.sort`, `List.Extra.unique`, [`AVL.Set.clear`](https://package.elm-lang.org/packages/owanturist/elm-avl-dict/2.1.0/AVL-Set#clear)
-  - two arguments: `List.filter f`, `List.take/drop n`, `List.Extra.filterNot f`, `List.Extra.takeWhile/dropWhile(Right) f`, `List.sortBy f`, `List.sortWith f`, `List.Extra.uniqueBy f`
+  - two arguments: `List.filter f`, `List.Extra.filterNot f`, `List.Extra.takeWhile/dropWhile(Right) f`, `List.sortBy f`, `List.sortWith f`, `List.Extra.uniqueBy f`
   - three arguments: `Array.set i new`, `Array.Extra.resizelRepeat l pad`, `List.Extra.setAt i new`
 
 Note that `update` or `setWhere` operations for example _can_ have an effect even after the same operation has already been applied.

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6465,7 +6465,7 @@ listSortCompositionChecks checkInfo =
     operationDoesNotChangeResultOfOperationCompositionCheck { argCount = 1 } checkInfo
 
 
-{-| Condense applying the the same function with equal arguments (except the last one) twice in sequence into one.
+{-| Condense applying the same function with equal arguments (except the last one) twice in sequence into one.
 This applies to functions that are equivalent to identity when operating on the result another such function.
 
 Examples of such functions:

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13079,6 +13079,7 @@ listSortByTests =
                 """module A exposing (..)
 a = List.sortBy fn
 b = List.sortBy fn list
+c = List.sortBy << List.sortBy fn
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -13250,6 +13251,40 @@ a = List.sortBy (\\b -> b) list
 a = List.sort list
 """
                         ]
+        , test "should replace List.sortBy f (List.sortBy f list) by (List.sortBy f list)" <|
+            \() ->
+                """module A exposing (..)
+a = List.sortBy f (List.sortBy f list)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary List.sortBy after equivalent List.sortBy"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "List.sortBy"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 16 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.sortBy f list)
+"""
+                        ]
+        , test "should replace List.sortBy f << List.sortBy f by List.sortBy f" <|
+            \() ->
+                """module A exposing (..)
+a = List.sortBy f << List.sortBy f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary List.sortBy after equivalent List.sortBy"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "List.sortBy"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 16 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.sortBy f
+"""
+                        ]
         ]
 
 
@@ -13263,6 +13298,7 @@ a = List.sortWith fn
 b = List.sortWith fn list
 b = List.sortWith (always fn) list
 b = List.sortWith (always (always fn)) list
+e = List.sortWith << List.sortWith f
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -13576,6 +13612,40 @@ a = List.sortWith (always (\\_ -> LT))
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.reverse
+"""
+                        ]
+        , test "should replace List.sortWith f (List.sortWith f list) by (List.sortWith f list)" <|
+            \() ->
+                """module A exposing (..)
+a = List.sortWith f (List.sortWith f list)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary List.sortWith after equivalent List.sortWith"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "List.sortWith"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 18 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.sortWith f list)
+"""
+                        ]
+        , test "should replace List.sortWith f << List.sortWith f by List.sortWith f" <|
+            \() ->
+                """module A exposing (..)
+a = List.sortWith f << List.sortWith f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary List.sortWith after equivalent List.sortWith"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "List.sortWith"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 18 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.sortWith f
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13034,6 +13034,40 @@ a = List.sort [ a ]
 a = [ a ]
 """
                         ]
+        , test "should replace List.sort (List.sort list) by (List.sort list)" <|
+            \() ->
+                """module A exposing (..)
+a = List.sort (List.sort list)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary List.sort after List.sort"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "List.sort"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 14 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.sort list)
+"""
+                        ]
+        , test "should replace List.sort << List.sort by List.sort" <|
+            \() ->
+                """module A exposing (..)
+a = List.sort << List.sort
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary List.sort after List.sort"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "List.sort"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 14 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.sort
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Implements #155 and add the same checks for `sortBy`, `sortWith` with equal arguments
