### PR TITLE
Add Json.Decode.andThen simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `String.foldl/r f initial ""` to `initial`
 - `String.foldl/r (\_ soFar -> soFar) initial string` to `initial`
 - the same operations for `Json.Decode.map` as for e.g. `Task.map` and `Result.map`
+- the same operations for `Json.Decode.andThen` as for e.g. `Task.andThen` and `Result.andThen`
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1045,6 +1045,18 @@ All of these also apply for `Sub`.
     Json.Decode.map f (Json.Decode.succeed a)
     --> Json.Decode.succeed (f a)
 
+    Json.Decode.andThen f (Json.Decode.fail x)
+    --> Json.Decode.fail x
+
+    Json.Decode.andThen f (Json.Decode.succeed a)
+    --> f a
+
+    Json.Decode.andThen Json.Decode.succeed decoder
+    --> decoder
+
+    Json.Decode.andThen (\a -> Json.Decode.succeed b) decoder
+    --> Json.Decode.map (\a -> b) decoder
+
     Json.Decode.oneOf [ a ]
     --> a
 
@@ -2660,6 +2672,7 @@ functionCallChecks =
         , ( ( [ "Task" ], "sequence" ), ( 1, taskSequenceChecks ) )
         , ( ( [ "Json", "Decode" ], "oneOf" ), ( 1, oneOfChecks ) )
         , ( ( [ "Json", "Decode" ], "map" ), ( 2, jsonDecodeMapChecks ) )
+        , ( ( [ "Json", "Decode" ], "andThen" ), ( 2, jsonDecodeAndThenChecks ) )
         , ( ( [ "Html", "Attributes" ], "classList" ), ( 1, htmlAttributesClassListChecks ) )
         , ( ( [ "Parser" ], "oneOf" ), ( 1, oneOfChecks ) )
         , ( ( [ "Parser", "Advanced" ], "oneOf" ), ( 1, oneOfChecks ) )
@@ -7588,6 +7601,18 @@ jsonDecodeMapChecks checkInfo =
 jsonDecodeMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 jsonDecodeMapCompositionChecks checkInfo =
     wrapToMapCompositionChecks jsonDecoderWithSucceedAsWrap checkInfo
+
+
+jsonDecodeAndThenChecks : CheckInfo -> Maybe (Error {})
+jsonDecodeAndThenChecks checkInfo =
+    firstThatConstructsJust
+        [ \() ->
+            Maybe.andThen
+                (\taskArg -> callOnEmptyReturnsEmptyCheck taskArg jsonDecoderWithSucceedAsWrap checkInfo)
+                (secondArg checkInfo)
+        , \() -> wrapperAndThenChecks jsonDecoderWithSucceedAsWrap checkInfo
+        ]
+        ()
 
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -989,7 +989,7 @@ All of these also apply for `Sub`.
     --> task
 
     Task.andThen (\a -> Task.succeed b) task
-    --> Task.map (\a -> b) x
+    --> Task.map (\a -> b) task
 
     Task.mapError identity task
     --> task


### PR DESCRIPTION
Adds `Json.Decode.andThen` simplifications listed in #2 and more
```elm
Json.Decode.andThen f (Json.Decode.fail x)
--> Json.Decode.fail x

Json.Decode.andThen f (Json.Decode.succeed a)
--> f a

Json.Decode.andThen Json.Decode.succeed decoder
--> decoder

Json.Decode.andThen (\a -> Json.Decode.succeed b) decoder
--> Json.Decode.map (\a -> b) decoder
```

Bonus: Correcting one Task.andThen simplification in the summary