### PR TITLE
Add String.concat on List.intersperse checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `List.sort (List.sort list)` to `List.sort list`
 - `List.sortBy f (List.sortBy f list)` to `List.sortBy f list`
 - `String.concat (List.repeat n str)` to `String.repeat n str`
+- `String.concat (List.intersperse str strings)` to `String.join str strings`
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -299,6 +299,9 @@ Destructuring using case expressions
     String.concat (List.repeat n str)
     --> String.repeat n str
 
+    String.concat (List.intersperse str strings)
+    --> String.join str strings
+
     String.append "" str
     --> str
 
@@ -4493,15 +4496,27 @@ stringConcatChecks checkInfo =
             groupingOnSpecificFnCallCanBeCombinedCheck
                 { specificFn = ( [ "List" ], "repeat" ), combinedFn = ( [ "String" ], "repeat" ) }
                 checkInfo
+        , \() ->
+            groupingOnSpecificFnCallCanBeCombinedCheck
+                { specificFn = ( [ "List" ], "intersperse" ), combinedFn = ( [ "String" ], "join" ) }
+                checkInfo
         ]
         ()
 
 
 stringConcatCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 stringConcatCompositionChecks checkInfo =
-    groupingOnSpecificFnCallCanBeCombinedCompositionCheck
-        { specificFn = ( [ "List" ], "repeat" ), combinedFn = ( [ "String" ], "repeat" ) }
-        checkInfo
+    firstThatConstructsJust
+        [ \() ->
+            groupingOnSpecificFnCallCanBeCombinedCompositionCheck
+                { specificFn = ( [ "List" ], "repeat" ), combinedFn = ( [ "String" ], "repeat" ) }
+                checkInfo
+        , \() ->
+            groupingOnSpecificFnCallCanBeCombinedCompositionCheck
+                { specificFn = ( [ "List" ], "intersperse" ), combinedFn = ( [ "String" ], "join" ) }
+                checkInfo
+        ]
+        ()
 
 
 stringWordsChecks : CheckInfo -> Maybe (Error {})

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5981,6 +5981,54 @@ a = String.concat << List.repeat n
 a = String.repeat n
 """
                         ]
+        , test "should replace String.concat (List.intersperse str strings) by (String.join str strings)" <|
+            \() ->
+                """module A exposing (..)
+a = String.concat (List.intersperse str strings)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.concat on List.intersperse can be combined into String.join"
+                            , details = [ "You can replace these two operations by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
+                            , under = "String.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (String.join str strings)
+"""
+                        ]
+        , test "should replace str |> List.intersperse str |> String.concat by str |> String.join str" <|
+            \() ->
+                """module A exposing (..)
+a = str |> List.intersperse str |> String.concat
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.concat on List.intersperse can be combined into String.join"
+                            , details = [ "You can replace these two operations by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
+                            , under = "String.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = str |> String.join str
+"""
+                        ]
+        , test "should replace String.concat << List.intersperse str by String.join str" <|
+            \() ->
+                """module A exposing (..)
+a = String.concat << List.intersperse str
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.concat on List.intersperse can be combined into String.join"
+                            , details = [ "You can replace these two operations by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
+                            , under = "String.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.join str
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Adds the last string simplification from #2 
```elm
String.concat (List.intersperse str strings)
--> String.join str strings
```
including composition checks.