### PR TITLE
Add tuple access on tuple map simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - the same operations for `Json.Decode.map` as for e.g. `Task.map` and `Result.map`
 - the same operations for `Json.Decode.map2-8` as for e.g. `Task.mapN` and `Result.mapN`
 - the same operations for `Json.Decode.andThen` as for e.g. `Task.andThen` and `Result.andThen`
+- `Tuple.first (Tuple.mapSecond changeFirst tuple)` to `Tuple.first tuple`
+- `Tuple.first (Tuple.mapBoth changeFirst changeSecond tuple)` to `Tuple.first (Tuple.mapFirst changeFirst tuple)`
+- `Tuple.second (Tuple.mapFirst changeSecond tuple)` to `Tuple.second tuple`
+- `Tuple.second (Tuple.mapBoth changeFirst changeSecond tuple)` to `Tuple.second (Tuple.mapSecond changeSecond tuple)`
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4605,7 +4605,7 @@ tuplePartChecks partConfig checkInfo =
             case AstHelpers.getSpecificFunctionCall ( [ "Tuple" ], "mapBoth" ) checkInfo.lookupTable checkInfo.firstArg of
                 Just tupleMapBothCall ->
                     case tupleMapBothCall.argsAfterFirst of
-                        secondMapperArg :: tuple :: [] ->
+                        secondMapperArg :: _ :: [] ->
                             Just
                                 (Rule.errorWithFix
                                     { message = qualifiedToString ( [ "Tuple" ], "mapBoth" ) ++ " before " ++ qualifiedToString checkInfo.fn ++ " is the same as " ++ qualifiedToString partConfig.mapFn
@@ -4657,7 +4657,7 @@ tuplePartCompositionChecks partConfig checkInfo =
                 Nothing
         , \() ->
             case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
-                ( ( [ "Tuple" ], "mapBoth" ), firstMapperArg :: secondMapperArg :: [] ) ->
+                ( ( [ "Tuple" ], "mapBoth" ), firstMapperArg :: _ :: [] ) ->
                     Just
                         { info =
                             { message = qualifiedToString ( [ "Tuple" ], "mapBoth" ) ++ " before " ++ qualifiedToString checkInfo.later.fn ++ " is the same as " ++ qualifiedToString partConfig.mapFn

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -266,8 +266,20 @@ Destructuring using case expressions
     Tuple.first ( a, b )
     --> a
 
+    Tuple.first (Tuple.mapSecond changeFirst tuple)
+    --> Tuple.first tuple
+
+    Tuple.first (Tuple.mapBoth changeFirst changeSecond tuple)
+    --> Tuple.first (Tuple.mapFirst changeFirst tuple)
+
     Tuple.second ( a, b )
     --> b
+
+    Tuple.second (Tuple.mapFirst changeSecond tuple)
+    --> Tuple.second tuple
+
+    Tuple.second (Tuple.mapBoth changeFirst changeSecond tuple)
+    --> Tuple.second (Tuple.mapSecond changeSecond tuple)
 
 
 ### Strings
@@ -4457,66 +4469,220 @@ tuplePairChecks checkInfo =
 
 tupleFirstChecks : CheckInfo -> Maybe (Error {})
 tupleFirstChecks checkInfo =
-    tuplePartChecks { access = .first, description = "first" } checkInfo
+    tuplePartChecks
+        { part = TupleFirst
+        , description = "first"
+        , mapUnrelatedFn = ( [ "Tuple" ], "mapSecond" )
+        , mapFn = ( [ "Tuple" ], "mapFirst" )
+        }
+        checkInfo
 
 
 tupleFirstCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 tupleFirstCompositionChecks checkInfo =
-    case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
-        ( ( [ "Tuple" ], "pair" ), first :: [] ) ->
-            Just
-                { info =
-                    { message = qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in that first part"
-                    , details = [ "You can replace this call by always with the first argument given to " ++ qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ "." ]
-                    }
-                , fix =
-                    replaceBySubExpressionFix checkInfo.earlier.range first
-                        ++ [ Fix.insertAt checkInfo.earlier.range.start
-                                (qualifiedToString (qualify ( [ "Basics" ], "always" ) checkInfo) ++ " ")
-                           , Fix.removeRange checkInfo.later.removeRange
-                           ]
+    firstThatConstructsJust
+        [ \() ->
+            tuplePartCompositionChecks
+                { part = TupleFirst
+                , description = "first"
+                , mapUnrelatedFn = ( [ "Tuple" ], "mapSecond" )
+                , mapFn = ( [ "Tuple" ], "mapFirst" )
                 }
+                checkInfo
+        , \() ->
+            case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
+                ( ( [ "Tuple" ], "pair" ), first :: [] ) ->
+                    Just
+                        { info =
+                            { message = qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in that first part"
+                            , details = [ "You can replace this call by always with the first argument given to " ++ qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ "." ]
+                            }
+                        , fix =
+                            replaceBySubExpressionFix checkInfo.earlier.range first
+                                ++ [ Fix.insertAt checkInfo.earlier.range.start
+                                        (qualifiedToString (qualify ( [ "Basics" ], "always" ) checkInfo) ++ " ")
+                                   , Fix.removeRange checkInfo.later.removeRange
+                                   ]
+                        }
 
-        _ ->
-            Nothing
+                _ ->
+                    Nothing
+        ]
+        ()
 
 
 tupleSecondChecks : CheckInfo -> Maybe (Error {})
 tupleSecondChecks checkInfo =
-    tuplePartChecks { access = .second, description = "second" } checkInfo
+    tuplePartChecks
+        { part = TupleSecond
+        , description = "second"
+        , mapFn = ( [ "Tuple" ], "mapSecond" )
+        , mapUnrelatedFn = ( [ "Tuple" ], "mapFirst" )
+        }
+        checkInfo
 
 
 tupleSecondCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 tupleSecondCompositionChecks checkInfo =
-    case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
-        ( ( [ "Tuple" ], "pair" ), _ :: [] ) ->
-            Just
-                (compositionAlwaysReturnsIncomingError
-                    (qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in the incoming second part")
-                    checkInfo
-                )
+    firstThatConstructsJust
+        [ \() ->
+            tuplePartCompositionChecks
+                { part = TupleSecond
+                , description = "second"
+                , mapFn = ( [ "Tuple" ], "mapSecond" )
+                , mapUnrelatedFn = ( [ "Tuple" ], "mapFirst" )
+                }
+                checkInfo
+        , \() ->
+            case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
+                ( ( [ "Tuple" ], "pair" ), _ :: [] ) ->
+                    Just
+                        (compositionAlwaysReturnsIncomingError
+                            (qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in the incoming second part")
+                            checkInfo
+                        )
 
-        _ ->
-            Nothing
+                _ ->
+                    Nothing
+        ]
+        ()
+
+
+type TuplePart
+    = TupleFirst
+    | TupleSecond
 
 
 tuplePartChecks :
-    { access : { first : Node Expression, second : Node Expression } -> Node Expression
+    { part : TuplePart
     , description : String
+    , mapFn : ( ModuleName, String )
+    , mapUnrelatedFn : ( ModuleName, String )
     }
     -> CheckInfo
     -> Maybe (Error {})
 tuplePartChecks partConfig checkInfo =
-    Maybe.map
-        (\tuple ->
-            Rule.errorWithFix
-                { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on a known tuple will result in the tuple's " ++ partConfig.description ++ " part"
-                , details = [ "You can replace this call by the tuple's " ++ partConfig.description ++ " part." ]
-                }
-                checkInfo.fnRange
-                (replaceBySubExpressionFix checkInfo.parentRange (tuple |> partConfig.access))
-        )
-        (AstHelpers.getTuple2 checkInfo.firstArg checkInfo.lookupTable)
+    firstThatConstructsJust
+        [ \() ->
+            Maybe.map
+                (\tuple ->
+                    Rule.errorWithFix
+                        { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on a known tuple will result in the tuple's " ++ partConfig.description ++ " part"
+                        , details = [ "You can replace this call by the tuple's " ++ partConfig.description ++ " part." ]
+                        }
+                        checkInfo.fnRange
+                        (replaceBySubExpressionFix checkInfo.parentRange
+                            (case partConfig.part of
+                                TupleFirst ->
+                                    tuple.first
+
+                                TupleSecond ->
+                                    tuple.second
+                            )
+                        )
+                )
+                (AstHelpers.getTuple2 checkInfo.firstArg checkInfo.lookupTable)
+        , \() ->
+            case AstHelpers.getSpecificFunctionCall partConfig.mapUnrelatedFn checkInfo.lookupTable checkInfo.firstArg of
+                Just mapSecondCall ->
+                    case mapSecondCall.argsAfterFirst of
+                        unmappedTuple :: [] ->
+                            Just
+                                (Rule.errorWithFix
+                                    { message = "Unnecessary " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " before " ++ qualifiedToString checkInfo.fn
+                                    , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " call by the unchanged tuple." ]
+                                    }
+                                    checkInfo.fnRange
+                                    (keepOnlyFix { parentRange = mapSecondCall.nodeRange, keep = Node.range unmappedTuple })
+                                )
+
+                        _ ->
+                            Nothing
+
+                Nothing ->
+                    Nothing
+        , \() ->
+            case AstHelpers.getSpecificFunctionCall ( [ "Tuple" ], "mapBoth" ) checkInfo.lookupTable checkInfo.firstArg of
+                Just tupleMapBothCall ->
+                    case tupleMapBothCall.argsAfterFirst of
+                        secondMapperArg :: tuple :: [] ->
+                            Just
+                                (Rule.errorWithFix
+                                    { message = qualifiedToString ( [ "Tuple" ], "mapBoth" ) ++ " before " ++ qualifiedToString checkInfo.fn ++ " is the same as " ++ qualifiedToString partConfig.mapFn
+                                    , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString ( [ "Tuple" ], "mapBoth" ) ++ " call by " ++ qualifiedToString partConfig.mapFn ++ " with the same " ++ partConfig.description ++ " mapping and tuple." ]
+                                    }
+                                    checkInfo.fnRange
+                                    (case partConfig.part of
+                                        TupleFirst ->
+                                            Fix.replaceRangeBy tupleMapBothCall.fnRange
+                                                (qualifiedToString (qualify partConfig.mapFn checkInfo))
+                                                :: keepOnlyFix
+                                                    { parentRange = Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg, Node.range secondMapperArg ]
+                                                    , keep = Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg ]
+                                                    }
+
+                                        TupleSecond ->
+                                            [ Fix.replaceRangeBy (Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg ])
+                                                (qualifiedToString (qualify partConfig.mapFn checkInfo))
+                                            ]
+                                    )
+                                )
+
+                        _ ->
+                            Nothing
+
+                Nothing ->
+                    Nothing
+        ]
+        ()
+
+
+tuplePartCompositionChecks :
+    { part : TuplePart, description : String, mapFn : ( ModuleName, String ), mapUnrelatedFn : ( ModuleName, String ) }
+    -> CompositionIntoCheckInfo
+    -> Maybe ErrorInfoAndFix
+tuplePartCompositionChecks partConfig checkInfo =
+    firstThatConstructsJust
+        [ \() ->
+            if checkInfo.earlier.fn == partConfig.mapUnrelatedFn then
+                Just
+                    { info =
+                        { message = "Unnecessary " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " before " ++ qualifiedToString checkInfo.later.fn
+                        , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can remove the " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " call." ]
+                        }
+                    , fix = [ Fix.removeRange checkInfo.earlier.removeRange ]
+                    }
+
+            else
+                Nothing
+        , \() ->
+            case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
+                ( ( [ "Tuple" ], "mapBoth" ), firstMapperArg :: secondMapperArg :: [] ) ->
+                    Just
+                        { info =
+                            { message = qualifiedToString ( [ "Tuple" ], "mapBoth" ) ++ " before " ++ qualifiedToString checkInfo.later.fn ++ " is the same as " ++ qualifiedToString partConfig.mapFn
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString ( [ "Tuple" ], "mapBoth" ) ++ " call by " ++ qualifiedToString partConfig.mapFn ++ " with the same " ++ partConfig.description ++ " mapping." ]
+                            }
+                        , fix =
+                            case partConfig.part of
+                                TupleFirst ->
+                                    Fix.replaceRangeBy checkInfo.earlier.fnRange
+                                        (qualifiedToString (qualify partConfig.mapFn checkInfo))
+                                        :: keepOnlyFix
+                                            { parentRange = checkInfo.earlier.range
+                                            , keep = Range.combine [ checkInfo.earlier.fnRange, Node.range firstMapperArg ]
+                                            }
+
+                                TupleSecond ->
+                                    [ Fix.replaceRangeBy (Range.combine [ checkInfo.earlier.fnRange, Node.range firstMapperArg ])
+                                        (qualifiedToString (qualify partConfig.mapFn checkInfo))
+                                    ]
+                        }
+
+                _ ->
+                    Nothing
+        ]
+        ()
 
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15138,6 +15138,70 @@ a = Tuple.first << (first |> f |> Tuple.pair)
 a = always (first |> f)
 """
                         ]
+        , test "should replace Tuple.mapSecond changeSecond tuple |> Tuple.first by tuple |> Tuple.first" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.mapSecond changeSecond tuple |> Tuple.first
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Tuple.mapSecond before Tuple.first"
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapSecond call by the unchanged tuple." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = tuple |> Tuple.first
+"""
+                        ]
+        , test "should replace Tuple.first << Tuple.mapSecond changeSecond by Tuple.first" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.first << Tuple.mapSecond changeSecond
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Tuple.mapSecond before Tuple.first"
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can remove the Tuple.mapSecond call." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Tuple.first
+"""
+                        ]
+        , test "should replace Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.first by Tuple.mapFirst changeFirst tuple |> Tuple.first" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.first
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.mapBoth before Tuple.first is the same as Tuple.mapFirst"
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapBoth call by Tuple.mapFirst with the same first mapping and tuple." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Tuple.mapFirst changeFirst tuple |> Tuple.first
+"""
+                        ]
+        , test "should replace Tuple.first << Tuple.mapBoth changeFirst changeSecond by Tuple.first << Tuple.mapFirst changeFirst" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.first << Tuple.mapBoth changeFirst changeSecond
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.mapBoth before Tuple.first is the same as Tuple.mapFirst"
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapBoth call by Tuple.mapFirst with the same first mapping." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Tuple.first << Tuple.mapFirst changeFirst
+"""
+                        ]
         ]
 
 
@@ -15198,6 +15262,70 @@ a = Tuple.second << (second |> f |> Tuple.pair)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = identity
+"""
+                        ]
+        , test "should replace Tuple.mapFirst changeSecond tuple |> Tuple.second by tuple |> Tuple.second" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.mapFirst changeSecond tuple |> Tuple.second
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Tuple.mapFirst before Tuple.second"
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapFirst call by the unchanged tuple." ]
+                            , under = "Tuple.second"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = tuple |> Tuple.second
+"""
+                        ]
+        , test "should replace Tuple.second << Tuple.mapFirst changeSecond by Tuple.second" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.second << Tuple.mapFirst changeSecond
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Tuple.mapFirst before Tuple.second"
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can remove the Tuple.mapFirst call." ]
+                            , under = "Tuple.second"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Tuple.second
+"""
+                        ]
+        , test "should replace Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.second by Tuple.mapFirst changeFirst tuple |> Tuple.second" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.second
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.mapBoth before Tuple.second is the same as Tuple.mapSecond"
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapBoth call by Tuple.mapSecond with the same second mapping and tuple." ]
+                            , under = "Tuple.second"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Tuple.mapSecond changeSecond tuple |> Tuple.second
+"""
+                        ]
+        , test "should replace Tuple.second << Tuple.mapBoth changeFirst changeSecond by Tuple.second << Tuple.mapSecond changeSecond" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.second << Tuple.mapBoth changeFirst changeSecond
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Tuple.mapBoth before Tuple.second is the same as Tuple.mapSecond"
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapBoth call by Tuple.mapSecond with the same second mapping." ]
+                            , under = "Tuple.second"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Tuple.second << Tuple.mapSecond changeSecond
 """
                         ]
         ]


### PR DESCRIPTION
```elm
Tuple.first (Tuple.mapSecond changeFirst tuple)
--> Tuple.first tuple

Tuple.first (Tuple.mapBoth changeFirst changeSecond tuple)
--> Tuple.first (Tuple.mapFirst changeFirst tuple)

Tuple.second (Tuple.mapFirst changeSecond tuple)
--> Tuple.second tuple

Tuple.second (Tuple.mapBoth changeFirst changeSecond tuple)
--> Tuple.second (Tuple.mapSecond changeSecond tuple)
```
including composition checks.

Note that this PR doesn't include e.g.
```elm
Tuple.second (Tuple.mapSecond changeSecond tuple)
--> changeSecond (Tuple.first tuple)
```
as I'm still a bit unsure how to fix it.