### PR TITLE
Add Json.Decode.map simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `Set.foldl/r (\_ soFar -> soFar) initial set` to `initial`
 - `String.foldl/r f initial ""` to `initial`
 - `String.foldl/r (\_ soFar -> soFar) initial string` to `initial`
+- the same operations for `Json.Decode.map` as for e.g. `Task.map` and `Result.map`
 
 ## [2.1.2] - 2023-09-28
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -23974,6 +23974,7 @@ jsonDecodeTests : Test
 jsonDecodeTests =
     Test.describe "Json.Decode"
         [ jsonDecodeMapTests
+        , jsonDecodeOneOfTests
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -23908,6 +23908,7 @@ a = Task.sequence [ a, Task.fail x]
         ]
 
 
+
 -- Parser
 
 
@@ -23968,11 +23969,13 @@ a = x
 
 -- Json.Decode
 
+
 jsonDecodeTests : Test
 jsonDecodeTests =
     Test.describe "Json.Decode"
         [ jsonDecodeMapTests
         ]
+
 
 jsonDecodeMapTests : Test
 jsonDecodeMapTests =
@@ -24220,6 +24223,7 @@ a = Json.Decode.succeed << f
 """
                         ]
         ]
+
 
 jsonDecodeOneOfTests : Test
 jsonDecodeOneOfTests =

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -23908,7 +23908,6 @@ a = Task.sequence [ a, Task.fail x]
         ]
 
 
-
 -- Parser
 
 
@@ -23969,9 +23968,261 @@ a = x
 
 -- Json.Decode
 
-
 jsonDecodeTests : Test
 jsonDecodeTests =
+    Test.describe "Json.Decode"
+        [ jsonDecodeMapTests
+        ]
+
+jsonDecodeMapTests : Test
+jsonDecodeMapTests =
+    describe "Json.Decode.map"
+        [ test "should not report Json.Decode.map used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map f json decoder
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Json.Decode.map f (Json.Decode.fail z) by (Json.Decode.fail z)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map f (Json.Decode.fail z)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a failing decoder will result in the given failing decoder"
+                            , details = [ "You can replace this call by the given failing decoder." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = (Json.Decode.fail z)
+"""
+                        ]
+        , test "should replace Json.Decode.map f <| Json.Decode.fail z by Json.Decode.fail z" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map f <| Json.Decode.fail z
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a failing decoder will result in the given failing decoder"
+                            , details = [ "You can replace this call by the given failing decoder." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.fail z
+"""
+                        ]
+        , test "should replace Json.Decode.fail z |> Json.Decode.map f by Json.Decode.fail z" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.fail z |> Json.Decode.map f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a failing decoder will result in the given failing decoder"
+                            , details = [ "You can replace this call by the given failing decoder." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.fail z
+"""
+                        ]
+        , test "should replace Json.Decode.map identity json decoder by json decoder" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map identity json decoder
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map with an identity function will always return the same given json decoder"
+                            , details = [ "You can replace this call by the json decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = json decoder
+"""
+                        ]
+        , test "should replace Json.Decode.map identity <| json decoder by json decoder" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map identity <| json decoder
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map with an identity function will always return the same given json decoder"
+                            , details = [ "You can replace this call by the json decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = json decoder
+"""
+                        ]
+        , test "should replace json decoder |> Json.Decode.map identity by json decoder" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = json decoder |> Json.Decode.map identity
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map with an identity function will always return the same given json decoder"
+                            , details = [ "You can replace this call by the json decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = json decoder
+"""
+                        ]
+        , test "should replace Json.Decode.map identity by identity" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map identity
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map with an identity function will always return the same given json decoder"
+                            , details = [ "You can replace this call by identity." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = identity
+"""
+                        ]
+        , test "should replace Json.Decode.map f (Json.Decode.succeed x) by Json.Decode.succeed (f x)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map f (Json.Decode.succeed x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a succeeding decoder will result in Json.Decode.succeed with the function applied to the value inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function directly applied to the value inside the succeeding decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.succeed (f x)
+"""
+                        ]
+        , test "should replace Json.Decode.map f <| Json.Decode.succeed x by Json.Decode.succeed <| f <| x" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map f <| Json.Decode.succeed x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a succeeding decoder will result in Json.Decode.succeed with the function applied to the value inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function directly applied to the value inside the succeeding decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.succeed <| f <| x
+"""
+                        ]
+        , test "should replace Json.Decode.succeed x |> Json.Decode.map f by x |> f |> Json.Decode.succeed" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.succeed x |> Json.Decode.map f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a succeeding decoder will result in Json.Decode.succeed with the function applied to the value inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function directly applied to the value inside the succeeding decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = x |> f |> Json.Decode.succeed
+"""
+                        ]
+        , test "should replace x |> Json.Decode.succeed |> Json.Decode.map f by x |> f |> Json.Decode.succeed" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = x |> Json.Decode.succeed |> Json.Decode.map f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a succeeding decoder will result in Json.Decode.succeed with the function applied to the value inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function directly applied to the value inside the succeeding decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = x |> f |> Json.Decode.succeed
+"""
+                        ]
+        , test "should replace Json.Decode.map f <| Json.Decode.succeed <| x by Json.Decode.succeed <| f <| x" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map f <| Json.Decode.succeed <| x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a succeeding decoder will result in Json.Decode.succeed with the function applied to the value inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function directly applied to the value inside the succeeding decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.succeed <| f <| x
+"""
+                        ]
+        , test "should replace Json.Decode.map f << Json.Decode.succeed by Json.Decode.succeed << f" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map f << Json.Decode.succeed
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map on a succeeding decoder will result in Json.Decode.succeed with the function applied to the value inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function directly applied to the value inside the succeeding decoder itself." ]
+                            , under = "Json.Decode.map"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.succeed << f
+"""
+                        ]
+        ]
+
+jsonDecodeOneOfTests : Test
+jsonDecodeOneOfTests =
     describe "Json.Decode.oneOf"
         [ test "should not report Json.Decode.oneOf used with okay arguments" <|
             \() ->


### PR DESCRIPTION
The simplifications listed for `Json.Decode.map` in #2
```elm
Json.Decode.map identity decoder
--> decoder

Json.Decode.map f (Json.Decode.fail x)
--> Json.Decode.fail x

Json.Decode.map f (Json.Decode.succeed a)
--> Json.Decode.succeed (f a)
```
including composition checks