### PR TITLE
Add String.concat on List.repeat call simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `List.sort (List.sort list)` to `List.sort list`
 - `List.sortBy f (List.sortBy f list)` to `List.sortBy f list`
 - `List.sortWith f (List.sortWith f list)` to `List.sortWith f list`
+- `String.concat (List.repeat n str)` to `String.repeat n str`
 
 ## [2.1.2] - 2023-09-28
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5933,6 +5933,54 @@ a = String.concat []
 a = ""
 """
                         ]
+        , test "should replace String.concat (List.repeat n str) by (String.repeat n str)" <|
+            \() ->
+                """module A exposing (..)
+a = String.concat (List.repeat n str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.concat on List.repeat can be combined into String.repeat"
+                            , details = [ "You can replace these two operations by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
+                            , under = "String.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (String.repeat n str)
+"""
+                        ]
+        , test "should replace str |> List.repeat n |> String.concat by str |> String.repeat n" <|
+            \() ->
+                """module A exposing (..)
+a = str |> List.repeat n |> String.concat
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.concat on List.repeat can be combined into String.repeat"
+                            , details = [ "You can replace these two operations by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
+                            , under = "String.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = str |> String.repeat n
+"""
+                        ]
+        , test "should replace String.concat << List.repeat n by String.repeat n" <|
+            \() ->
+                """module A exposing (..)
+a = String.concat << List.repeat n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.concat on List.repeat can be combined into String.repeat"
+                            , details = [ "You can replace these two operations by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
+                            , under = "String.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.repeat n
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5768,7 +5768,7 @@ stringSimplificationTests =
         , stringIsEmptyTests
         , stringLengthTests
         , stringConcatTests
-        , joinTests
+        , stringJoinTests
         , stringRepeatTests
         , stringReplaceTests
         , stringWordsTests
@@ -5936,8 +5936,8 @@ a = ""
         ]
 
 
-joinTests : Test
-joinTests =
+stringJoinTests : Test
+stringJoinTests =
     describe "String.join"
         [ test "should not report String.join that contains a variable or expression" <|
             \() ->

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5767,7 +5767,7 @@ stringSimplificationTests =
         , stringFromListTests
         , stringIsEmptyTests
         , stringLengthTests
-        , concatTests
+        , stringConcatTests
         , joinTests
         , stringRepeatTests
         , stringReplaceTests
@@ -5907,8 +5907,8 @@ a = 13
         ]
 
 
-concatTests : Test
-concatTests =
+stringConcatTests : Test
+stringConcatTests =
     describe "String.concat"
         [ test "should not report String.concat that contains a variable or expression" <|
             \() ->

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14971,8 +14971,8 @@ arrayTests =
 
 arrayToListTests : Test
 arrayToListTests =
-    describe "String.toList"
-        [ test "should not report String.toList that contains a variable" <|
+    describe "Array.toList"
+        [ test "should not report Array.toList that contains a variable" <|
             \() ->
                 """module A exposing (..)
 import Array


### PR DESCRIPTION
Adds the last `String` simplification from #2 
```elm
String.concat (List.repeat n str)
--> String.repeat n str
```
including composition.

Bonus: Corrected test names.

I'm thinking we could add the same for `String.concat (List.intersperse s strings) --> String.join s strings`