### PR TITLE
Remove List.sortWith on equivalent List.sortWith simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - composition checks now also detect function pairs across nested compositions like `(here << ...) >> (... << there)`
 - `List.sort (List.sort list)` to `List.sort list`
 - `List.sortBy f (List.sortBy f list)` to `List.sortBy f list`
-- `List.sortWith f (List.sortWith f list)` to `List.sortWith f list`
 - `String.concat (List.repeat n str)` to `String.repeat n str`
 
 ## [2.1.2] - 2023-09-28

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -694,11 +694,17 @@ Destructuring using case expressions
     List.reverse (List.reverse list)
     --> list
 
+    List.sort (List.sort list)
+    --> List.sort list
+
     List.sortBy (always a) list
     --> list
 
     List.sortBy identity list
     --> List.sort list
+
+    List.sortBy f (List.sortBy f list)
+    --> List.sortBy f list
 
     List.sortWith (\_ _ -> LT) list
     --> List.reverse list
@@ -716,8 +722,6 @@ Destructuring using case expressions
     List.sort [ a ]
     --> [ a ]
 
-    List.sort (List.sort list)
-    --> List.sort list
 
     -- same for up to List.map5 when any list is empty
     List.map2 f xs []
@@ -2799,7 +2803,6 @@ compositionIntoChecks =
         , ( ( [ "List" ], "reverse" ), listReverseCompositionChecks )
         , ( ( [ "List" ], "sort" ), listSortCompositionChecks )
         , ( ( [ "List" ], "sortBy" ), listSortByCompositionChecks )
-        , ( ( [ "List" ], "sortWith" ), listSortWithCompositionChecks )
         , ( ( [ "List" ], "map" ), listMapCompositionChecks )
         , ( ( [ "List" ], "filterMap" ), listFilterMapCompositionChecks )
         , ( ( [ "List" ], "intersperse" ), listIntersperseCompositionChecks )
@@ -6737,14 +6740,8 @@ listSortWithChecks checkInfo =
 
                 Nothing ->
                     Nothing
-        , \() -> operationDoesNotChangeResultOfOperationCheck checkInfo
         ]
         ()
-
-
-listSortWithCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listSortWithCompositionChecks checkInfo =
-    operationDoesNotChangeResultOfOperationCompositionCheck { argCount = 2 } checkInfo
 
 
 listTakeChecks : CheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6558,7 +6558,7 @@ This applies to functions that are equivalent to identity when operating on the 
 Examples of such functions:
 
   - one argument: `Simplify.expectNaN`, `Review.Rule.providesFixesForModuleRule`, `List.sort`, `List.Extra.unique`, [`AVL.Set.clear`](https://package.elm-lang.org/packages/owanturist/elm-avl-dict/2.1.0/AVL-Set#clear)
-  - two arguments: `List.filter f`, `List.Extra.filterNot f`, `List.Extra.takeWhile/dropWhile(Right) f`, `List.sortBy f`, `List.sortWith f`, `List.Extra.uniqueBy f`
+  - two arguments: `List.filter f`, `List.Extra.filterNot f`, `List.Extra.takeWhile/dropWhile(Right) f`, `List.sortBy f`, `List.Extra.uniqueBy f`
   - three arguments: `Array.set i new`, `Array.Extra.resizelRepeat l pad`, `List.Extra.setAt i new`
 
 Note that `update` or `setWhere` operations for example _can_ have an effect even after the same operation has already been applied.

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13346,7 +13346,7 @@ a = List.sortWith fn
 b = List.sortWith fn list
 b = List.sortWith (always fn) list
 b = List.sortWith (always (always fn)) list
-e = List.sortWith << List.sortWith f
+e = List.sortWith f (List.sortWith f list) -- because e.g. List.sortWith (\\_ _ -> LT) is equivalent to List.reverse
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -13660,40 +13660,6 @@ a = List.sortWith (always (\\_ -> LT))
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = List.reverse
-"""
-                        ]
-        , test "should replace List.sortWith f (List.sortWith f list) by (List.sortWith f list)" <|
-            \() ->
-                """module A exposing (..)
-a = List.sortWith f (List.sortWith f list)
-"""
-                    |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.sortWith after equivalent List.sortWith"
-                            , details = [ "You can remove this additional operation." ]
-                            , under = "List.sortWith"
-                            }
-                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 18 } }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = (List.sortWith f list)
-"""
-                        ]
-        , test "should replace List.sortWith f << List.sortWith f by List.sortWith f" <|
-            \() ->
-                """module A exposing (..)
-a = List.sortWith f << List.sortWith f
-"""
-                    |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.sortWith after equivalent List.sortWith"
-                            , details = [ "You can remove this additional operation." ]
-                            , under = "List.sortWith"
-                            }
-                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 18 } }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.sortWith f
 """
                         ]
         ]


### PR DESCRIPTION
The recently added simplification `List.sortWith f (List.sortWith f list) --> List.sortWith f list`
is not correct with for example `f = \_ _ -> LT` [which would reverse the list](https://github.com/jfmengels/elm-review-simplify/blob/main/src/Simplify.elm#L703).

Thanks to Morten Kolstad on slack for finding and explaining this edge case!