### PR TITLE
Type properties use qualified fn instead of just the name

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6024,7 +6024,7 @@ listFilterMapCompositionChecks checkInfo =
     mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks { mapFn = ( [ "List" ], "map" ) } checkInfo
 
 
-emptiableWrapperFilterMapChecks : EmptiableProperties (WrapperProperties otherProperties) -> CheckInfo -> Maybe (Error {})
+emptiableWrapperFilterMapChecks : EmptiableProperties (WrapperProperties { otherProperties | mapFn : ( ModuleName, String ) }) -> CheckInfo -> Maybe (Error {})
 emptiableWrapperFilterMapChecks emptiableWrapper checkInfo =
     firstThatConstructsJust
         [ \() ->
@@ -6037,7 +6037,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper checkInfo =
                             }
                             checkInfo.fnRange
                             (Fix.replaceRangeBy checkInfo.fnRange
-                                (qualifiedToString (qualify ( emptiableWrapper.moduleName, "map" ) checkInfo))
+                                (qualifiedToString (qualify emptiableWrapper.mapFn checkInfo))
                                 :: List.concatMap (\call -> replaceBySubExpressionFix call.nodeRange call.firstArg) justCalls
                             )
                         )
@@ -6069,7 +6069,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper checkInfo =
                 Undetermined ->
                     Nothing
         , \() ->
-            mapToOperationWithIdentityCanBeCombinedToOperationChecks { mapFn = ( emptiableWrapper.moduleName, "map" ) } checkInfo
+            mapToOperationWithIdentityCanBeCombinedToOperationChecks { mapFn = emptiableWrapper.mapFn } checkInfo
         , \() ->
             Maybe.andThen
                 (\listArg -> callOnEmptyReturnsEmptyCheck listArg emptiableWrapper checkInfo)

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8130,6 +8130,7 @@ resultWithErrAsWrap :
             { description : Description
             , is : ModuleNameLookupTable -> Node Expression -> Bool
             }
+        , mapFn : ( ModuleName, String )
         }
 resultWithErrAsWrap =
     { moduleName = [ "Result" ]
@@ -8147,6 +8148,7 @@ resultWithErrAsWrap =
             \lookupTable expr ->
                 isJust (AstHelpers.getSpecificFunctionCall ( [ "Result" ], "Ok" ) lookupTable expr)
         }
+    , mapFn = ( [ "Result" ], "mapError" )
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7875,8 +7875,7 @@ nonEmptiableWrapperAndThenAlwaysChecks wrapper checkInfo =
 
 type alias TypeProperties properties =
     { properties
-        | moduleName : ModuleName
-        , represents : String
+        | represents : String
     }
 
 
@@ -8056,8 +8055,7 @@ emptyAsString qualifyResources emptiable =
 
 randomGeneratorWrapper : NonEmptiableProperties (WrapperProperties { mapFn : ( ModuleName, String ) })
 randomGeneratorWrapper =
-    { moduleName = [ "Random" ]
-    , represents = "random generator"
+    { represents = "random generator"
     , wrap =
         { description = A "constant generator"
         , fn = ( [ "Random" ], "constant" )
@@ -8074,8 +8072,7 @@ maybeWithJustAsWrap :
     EmptiableProperties
         (WrapperProperties { mapFn : ( ModuleName, String ) })
 maybeWithJustAsWrap =
-    { moduleName = [ "Maybe" ]
-    , represents = "maybe"
+    { represents = "maybe"
     , empty =
         { description = Constant "Nothing"
         , is =
@@ -8105,8 +8102,7 @@ resultWithOkAsWrap :
         , mapFn : ( ModuleName, String )
         }
 resultWithOkAsWrap =
-    { moduleName = [ "Result" ]
-    , represents = "result"
+    { represents = "result"
     , wrap =
         { description = An "okay result"
         , fn = ( [ "Result" ], "Ok" )
@@ -8133,8 +8129,7 @@ resultWithErrAsWrap :
         , mapFn : ( ModuleName, String )
         }
 resultWithErrAsWrap =
-    { moduleName = [ "Result" ]
-    , represents = "result"
+    { represents = "result"
     , wrap =
         { description = An "error"
         , fn = ( [ "Result" ], "Err" )
@@ -8161,8 +8156,7 @@ taskWithSucceedAsWrap :
         , mapFn : ( ModuleName, String )
         }
 taskWithSucceedAsWrap =
-    { moduleName = [ "Task" ]
-    , represents = "task"
+    { represents = "task"
     , wrap =
         { description = A "succeeding task"
         , fn = ( [ "Task" ], "succeed" )
@@ -8189,8 +8183,7 @@ taskWithFailAsWrap :
         , mapFn : ( ModuleName, String )
         }
 taskWithFailAsWrap =
-    { moduleName = [ "Task" ]
-    , represents = "task"
+    { represents = "task"
     , wrap =
         { description = A "failing task"
         , fn = ( [ "Task" ], "fail" )
@@ -8217,8 +8210,7 @@ jsonDecoderWithSucceedAsWrap :
         , mapFn : ( ModuleName, String )
         }
 jsonDecoderWithSucceedAsWrap =
-    { moduleName = [ "Json", "Decode" ]
-    , represents = "json decoder"
+    { represents = "json decoder"
     , wrap =
         { description = A "succeeding decoder"
         , fn = ( [ "Json", "Decode" ], "succeed" )
@@ -8238,8 +8230,7 @@ jsonDecoderWithSucceedAsWrap =
 
 listCollection : CollectionProperties (WrapperProperties (FromListProperties { mapFn : ( ModuleName, String ) }))
 listCollection =
-    { moduleName = [ "List" ]
-    , represents = "list"
+    { represents = "list"
     , empty =
         { description = Constant "[]"
         , is = \_ expr -> AstHelpers.getListLiteral expr == Just []
@@ -8288,8 +8279,7 @@ listDetermineLength resources expressionNode =
 
 stringCollection : CollectionProperties (WrapperProperties (FromListProperties {}))
 stringCollection =
-    { moduleName = [ "String" ]
-    , represents = "string"
+    { represents = "string"
     , empty =
         { description = Constant emptyStringAsString
         , asString = \_ -> emptyStringAsString
@@ -8325,8 +8315,7 @@ stringDetermineLength expression =
 
 arrayCollection : CollectionProperties (FromListProperties (IndexableProperties {}))
 arrayCollection =
-    { moduleName = [ "Array" ]
-    , represents = "array"
+    { represents = "array"
     , empty =
         { description = Constant (qualifiedToString ( [ "Array" ], "empty" ))
         , is =
@@ -8393,8 +8382,7 @@ arrayDetermineSize resources expressionNode =
 
 setCollection : CollectionProperties (WrapperProperties (FromListProperties {}))
 setCollection =
-    { moduleName = [ "Set" ]
-    , represents = "set"
+    { represents = "set"
     , empty =
         { description = Constant (qualifiedToString ( [ "Set" ], "empty" ))
         , is =
@@ -8471,8 +8459,7 @@ setDetermineSize resources expressionNode =
 
 dictCollection : CollectionProperties (FromListProperties {})
 dictCollection =
-    { moduleName = [ "Dict" ]
-    , represents = "dict"
+    { represents = "dict"
     , empty =
         { description = Constant (qualifiedToString ( [ "Dict" ], "empty" ))
         , is =
@@ -8546,8 +8533,7 @@ dictDetermineSize resources expressionNode =
 
 cmdCollection : EmptiableProperties {}
 cmdCollection =
-    { moduleName = [ "Platform", "Cmd" ]
-    , represents = "command"
+    { represents = "command"
     , empty =
         { description =
             Constant "Cmd.none"
@@ -8563,8 +8549,7 @@ cmdCollection =
 
 subCollection : EmptiableProperties {}
 subCollection =
-    { moduleName = [ "Platform", "Sub" ]
-    , represents = "subscription"
+    { represents = "subscription"
     , empty =
         { description =
             Constant "Sub.none"

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6032,8 +6032,8 @@ emptiableWrapperFilterMapChecks emptiableWrapper checkInfo =
                 Determined justCalls ->
                     Just
                         (Rule.errorWithFix
-                            { message = qualifiedToString checkInfo.fn ++ " with a function that will always return Just is the same as " ++ qualifiedToString ( emptiableWrapper.moduleName, "map" )
-                            , details = [ "You can remove the `Just`s and replace the call by " ++ qualifiedToString ( emptiableWrapper.moduleName, "map" ) ++ "." ]
+                            { message = qualifiedToString checkInfo.fn ++ " with a function that will always return Just is the same as " ++ qualifiedToString emptiableWrapper.mapFn
+                            , details = [ "You can remove the `Just`s and replace the call by " ++ qualifiedToString emptiableWrapper.mapFn ++ "." ]
                             }
                             checkInfo.fnRange
                             (Fix.replaceRangeBy checkInfo.fnRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9616,20 +9616,20 @@ collectionUnionWithLiteralsChecks collection checkInfo =
             Nothing
 
 
-collectionInsertChecks : CollectionProperties otherProperties -> CheckInfo -> Maybe (Error {})
+collectionInsertChecks : CollectionProperties (WrapperProperties otherProperties) -> CheckInfo -> Maybe (Error {})
 collectionInsertChecks collection checkInfo =
     case secondArg checkInfo of
         Just collectionArg ->
             if collection.empty.is checkInfo.lookupTable collectionArg then
                 Just
                     (Rule.errorWithFix
-                        { message = "Use " ++ qualifiedToString ( collection.moduleName, "singleton" ) ++ " instead of inserting in " ++ descriptionForIndefinite collection.empty.description
-                        , details = [ "You can replace this call by " ++ qualifiedToString ( collection.moduleName, "singleton" ) ++ "." ]
+                        { message = "Use " ++ qualifiedToString collection.wrap.fn ++ " instead of inserting in " ++ descriptionForIndefinite collection.empty.description
+                        , details = [ "You can replace this call by " ++ qualifiedToString collection.wrap.fn ++ "." ]
                         }
                         checkInfo.fnRange
                         (replaceBySubExpressionFix checkInfo.parentRange checkInfo.firstArg
                             ++ [ Fix.insertAt checkInfo.parentRange.start
-                                    (qualifiedToString (qualify ( collection.moduleName, "singleton" ) checkInfo) ++ " ")
+                                    (qualifiedToString (qualify collection.wrap.fn checkInfo) ++ " ")
                                ]
                         )
                     )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7384,7 +7384,7 @@ sequenceOrFirstEmptyChecks emptiable checkInfo =
             Nothing
 
 
-wrapperSequenceChecks : WrapperProperties { otherProperties | mapFnName : String } -> CheckInfo -> Maybe (Error {})
+wrapperSequenceChecks : WrapperProperties { otherProperties | mapFn : ( ModuleName, String ) } -> CheckInfo -> Maybe (Error {})
 wrapperSequenceChecks wrapper checkInfo =
     firstThatConstructsJust
         [ \() ->
@@ -7401,13 +7401,9 @@ wrapperSequenceChecks wrapper checkInfo =
             case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.firstArg of
                 Just singletonList ->
                     let
-                        mapFn : ( ModuleName, String )
-                        mapFn =
-                            ( wrapper.moduleName, wrapper.mapFnName )
-
                         replacement : QualifyResources a -> String
                         replacement qualifyResources =
-                            qualifiedToString (qualify mapFn qualifyResources)
+                            qualifiedToString (qualify wrapper.mapFn qualifyResources)
                                 ++ " "
                                 ++ qualifiedToString (qualify ( [ "List" ], "singleton" ) qualifyResources)
                     in
@@ -7454,18 +7450,14 @@ wrapperSequenceChecks wrapper checkInfo =
         ()
 
 
-mappableSequenceCompositionChecks : TypeProperties { otherProperties | mapFnName : String } -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+mappableSequenceCompositionChecks : TypeProperties { otherProperties | mapFn : ( ModuleName, String ) } -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 mappableSequenceCompositionChecks mappable checkInfo =
     case checkInfo.earlier.fn of
         ( [ "List" ], "singleton" ) ->
             let
-                mapFn : ( ModuleName, String )
-                mapFn =
-                    ( mappable.moduleName, mappable.mapFnName )
-
                 replacement : QualifyResources a -> String
                 replacement qualifyResources =
-                    qualifiedToString (qualify mapFn qualifyResources)
+                    qualifiedToString (qualify mappable.mapFn qualifyResources)
                         ++ " "
                         ++ qualifiedToString (qualify ( [ "List" ], "singleton" ) qualifyResources)
             in
@@ -8062,7 +8054,7 @@ emptyAsString qualifyResources emptiable =
     emptiable.empty.asString (extractQualifyResources qualifyResources)
 
 
-randomGeneratorWrapper : NonEmptiableProperties (WrapperProperties { mapFnName : String })
+randomGeneratorWrapper : NonEmptiableProperties (WrapperProperties { mapFn : ( ModuleName, String ) })
 randomGeneratorWrapper =
     { moduleName = [ "Random" ]
     , represents = "random generator"
@@ -8074,13 +8066,13 @@ randomGeneratorWrapper =
                 Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Random" ], "constant" ) lookupTable expr)
         }
     , empty = { invalid = () }
-    , mapFnName = "map"
+    , mapFn = ( [ "Random" ], "map" )
     }
 
 
 maybeWithJustAsWrap :
     EmptiableProperties
-        (WrapperProperties { mapFnName : String })
+        (WrapperProperties { mapFn : ( ModuleName, String ) })
 maybeWithJustAsWrap =
     { moduleName = [ "Maybe" ]
     , represents = "maybe"
@@ -8100,7 +8092,7 @@ maybeWithJustAsWrap =
             \lookupTable expr ->
                 Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Maybe" ], "Just" ) lookupTable expr)
         }
-    , mapFnName = "map"
+    , mapFn = ( [ "Maybe" ], "map" )
     }
 
 
@@ -8110,7 +8102,7 @@ resultWithOkAsWrap :
             { description : Description
             , is : ModuleNameLookupTable -> Node Expression -> Bool
             }
-        , mapFnName : String
+        , mapFn : ( ModuleName, String )
         }
 resultWithOkAsWrap =
     { moduleName = [ "Result" ]
@@ -8128,7 +8120,7 @@ resultWithOkAsWrap =
             \lookupTable expr ->
                 isJust (AstHelpers.getSpecificFunctionCall ( [ "Result" ], "Err" ) lookupTable expr)
         }
-    , mapFnName = "map"
+    , mapFn = ( [ "Result" ], "map" )
     }
 
 
@@ -8164,7 +8156,7 @@ taskWithSucceedAsWrap :
             { description : Description
             , is : ModuleNameLookupTable -> Node Expression -> Bool
             }
-        , mapFnName : String
+        , mapFn : ( ModuleName, String )
         }
 taskWithSucceedAsWrap =
     { moduleName = [ "Task" ]
@@ -8182,7 +8174,7 @@ taskWithSucceedAsWrap =
             \lookupTable expr ->
                 isJust (AstHelpers.getSpecificFunctionCall ( [ "Task" ], "fail" ) lookupTable expr)
         }
-    , mapFnName = "map"
+    , mapFn = ( [ "Task" ], "map" )
     }
 
 
@@ -8192,7 +8184,7 @@ taskWithFailAsWrap :
             { description : Description
             , is : ModuleNameLookupTable -> Node Expression -> Bool
             }
-        , mapFnName : String
+        , mapFn : ( ModuleName, String )
         }
 taskWithFailAsWrap =
     { moduleName = [ "Task" ]
@@ -8210,7 +8202,7 @@ taskWithFailAsWrap =
             \lookupTable expr ->
                 isJust (AstHelpers.getSpecificFunctionCall ( [ "Task" ], "succeed" ) lookupTable expr)
         }
-    , mapFnName = "mapError"
+    , mapFn = ( [ "Task" ], "mapError" )
     }
 
 
@@ -8220,7 +8212,7 @@ jsonDecoderWithSucceedAsWrap :
             { description : Description
             , is : ModuleNameLookupTable -> Node Expression -> Bool
             }
-        , mapFnName : String
+        , mapFn : ( ModuleName, String )
         }
 jsonDecoderWithSucceedAsWrap =
     { moduleName = [ "Json", "Decode" ]
@@ -8238,11 +8230,11 @@ jsonDecoderWithSucceedAsWrap =
             \lookupTable expr ->
                 isJust (AstHelpers.getSpecificFunctionCall ( [ "Json", "Decode" ], "fail" ) lookupTable expr)
         }
-    , mapFnName = "map"
+    , mapFn = ( [ "Json", "Decode" ], "map" )
     }
 
 
-listCollection : CollectionProperties (WrapperProperties (FromListProperties { mapFnName : String }))
+listCollection : CollectionProperties (WrapperProperties (FromListProperties { mapFn : ( ModuleName, String ) }))
 listCollection =
     { moduleName = [ "List" ]
     , represents = "list"
@@ -8260,7 +8252,7 @@ listCollection =
             \lookupTable expr ->
                 Maybe.map .element (AstHelpers.getListSingleton lookupTable expr)
         }
-    , mapFnName = "map"
+    , mapFn = ( [ "List" ], "map" )
     , fromListLiteralRange = \_ expr -> AstHelpers.getListLiteralRange expr
     , fromListLiteralDescription = "list literal"
     , literalUnionLeftElementsStayOnTheLeft = True
@@ -8831,7 +8823,7 @@ getValueWithNodeRange getValue expressionNode =
 
 
 wrapperAndThenChecks :
-    WrapperProperties { otherProperties | mapFnName : String }
+    WrapperProperties { otherProperties | mapFn : ( ModuleName, String ) }
     -> CheckInfo
     -> Maybe (Error {})
 wrapperAndThenChecks wrapper checkInfo =
@@ -8877,19 +8869,14 @@ wrapperAndThenChecks wrapper checkInfo =
                     checkInfo.firstArg
             of
                 Determined wrapCalls ->
-                    let
-                        mapFn : ( ModuleName, String )
-                        mapFn =
-                            ( wrapper.moduleName, wrapper.mapFnName )
-                    in
                     Just
                         (Rule.errorWithFix
-                            { message = qualifiedToString checkInfo.fn ++ " with a function that always returns " ++ descriptionForIndefinite wrapper.wrap.description ++ " is the same as " ++ qualifiedToString mapFn ++ " with the function returning the value inside"
-                            , details = [ "You can replace this call by " ++ qualifiedToString mapFn ++ " with the function returning the value inside " ++ descriptionForDefinite "the" wrapper.wrap.description ++ "." ]
+                            { message = qualifiedToString checkInfo.fn ++ " with a function that always returns " ++ descriptionForIndefinite wrapper.wrap.description ++ " is the same as " ++ qualifiedToString wrapper.mapFn ++ " with the function returning the value inside"
+                            , details = [ "You can replace this call by " ++ qualifiedToString wrapper.mapFn ++ " with the function returning the value inside " ++ descriptionForDefinite "the" wrapper.wrap.description ++ "." ]
                             }
                             checkInfo.fnRange
                             (Fix.replaceRangeBy checkInfo.fnRange
-                                (qualifiedToString (qualify mapFn checkInfo))
+                                (qualifiedToString (qualify wrapper.mapFn checkInfo))
                                 :: List.concatMap (\call -> replaceBySubExpressionFix call.nodeRange call.value) wrapCalls
                             )
                         )


### PR DESCRIPTION
Modules don't always expose functions we might expect to apply some simplifications.
E.g.
- `Array` and [`Graph`](https://dark.elm.dmy.fr/packages/elm-community/graph/latest/Graph) do not expose a `singleton`
- `Array` and many other data structures do not provide `sum`, `product`, `any` or `all` which could be used in the `foldl/r` simplifications

Often, these extra helpers are provided by modules in different packages.

Currently, only a function's name is stored in the type properties which has to manually combined with its module name.
This PR replaces these function names by qualified names.