### PR TITLE
More "on wrap always returns incoming" composition checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 - `Tuple.second (Tuple.mapBoth changeFirst changeSecond tuple)` to `Tuple.second (Tuple.mapSecond changeSecond tuple)`
 - `Maybe.withDefault a << Just` to `identity`
 - `Result.withDefault a << Ok` to `identity`
+- `List.sum << List.singleton` to `identity`
+- `List.product << List.singleton` to `identity`
+- `List.concat << List.singleton` to `identity`
+- `Platform.Cmd.batch << List.singleton` to `identity`
+- `Platform.Sub.batch << List.singleton` to `identity`
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9089,7 +9089,7 @@ withDefaultChecks emptiable checkInfo =
 
 wrapperWithDefaultChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 wrapperWithDefaultChecks wrapper checkInfo =
-    onWrapperAlwaysReturnsIncomingCompositionCheck { operationArgCount = 2 } wrapper checkInfo
+    onWrapAlwaysReturnsIncomingCompositionCheck { operationArgCount = 2 } wrapper checkInfo
 
 
 emptiableWithDefaultChecks :
@@ -9535,7 +9535,7 @@ For example
 
     Cmd.batch [ a ] --> a
 
-Use together with `onWrapperAlwaysReturnsIncomingCompositionCheck`
+Use together with `onWrapAlwaysReturnsIncomingCompositionCheck`
 
 -}
 callOnWrapReturnsItsValue :
@@ -9577,8 +9577,8 @@ For example
 Use together with `callOnWrapReturnsItsValue`.
 
 -}
-onWrapperAlwaysReturnsIncomingCompositionCheck : { operationArgCount : Int } -> WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-onWrapperAlwaysReturnsIncomingCompositionCheck config wrapper checkInfo =
+onWrapAlwaysReturnsIncomingCompositionCheck : { operationArgCount : Int } -> WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+onWrapAlwaysReturnsIncomingCompositionCheck config wrapper checkInfo =
     if (checkInfo.earlier.fn == wrapper.wrap.fn) && (List.length checkInfo.later.args == (config.operationArgCount - 1)) then
         Just
             (compositionAlwaysReturnsIncomingError

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9582,7 +9582,7 @@ onWrapAlwaysReturnsIncomingCompositionCheck config wrapper checkInfo =
     if (checkInfo.earlier.fn == wrapper.wrap.fn) && (List.length checkInfo.later.args == (config.operationArgCount - 1)) then
         Just
             (compositionAlwaysReturnsIncomingError
-                (qualifiedToString checkInfo.later.fn ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will always result in the value inside")
+                (qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will always result in the value inside")
                 checkInfo
             )
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8193,6 +8193,22 @@ a = [ b ] |> List.concat
 a = b
 """
                         ]
+        , test "should replace List.concat << List.singleton by identity" <|
+            \() ->
+                """module A exposing (..)
+a = List.concat << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.concat on a singleton list will always result in the value inside"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "List.concat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
         , test "should report List.concat that only contains list literals" <|
             \() ->
                 """module A exposing (..)
@@ -10650,6 +10666,22 @@ a = List.sum [ a ]
 a = a
 """
                         ]
+        , test "should replace List.sum << List.singleton by identity" <|
+            \() ->
+                """module A exposing (..)
+a = List.sum << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.sum on a singleton list will always result in the value inside"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "List.sum"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
         ]
 
 
@@ -10702,6 +10734,22 @@ a = List.product [ a ]
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = a
+"""
+                        ]
+        , test "should replace List.product << List.singleton by identity" <|
+            \() ->
+                """module A exposing (..)
+a = List.product << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.product on a singleton list will always result in the value inside"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "List.product"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
 """
                         ]
         ]
@@ -22715,6 +22763,22 @@ a = Cmd.batch [ b ]
 a = b
 """
                         ]
+        , test "should replace Cmd.batch << List.singleton by identity" <|
+            \() ->
+                """module A exposing (..)
+a = Cmd.batch << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Cmd.batch on a singleton list will always result in the value inside"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "Cmd.batch"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
         , test "should replace Cmd.batch [ b, Cmd.none ] by Cmd.batch [ b ]" <|
             \() ->
                 """module A exposing (..)
@@ -22876,6 +22940,22 @@ a = Sub.batch [ f n ]
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (f n)
+"""
+                        ]
+        , test "should replace Sub.batch << List.singleton by identity" <|
+            \() ->
+                """module A exposing (..)
+a = Sub.batch << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Sub.batch on a singleton list will always result in the value inside"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "Sub.batch"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
 """
                         ]
         , test "should replace Sub.batch [ b, Sub.none ] by Sub.batch []" <|


### PR DESCRIPTION
Free simplifications enabled by the recently added `onWrapAlwaysReturnsIncomingCompositionCheck`
```elm
List.sum << List.singleton --> identity
List.product << List.singleton --> identity
List.concat << List.singleton --> identity
Platform.Cmd.batch << List.singleton --> identity
Platform.Sub.batch << List.singleton --> identity
```