### PR TITLE
Add String.foldl/r checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 - `String.concat (List.intersperse str strings)` to `String.join str strings`
 - `Set.foldl/r f initial Set.empty` to `initial`
 - `Set.foldl/r (\_ soFar -> soFar) initial set` to `initial`
-- `String.foldl/r f initial Set.empty` to `initial`
-- `String.foldl/r (\_ soFar -> soFar) initial set` to `initial`
+- `String.foldl/r f initial ""` to `initial`
+- `String.foldl/r (\_ soFar -> soFar) initial string` to `initial`
 
 ## [2.1.2] - 2023-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - `String.concat (List.intersperse str strings)` to `String.join str strings`
 - `Set.foldl/r f initial Set.empty` to `initial`
 - `Set.foldl/r (\_ soFar -> soFar) initial set` to `initial`
+- `String.foldl/r f initial Set.empty` to `initial`
+- `String.foldl/r (\_ soFar -> soFar) initial set` to `initial`
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -383,6 +383,13 @@ Destructuring using case expressions
     String.slice -1 -2 str
     --> ""
 
+    -- The following simplifications for String.foldl also work for String.foldr
+    String.foldl f initial ""
+    --> initial
+
+    String.foldl (\_ soFar -> soFar) initial string
+    --> initial
+
 
 ### Maybes
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2627,6 +2627,8 @@ functionCallChecks =
         , ( ( [ "String" ], "left" ), ( 2, stringLeftChecks ) )
         , ( ( [ "String" ], "right" ), ( 2, stringRightChecks ) )
         , ( ( [ "String" ], "append" ), ( 2, collectionUnionChecks stringCollection ) )
+        , ( ( [ "String" ], "foldl" ), ( 3, stringFoldlChecks ) )
+        , ( ( [ "String" ], "foldr" ), ( 3, stringFoldrChecks ) )
         , ( ( [ "Platform", "Cmd" ], "batch" ), ( 1, subAndCmdBatchChecks cmdCollection ) )
         , ( ( [ "Platform", "Cmd" ], "map" ), ( 2, emptiableMapChecks cmdCollection ) )
         , ( ( [ "Platform", "Sub" ], "batch" ), ( 1, subAndCmdBatchChecks subCollection ) )
@@ -4847,6 +4849,16 @@ stringReplaceChecks checkInfo =
 
         Nothing ->
             Nothing
+
+
+stringFoldlChecks : CheckInfo -> Maybe (Error {})
+stringFoldlChecks checkInfo =
+    emptiableFoldChecks stringCollection checkInfo
+
+
+stringFoldrChecks : CheckInfo -> Maybe (Error {})
+stringFoldrChecks checkInfo =
+    emptiableFoldChecks stringCollection checkInfo
 
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5777,7 +5777,9 @@ stringSimplificationTests =
         , stringReverseTests
         , stringSliceTests
         , stringRightTests
-        , stringLeftTests, stringFoldlTests, stringFoldrTests
+        , stringLeftTests
+        , stringFoldlTests
+        , stringFoldrTests
         ]
 
 
@@ -7549,6 +7551,7 @@ a = ""
                         ]
         ]
 
+
 stringFoldlTests : Test
 stringFoldlTests =
     describe "String.foldl"
@@ -7707,6 +7710,7 @@ a = always
 """
                         ]
         ]
+
 
 
 -- LIST

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5777,7 +5777,7 @@ stringSimplificationTests =
         , stringReverseTests
         , stringSliceTests
         , stringRightTests
-        , stringLeftTests
+        , stringLeftTests, stringFoldlTests, stringFoldrTests
         ]
 
 
@@ -7549,6 +7549,164 @@ a = ""
                         ]
         ]
 
+stringFoldlTests : Test
+stringFoldlTests =
+    describe "String.foldl"
+        [ test "should not report String.foldl used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldl
+b = String.foldl (\\el soFar -> soFar - el)
+c = String.foldl (\\el soFar -> soFar - el) 20
+d = String.foldl (\\el soFar -> soFar - el) 20 string
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace String.foldl f initial \"\" by initial" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldl f initial ""
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.foldl on \"\" will always return the same given initial accumulator"
+                            , details = [ "You can replace this call by the initial accumulator itself." ]
+                            , under = "String.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = initial
+"""
+                        ]
+        , test "should replace String.foldl (always identity) initial string by initial" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldl (always identity) initial string
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.foldl with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by the given initial accumulator." ]
+                            , under = "String.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = initial
+"""
+                        ]
+        , test "should replace String.foldl (always identity) initial by always initial" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldl (always identity) initial
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.foldl with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by `always` with the given initial accumulator." ]
+                            , under = "String.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always initial
+"""
+                        ]
+        , test "should replace String.foldl (always identity) by always" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldl (always identity)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.foldl with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by `always` because the incoming accumulator will be returned, no matter which string is supplied next." ]
+                            , under = "String.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always
+"""
+                        ]
+        ]
+
+
+stringFoldrTests : Test
+stringFoldrTests =
+    describe "String.foldr"
+        [ test "should not report String.foldr used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldr
+b = String.foldr (\\el soFar -> soFar - el)
+c = String.foldr (\\el soFar -> soFar - el) 20
+d = String.foldr (\\el soFar -> soFar - el) 20 string
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace String.foldr f initial \"\" by initial" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldr f initial ""
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.foldr on \"\" will always return the same given initial accumulator"
+                            , details = [ "You can replace this call by the initial accumulator itself." ]
+                            , under = "String.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = initial
+"""
+                        ]
+        , test "should replace String.foldr (always identity) initial string by initial" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldr (always identity) initial string
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.foldr with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by the given initial accumulator." ]
+                            , under = "String.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = initial
+"""
+                        ]
+        , test "should replace String.foldr (always identity) initial by always initial" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldr (always identity) initial
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.foldr with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by `always` with the given initial accumulator." ]
+                            , under = "String.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always initial
+"""
+                        ]
+        , test "should replace String.foldr (always identity) by always" <|
+            \() ->
+                """module A exposing (..)
+a = String.foldr (always identity)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.foldr with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by `always` because the incoming accumulator will be returned, no matter which string is supplied next." ]
+                            , under = "String.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = always
+"""
+                        ]
+        ]
 
 
 -- LIST


### PR DESCRIPTION
Same as #217 for `String.foldl/foldr`
```elm
-- The following simplifications for String.foldl also work for String.foldr
String.foldl f initial ""
--> initial

String.foldl (\_ soFar -> soFar) initial string
--> initial
```