### PR TITLE
Add withDefault on wrap composition simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - `Tuple.first (Tuple.mapBoth changeFirst changeSecond tuple)` to `Tuple.first (Tuple.mapFirst changeFirst tuple)`
 - `Tuple.second (Tuple.mapFirst changeSecond tuple)` to `Tuple.second tuple`
 - `Tuple.second (Tuple.mapBoth changeFirst changeSecond tuple)` to `Tuple.second (Tuple.mapSecond changeSecond tuple)`
+- `Maybe.withDefault a << Just` to `identity`
+- `Result.withDefault a << Ok` to `identity`
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2877,10 +2877,12 @@ compositionIntoChecks =
         , ( ( [ "Tuple" ], "first" ), tupleFirstCompositionChecks )
         , ( ( [ "Tuple" ], "second" ), tupleSecondCompositionChecks )
         , ( ( [ "Maybe" ], "map" ), maybeMapCompositionChecks )
+        , ( ( [ "Maybe" ], "withDefault" ), wrapperWithDefaultChecks maybeWithJustAsWrap )
         , ( ( [ "Result" ], "map" ), resultMapCompositionChecks )
         , ( ( [ "Result" ], "mapError" ), resultMapErrorCompositionChecks )
         , ( ( [ "Result" ], "toMaybe" ), resultToMaybeCompositionChecks )
         , ( ( [ "Result" ], "fromMaybe" ), wrapperFromMaybeCompositionChecks resultWithOkAsWrap )
+        , ( ( [ "Result" ], "withDefault" ), wrapperWithDefaultChecks resultWithOkAsWrap )
         , ( ( [ "List" ], "reverse" ), listReverseCompositionChecks )
         , ( ( [ "List" ], "sort" ), listSortCompositionChecks )
         , ( ( [ "List" ], "sortBy" ), listSortByCompositionChecks )
@@ -9083,6 +9085,20 @@ withDefaultChecks emptiable checkInfo =
                 (secondArg checkInfo)
         ]
         ()
+
+
+wrapperWithDefaultChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+wrapperWithDefaultChecks wrapper checkInfo =
+    case ( checkInfo.earlier.fn == wrapper.wrap.fn, checkInfo.later.args ) of
+        ( True, _ :: [] ) ->
+            Just
+                (compositionAlwaysReturnsIncomingError
+                    (qualifiedToString checkInfo.later.fn ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will always result in the value inside")
+                    checkInfo
+                )
+
+        _ ->
+            Nothing
 
 
 emptiableWithDefaultChecks :

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -18134,6 +18134,7 @@ maybeWithDefaultTests =
             \() ->
                 """module A exposing (..)
 a = Maybe.withDefault x y
+b = Maybe.withDefault << Just
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -18215,6 +18216,22 @@ a = y |> Just |> Maybe.withDefault x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = y
+"""
+                        ]
+        , test "should replace Maybe.withDefault a << Just by identity" <|
+            \() ->
+                """module A exposing (..)
+a = Maybe.withDefault b << Just
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Maybe.withDefault on a just maybe will always result in the value inside"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "Maybe.withDefault"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
 """
                         ]
         ]
@@ -19216,6 +19233,7 @@ resultWithDefaultTests =
             \() ->
                 """module A exposing (..)
 a = Result.withDefault x y
+b = Result.withDefault << Ok
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -19297,6 +19315,22 @@ a = y |> Ok |> Result.withDefault x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = y
+"""
+                        ]
+        , test "should replace Result.withDefault a << Ok by identity" <|
+            \() ->
+                """module A exposing (..)
+a = Result.withDefault b << Ok
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Result.withDefault on an okay result will always result in the value inside"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "Result.withDefault"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
 """
                         ]
         ]


### PR DESCRIPTION
2 simple `withDefault` composition checks
```elm
Maybe.withDefault a << Just
--> identity

Result.withDefault a << Ok
--> identity
```
\+ a new helper that makes adding similar checks easy.