### PR TITLE
Use groupingOnSpecificFnCallCanBeCombined checks for List.concat on List.map

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4504,72 +4504,6 @@ stringConcatCompositionChecks checkInfo =
         checkInfo
 
 
-{-| Simplify this grouping operation on a given call to `specificFn` to a given `combinedFn`.
-
-Examples:
-
-  - `List.concat (List.map f list) --> List.concatMap f list` (same for sequence+map to traverse etc)
-  - `Parser/Decoder/Random/...sequence (List.repeat n x) --> Parser/Decoder/Random/...repeat n x`
-  - `String.concat (List.repeat n x) --> String.repeat n x`
-  - `Animation.loop (List.repeat n x) --> Animation.repeat n x` using [`mdgriffith/elm-style-animation`](https://package.elm-lang.org/packages/mdgriffith/elm-style-animation/4.0.0/)
-  - `FormattedText.concat (List.intersperse s list) --> FormattedText.join s list` using [`NoRedInk/elm-formatted-text-19`](https://package.elm-lang.org/packages/NoRedInk/elm-formatted-text-19/1.0.0/)
-
-Use in combination with `groupingOnSpecificFnCallCanBeCombinedCompositionCheck`
-
--}
-groupingOnSpecificFnCallCanBeCombinedCheck :
-    { specificFn : ( ModuleName, String ), combinedFn : ( ModuleName, String ) }
-    -> CheckInfo
-    -> Maybe (Error {})
-groupingOnSpecificFnCallCanBeCombinedCheck config checkInfo =
-    case AstHelpers.getSpecificFunctionCall config.specificFn checkInfo.lookupTable checkInfo.firstArg of
-        Just specificFnCall ->
-            Just
-                (Rule.errorWithFix
-                    { message = qualifiedToString checkInfo.fn ++ " on " ++ qualifiedToString config.specificFn ++ " can be combined into " ++ qualifiedToString config.combinedFn
-                    , details = [ "You can replace these two operations by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.specificFn ++ " which is meant for this exact purpose." ]
-                    }
-                    checkInfo.fnRange
-                    (Fix.replaceRangeBy
-                        specificFnCall.fnRange
-                        (qualifiedToString (qualify config.combinedFn checkInfo))
-                        :: keepOnlyFix { parentRange = checkInfo.parentRange, keep = specificFnCall.nodeRange }
-                    )
-                )
-
-        Nothing ->
-            Nothing
-
-
-{-| Simplify this grouping operation after a given call to `specificFn` to a given `combinedFn`,
-like `List.concat << List.map f --> List.concatMap f`.
-
-Use in combination with `groupingOnSpecificFnCallCanBeCombinedCheck` (where you will also find more examples).
-
--}
-groupingOnSpecificFnCallCanBeCombinedCompositionCheck :
-    { specificFn : ( ModuleName, String ), combinedFn : ( ModuleName, String ) }
-    -> CompositionIntoCheckInfo
-    -> Maybe ErrorInfoAndFix
-groupingOnSpecificFnCallCanBeCombinedCompositionCheck config checkInfo =
-    if checkInfo.earlier.fn == config.specificFn then
-        Just
-            { info =
-                { message = qualifiedToString checkInfo.later.fn ++ " on " ++ qualifiedToString config.specificFn ++ " can be combined into " ++ qualifiedToString config.combinedFn
-                , details = [ "You can replace these two operations by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.specificFn ++ " which is meant for this exact purpose." ]
-                }
-            , fix =
-                [ Fix.replaceRangeBy
-                    checkInfo.earlier.fnRange
-                    (qualifiedToString (qualify config.combinedFn checkInfo))
-                , Fix.removeRange checkInfo.later.removeRange
-                ]
-            }
-
-    else
-        Nothing
-
-
 stringWordsChecks : CheckInfo -> Maybe (Error {})
 stringWordsChecks checkInfo =
     callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> "[]" }
@@ -6034,6 +5968,11 @@ listFilterMapChecks checkInfo =
         ()
 
 
+listFilterMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+listFilterMapCompositionChecks checkInfo =
+    mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks { mapFn = ( [ "List" ], "map" ) } checkInfo
+
+
 emptiableWrapperFilterMapChecks : EmptiableProperties (WrapperProperties otherProperties) -> CheckInfo -> Maybe (Error {})
 emptiableWrapperFilterMapChecks emptiableWrapper checkInfo =
     firstThatConstructsJust
@@ -6118,11 +6057,6 @@ mapToOperationWithIdentityCanBeCombinedToOperationChecks config checkInfo =
             Nothing
 
 
-listFilterMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listFilterMapCompositionChecks checkInfo =
-    mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks { mapFn = ( [ "List" ], "map" ) } checkInfo
-
-
 mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks : { mapFn : ( ModuleName, String ) } -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks config checkInfo =
     case checkInfo.later.args of
@@ -6150,6 +6084,72 @@ mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks config check
 
         _ ->
             Nothing
+
+
+{-| Simplify this grouping operation on a given call to `specificFn` to a given `combinedFn`.
+
+Examples:
+
+  - `List.concat (List.map f list) --> List.concatMap f list` (same for sequence+map to traverse etc)
+  - `Parser/Decoder/Random/...sequence (List.repeat n x) --> Parser/Decoder/Random/...repeat n x`
+  - `String.concat (List.repeat n x) --> String.repeat n x`
+  - `Animation.loop (List.repeat n x) --> Animation.repeat n x` using [`mdgriffith/elm-style-animation`](https://package.elm-lang.org/packages/mdgriffith/elm-style-animation/4.0.0/)
+  - `FormattedText.concat (List.intersperse s list) --> FormattedText.join s list` using [`NoRedInk/elm-formatted-text-19`](https://package.elm-lang.org/packages/NoRedInk/elm-formatted-text-19/1.0.0/)
+
+Use in combination with `groupingOnSpecificFnCallCanBeCombinedCompositionCheck`
+
+-}
+groupingOnSpecificFnCallCanBeCombinedCheck :
+    { specificFn : ( ModuleName, String ), combinedFn : ( ModuleName, String ) }
+    -> CheckInfo
+    -> Maybe (Error {})
+groupingOnSpecificFnCallCanBeCombinedCheck config checkInfo =
+    case AstHelpers.getSpecificFunctionCall config.specificFn checkInfo.lookupTable checkInfo.firstArg of
+        Just specificFnCall ->
+            Just
+                (Rule.errorWithFix
+                    { message = qualifiedToString checkInfo.fn ++ " on " ++ qualifiedToString config.specificFn ++ " can be combined into " ++ qualifiedToString config.combinedFn
+                    , details = [ "You can replace these two operations by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.specificFn ++ " which is meant for this exact purpose." ]
+                    }
+                    checkInfo.fnRange
+                    (Fix.replaceRangeBy
+                        specificFnCall.fnRange
+                        (qualifiedToString (qualify config.combinedFn checkInfo))
+                        :: keepOnlyFix { parentRange = checkInfo.parentRange, keep = specificFnCall.nodeRange }
+                    )
+                )
+
+        Nothing ->
+            Nothing
+
+
+{-| Simplify this grouping operation after a given call to `specificFn` to a given `combinedFn`,
+like `List.concat << List.map f --> List.concatMap f`.
+
+Use in combination with `groupingOnSpecificFnCallCanBeCombinedCheck` (where you will also find more examples).
+
+-}
+groupingOnSpecificFnCallCanBeCombinedCompositionCheck :
+    { specificFn : ( ModuleName, String ), combinedFn : ( ModuleName, String ) }
+    -> CompositionIntoCheckInfo
+    -> Maybe ErrorInfoAndFix
+groupingOnSpecificFnCallCanBeCombinedCompositionCheck config checkInfo =
+    if checkInfo.earlier.fn == config.specificFn then
+        Just
+            { info =
+                { message = qualifiedToString checkInfo.later.fn ++ " on " ++ qualifiedToString config.specificFn ++ " can be combined into " ++ qualifiedToString config.combinedFn
+                , details = [ "You can replace these two operations by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.specificFn ++ " which is meant for this exact purpose." ]
+                }
+            , fix =
+                [ Fix.replaceRangeBy
+                    checkInfo.earlier.fnRange
+                    (qualifiedToString (qualify config.combinedFn checkInfo))
+                , Fix.removeRange checkInfo.later.removeRange
+                ]
+            }
+
+    else
+        Nothing
 
 
 listRangeChecks : CheckInfo -> Maybe (Error {})

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8087,8 +8087,8 @@ a = List.concat (List.map f x)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.concat can be combined using List.concatMap"
-                            , details = [ "List.concatMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.concat on List.map can be combined into List.concatMap"
+                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8103,8 +8103,8 @@ a = List.concat <| List.map f <| x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.concat can be combined using List.concatMap"
-                            , details = [ "List.concatMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.concat on List.map can be combined into List.concatMap"
+                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8119,8 +8119,8 @@ a = x |> List.map f |> List.concat
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.concat can be combined using List.concatMap"
-                            , details = [ "List.concatMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.concat on List.map can be combined into List.concatMap"
+                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8453,8 +8453,8 @@ a = List.map f >> List.concat
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.concat can be combined using List.concatMap"
-                            , details = [ "List.concatMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.concat on List.map can be combined into List.concatMap"
+                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8469,8 +8469,8 @@ a = List.concat << List.map f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.concat can be combined using List.concatMap"
-                            , details = [ "List.concatMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.concat on List.map can be combined into List.concatMap"
+                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)


### PR DESCRIPTION
The recently added groupingOnSpecificFnCallCanBeCombined checks only allowed simplifying this one check.
This was discussed in https://github.com/jfmengels/elm-review-simplify/pull/213#pullrequestreview-1651856394