### PR TITLE
Add Json.decode.mapN simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `String.foldl/r f initial ""` to `initial`
 - `String.foldl/r (\_ soFar -> soFar) initial string` to `initial`
 - the same operations for `Json.Decode.map` as for e.g. `Task.map` and `Result.map`
+- the same operations for `Json.Decode.map2-8` as for e.g. `Task.mapN` and `Result.mapN`
 - the same operations for `Json.Decode.andThen` as for e.g. `Task.andThen` and `Result.andThen`
 
 ## [2.1.2] - 2023-09-28

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1045,6 +1045,16 @@ All of these also apply for `Sub`.
     Json.Decode.map f (Json.Decode.succeed a)
     --> Json.Decode.succeed (f a)
 
+    -- the following simplifications for map3 work for all Json.Decode.mapN
+    Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.succeed b) (Json.Decode.succeed c)
+    --> Json.Decode.succeed (f a b c)
+
+    Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.fail x) thirdDecoder
+    --> Json.Decode.fail x
+
+    Json.Decode.map3 f firstDecoder (Json.Decode.fail x) thirdDecoder
+    --> Json.Decode.map2 f firstDecoder (Json.Decode.fail x)
+
     Json.Decode.andThen f (Json.Decode.fail x)
     --> Json.Decode.fail x
 
@@ -2672,6 +2682,13 @@ functionCallChecks =
         , ( ( [ "Task" ], "sequence" ), ( 1, taskSequenceChecks ) )
         , ( ( [ "Json", "Decode" ], "oneOf" ), ( 1, oneOfChecks ) )
         , ( ( [ "Json", "Decode" ], "map" ), ( 2, jsonDecodeMapChecks ) )
+        , ( ( [ "Json", "Decode" ], "map2" ), ( 3, jsonDecodeMapNChecks ) )
+        , ( ( [ "Json", "Decode" ], "map3" ), ( 4, jsonDecodeMapNChecks ) )
+        , ( ( [ "Json", "Decode" ], "map4" ), ( 5, jsonDecodeMapNChecks ) )
+        , ( ( [ "Json", "Decode" ], "map5" ), ( 6, jsonDecodeMapNChecks ) )
+        , ( ( [ "Json", "Decode" ], "map6" ), ( 7, jsonDecodeMapNChecks ) )
+        , ( ( [ "Json", "Decode" ], "map7" ), ( 8, jsonDecodeMapNChecks ) )
+        , ( ( [ "Json", "Decode" ], "map8" ), ( 9, jsonDecodeMapNChecks ) )
         , ( ( [ "Json", "Decode" ], "andThen" ), ( 2, jsonDecodeAndThenChecks ) )
         , ( ( [ "Html", "Attributes" ], "classList" ), ( 1, htmlAttributesClassListChecks ) )
         , ( ( [ "Parser" ], "oneOf" ), ( 1, oneOfChecks ) )
@@ -7599,6 +7616,15 @@ jsonDecodeMapChecks checkInfo =
 jsonDecodeMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 jsonDecodeMapCompositionChecks checkInfo =
     wrapToMapCompositionChecks jsonDecoderWithSucceedAsWrap checkInfo
+
+
+jsonDecodeMapNChecks : CheckInfo -> Maybe (Error {})
+jsonDecodeMapNChecks checkInfo =
+    firstThatConstructsJust
+        [ \() -> wrapperMapNChecks jsonDecoderWithSucceedAsWrap checkInfo
+        , \() -> mapNOrFirstEmptyConstructionChecks jsonDecoderWithSucceedAsWrap checkInfo
+        ]
+        ()
 
 
 jsonDecodeAndThenChecks : CheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2561,10 +2561,10 @@ functionCallChecks =
         , ( ( [ "Maybe" ], "andThen" ), ( 2, maybeAndThenChecks ) )
         , ( ( [ "Maybe" ], "withDefault" ), ( 2, withDefaultChecks maybeWithJustAsWrap ) )
         , ( ( [ "Result" ], "map" ), ( 2, resultMapChecks ) )
-        , ( ( [ "Result" ], "map2" ), ( 3, resultMapNChecks { n = 2 } ) )
-        , ( ( [ "Result" ], "map3" ), ( 4, resultMapNChecks { n = 3 } ) )
-        , ( ( [ "Result" ], "map4" ), ( 5, resultMapNChecks { n = 4 } ) )
-        , ( ( [ "Result" ], "map5" ), ( 6, resultMapNChecks { n = 5 } ) )
+        , ( ( [ "Result" ], "map2" ), ( 3, resultMapNChecks ) )
+        , ( ( [ "Result" ], "map3" ), ( 4, resultMapNChecks ) )
+        , ( ( [ "Result" ], "map4" ), ( 5, resultMapNChecks ) )
+        , ( ( [ "Result" ], "map5" ), ( 6, resultMapNChecks ) )
         , ( ( [ "Result" ], "mapError" ), ( 2, resultMapErrorChecks ) )
         , ( ( [ "Result" ], "andThen" ), ( 2, resultAndThenChecks ) )
         , ( ( [ "Result" ], "withDefault" ), ( 2, withDefaultChecks resultWithOkAsWrap ) )
@@ -2662,10 +2662,10 @@ functionCallChecks =
         , ( ( [ "Platform", "Sub" ], "batch" ), ( 1, subAndCmdBatchChecks subCollection ) )
         , ( ( [ "Platform", "Sub" ], "map" ), ( 2, emptiableMapChecks subCollection ) )
         , ( ( [ "Task" ], "map" ), ( 2, taskMapChecks ) )
-        , ( ( [ "Task" ], "map2" ), ( 3, taskMapNChecks { n = 2 } ) )
-        , ( ( [ "Task" ], "map3" ), ( 4, taskMapNChecks { n = 3 } ) )
-        , ( ( [ "Task" ], "map4" ), ( 5, taskMapNChecks { n = 4 } ) )
-        , ( ( [ "Task" ], "map5" ), ( 6, taskMapNChecks { n = 5 } ) )
+        , ( ( [ "Task" ], "map2" ), ( 3, taskMapNChecks ) )
+        , ( ( [ "Task" ], "map3" ), ( 4, taskMapNChecks ) )
+        , ( ( [ "Task" ], "map4" ), ( 5, taskMapNChecks ) )
+        , ( ( [ "Task" ], "map5" ), ( 6, taskMapNChecks ) )
         , ( ( [ "Task" ], "andThen" ), ( 2, taskAndThenChecks ) )
         , ( ( [ "Task" ], "mapError" ), ( 2, taskMapErrorChecks ) )
         , ( ( [ "Task" ], "onError" ), ( 2, taskOnErrorChecks ) )
@@ -4928,11 +4928,11 @@ resultMapCompositionChecks checkInfo =
     wrapToMapCompositionChecks resultWithOkAsWrap checkInfo
 
 
-resultMapNChecks : { n : Int } -> CheckInfo -> Maybe (Error {})
-resultMapNChecks config checkInfo =
+resultMapNChecks : CheckInfo -> Maybe (Error {})
+resultMapNChecks checkInfo =
     firstThatConstructsJust
-        [ \() -> wrapperMapNChecks config resultWithOkAsWrap checkInfo
-        , \() -> mapNOrFirstEmptyConstructionChecks config resultWithOkAsWrap checkInfo
+        [ \() -> wrapperMapNChecks resultWithOkAsWrap checkInfo
+        , \() -> mapNOrFirstEmptyConstructionChecks resultWithOkAsWrap checkInfo
         ]
         ()
 
@@ -6811,9 +6811,9 @@ For example given `resultWithOkAsWrap`:
 This is pretty similar to `wrapperSequenceChecks` where we look at arguments instead of list elements.
 
 -}
-wrapperMapNChecks : { n : Int } -> WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
-wrapperMapNChecks config wrapper checkInfo =
-    if List.length checkInfo.argsAfterFirst == config.n then
+wrapperMapNChecks : WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
+wrapperMapNChecks wrapper checkInfo =
+    if List.length checkInfo.argsAfterFirst == (checkInfo.argCount - 1) then
         -- fully applied
         case traverse (getValueWithNodeRange (wrapper.wrap.getValue checkInfo.lookupTable)) checkInfo.argsAfterFirst of
             Just wraps ->
@@ -6892,19 +6892,17 @@ This is pretty similar to `sequenceOrFirstEmptyChecks` where we look at argument
 
 -}
 mapNOrFirstEmptyConstructionChecks :
-    { n : Int }
-    ->
-        WrapperProperties
-            { otherProperties
-                | empty :
-                    { empty
-                        | is : ModuleNameLookupTable -> Node Expression -> Bool
-                        , description : Description
-                    }
-            }
+    WrapperProperties
+        { otherProperties
+            | empty :
+                { empty
+                    | is : ModuleNameLookupTable -> Node Expression -> Bool
+                    , description : Description
+                }
+        }
     -> CheckInfo
     -> Maybe (Error {})
-mapNOrFirstEmptyConstructionChecks config emptiable checkInfo =
+mapNOrFirstEmptyConstructionChecks emptiable checkInfo =
     case findMapAndAllBefore (getEmptyExpressionNode checkInfo.lookupTable emptiable) checkInfo.argsAfterFirst of
         -- no empty arg found
         Nothing ->
@@ -6917,7 +6915,7 @@ mapNOrFirstEmptyConstructionChecks config emptiable checkInfo =
                     let
                         replacement : { description : String, fix : List Fix }
                         replacement =
-                            case config.n - List.length checkInfo.argsAfterFirst of
+                            case checkInfo.argCount - (1 + List.length checkInfo.argsAfterFirst) of
                                 -- fully applied
                                 0 ->
                                     { description = descriptionForDefinite "the first" emptiable.empty.description
@@ -6965,7 +6963,7 @@ mapNOrFirstEmptyConstructionChecks config emptiable checkInfo =
                         keptArgCount =
                             List.length emptyAndBefore.before + 1
                     in
-                    if keptArgCount == config.n then
+                    if keptArgCount == (checkInfo.argCount - 1) then
                         -- last arg is empty
                         Nothing
 
@@ -6986,7 +6984,7 @@ mapNOrFirstEmptyConstructionChecks config emptiable checkInfo =
 
                             replacement : { description : String, fix : List Fix }
                             replacement =
-                                case config.n - List.length checkInfo.argsAfterFirst of
+                                case checkInfo.argCount - (1 + List.length checkInfo.argsAfterFirst) of
                                     -- fully applied
                                     0 ->
                                         { fix =
@@ -7246,11 +7244,11 @@ taskMapCompositionChecks checkInfo =
     wrapToMapCompositionChecks taskWithSucceedAsWrap checkInfo
 
 
-taskMapNChecks : { n : Int } -> CheckInfo -> Maybe (Error {})
-taskMapNChecks config checkInfo =
+taskMapNChecks : CheckInfo -> Maybe (Error {})
+taskMapNChecks checkInfo =
     firstThatConstructsJust
-        [ \() -> wrapperMapNChecks config taskWithSucceedAsWrap checkInfo
-        , \() -> mapNOrFirstEmptyConstructionChecks config taskWithSucceedAsWrap checkInfo
+        [ \() -> wrapperMapNChecks taskWithSucceedAsWrap checkInfo
+        , \() -> mapNOrFirstEmptyConstructionChecks taskWithSucceedAsWrap checkInfo
         ]
         ()
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -24227,6 +24227,7 @@ a = Json.Decode.succeed << f
                         ]
         ]
 
+
 jsonDecodeMapNTests : Test
 jsonDecodeMapNTests =
     -- testing behavior only with representatives for 2-8
@@ -24445,6 +24446,7 @@ a = (\\_ _ -> Json.Decode.map2 f decoder0 (Json.Decode.fail x))
 """
                         ]
         ]
+
 
 jsonDecodeAndThenTests : Test
 jsonDecodeAndThenTests =

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -23974,6 +23974,7 @@ jsonDecodeTests : Test
 jsonDecodeTests =
     Test.describe "Json.Decode"
         [ jsonDecodeMapTests
+        , jsonDecodeMapNTests
         , jsonDecodeAndThenTests
         , jsonDecodeOneOfTests
         ]
@@ -24226,6 +24227,224 @@ a = Json.Decode.succeed << f
                         ]
         ]
 
+jsonDecodeMapNTests : Test
+jsonDecodeMapNTests =
+    -- testing behavior only with representatives for 2-8
+    describe "Json.Decode.mapN"
+        [ test "should not report Json.Decode.map3 with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3
+b = Json.Decode.map3 f
+c = Json.Decode.map3 f decoder0
+d = Json.Decode.map3 f decoder0 decoder1
+e = Json.Decode.map3 f decoder0 decoder1 decoder2
+f = Json.Decode.map3 f (Json.Decode.succeed h) decoder1 decoder2 -- because this is a code style choice
+f = Json.Decode.map3 f (Json.Decode.succeed h)
+g = Json.Decode.map3 f decoder0 decoder1 (Json.Decode.fail x) -- because decoder0/1 can have an earlier failing decoder
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.succeed b) (Json.Decode.succeed c) by Json.Decode.succeed (f a b c)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.succeed b) (Json.Decode.succeed c)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 where each json decoder is a succeeding decoder will result in Json.Decode.succeed on the values inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function applied to the values inside each succeeding decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.succeed (f a b c)
+"""
+                        ]
+        , test "should replace c |> g |> Json.Decode.succeed |> Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.succeed b) by (c |> g) |> f a b |> Json.Decode.succeed" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = c |> g |> Json.Decode.succeed |> Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.succeed b)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 where each json decoder is a succeeding decoder will result in Json.Decode.succeed on the values inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function applied to the values inside each succeeding decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = (c |> g) |> f a b |> Json.Decode.succeed
+"""
+                        ]
+        , test "should replace Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.succeed b) <| Json.Decode.succeed <| g <| c by Json.Decode.succeed <| f a b <| (g <| c)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.succeed b) <| Json.Decode.succeed <| g <| c
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 where each json decoder is a succeeding decoder will result in Json.Decode.succeed on the values inside"
+                            , details = [ "You can replace this call by Json.Decode.succeed with the function applied to the values inside each succeeding decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.succeed <| f a b <| (g <| c)
+"""
+                        ]
+        , test "should replace Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.fail x) decoder2 by (Json.Decode.fail x)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.fail x) decoder2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 where we know the first failing decoder will result in that failing decoder"
+                            , details = [ "You can replace this call by the first failing decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = (Json.Decode.fail x)
+"""
+                        ]
+        , test "should replace Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.fail x) by always (Json.Decode.fail x)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.fail x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 where we know the first failing decoder will result in that failing decoder"
+                            , details = [ "You can replace this call by always with the first failing decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = always (Json.Decode.fail x)
+"""
+                        ]
+        , test "should replace Json.Decode.map3 f (Json.Decode.fail x) decoder1 decoder2 by (Json.Decode.fail x)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3 f (Json.Decode.fail x) decoder1 decoder2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 where we know the first failing decoder will result in that failing decoder"
+                            , details = [ "You can replace this call by the first failing decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = (Json.Decode.fail x)
+"""
+                        ]
+        , test "should replace Json.Decode.map3 f (Json.Decode.fail x) decoder1 by always (Json.Decode.fail x)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3 f (Json.Decode.fail x) decoder1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 where we know the first failing decoder will result in that failing decoder"
+                            , details = [ "You can replace this call by always with the first failing decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = always (Json.Decode.fail x)
+"""
+                        ]
+        , test "should replace Json.Decode.map3 f (Json.Decode.fail x) by (\\_ _ -> (Json.Decode.fail x))" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3 f (Json.Decode.fail x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 where we know the first failing decoder will result in that failing decoder"
+                            , details = [ "You can replace this call by \\_ _ -> with the first failing decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = (\\_ _ -> (Json.Decode.fail x))
+"""
+                        ]
+        , test "should replace Json.Decode.map3 f decoder0 (Json.Decode.fail x) decoder2 by Json.Decode.map2 f decoder0 (Json.Decode.fail x)" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map3 f decoder0 (Json.Decode.fail x) decoder2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map3 with a failing decoder early will ignore later arguments"
+                            , details = [ "You can replace this call by Json.Decode.map2 with the same arguments until the first failing decoder." ]
+                            , under = "Json.Decode.map3"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map2 f decoder0 (Json.Decode.fail x)
+"""
+                        ]
+        , test "should replace Json.Decode.map4 f decoder0 (Json.Decode.fail x) decoder3 by always (Json.Decode.map2 f decoder0 (Json.Decode.fail x))" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map4 f decoder0 (Json.Decode.fail x) decoder3
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map4 with a failing decoder early will ignore later arguments"
+                            , details = [ "You can replace this call by always with Json.Decode.map2 with the same arguments until the first failing decoder." ]
+                            , under = "Json.Decode.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = always (Json.Decode.map2 f decoder0 (Json.Decode.fail x))
+"""
+                        ]
+        , test "should replace Json.Decode.map4 f decoder0 (Json.Decode.fail x) by (\\_ _ -> Json.Decode.map2 f decoder0 (Json.Decode.fail x))" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.map4 f decoder0 (Json.Decode.fail x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.map4 with a failing decoder early will ignore later arguments"
+                            , details = [ "You can replace this call by \\_ _ -> with Json.Decode.map2 with the same arguments until the first failing decoder." ]
+                            , under = "Json.Decode.map4"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = (\\_ _ -> Json.Decode.map2 f decoder0 (Json.Decode.fail x))
+"""
+                        ]
+        ]
 
 jsonDecodeAndThenTests : Test
 jsonDecodeAndThenTests =


### PR DESCRIPTION
Completes the `Json.Decode` simplifications listed in #2 and more.
```elm
-- the following simplifications for map3 work for all Json.Decode.mapN
Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.succeed b) (Json.Decode.succeed c)
--> Json.Decode.succeed (f a b c)

Json.Decode.map3 f (Json.Decode.succeed a) (Json.Decode.fail x) thirdDecoder
--> Json.Decode.fail x

Json.Decode.map3 f firstDecoder (Json.Decode.fail x) thirdDecoder
--> Json.Decode.map2 f firstDecoder (Json.Decode.fail x)
```
Bonus: Make using mapN checks more concise by using `argCount` to infer the `n`
