### PR TITLE
Add Array.foldl/r simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@
 - `List.maximum << List.singleton` to `Just`
 - `Maybe.map2 f firstMaybe Nothing` to `Nothing` (same for all Maybe.mapN)
 - `Maybe.map2 f (Just a) (Just b)` to `Just (f a b)` (same for all Maybe.mapN)
+- `Array.foldl f initial Array.empty` to `initial` (same for `Array.foldr`)
+- `Array.foldl (\_ soFar -> soFar) initial array` to `initial` (same for `Array.foldr`)
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -846,6 +846,13 @@ Destructuring using case expressions
     Array.set 100 x (Array.fromList [ a, b, c ])
     --> Array.fromList [ a, b, c ]
 
+    -- The following simplifications for Array.foldl also work for Array.foldr
+    Array.foldl f initial Array.empty
+    --> initial
+
+    Array.foldl (\_ soFar -> soFar) initial array
+    --> initial
+
 
 ### Sets
 
@@ -2656,6 +2663,8 @@ functionCallChecks =
         , ( ( [ "Array" ], "append" ), ( 2, collectionUnionChecks arrayCollection ) )
         , ( ( [ "Array" ], "get" ), ( 2, getChecks arrayCollection ) )
         , ( ( [ "Array" ], "set" ), ( 3, setChecks arrayCollection ) )
+        , ( ( [ "Array" ], "foldl" ), ( 3, arrayFoldlChecks ) )
+        , ( ( [ "Array" ], "foldr" ), ( 3, arrayFoldrChecks ) )
         , ( ( [ "Set" ], "map" ), ( 2, emptiableMapChecks setCollection ) )
         , ( ( [ "Set" ], "filter" ), ( 2, emptiableFilterChecks setCollection ) )
         , ( ( [ "Set" ], "remove" ), ( 2, collectionRemoveChecks setCollection ) )
@@ -6578,6 +6587,16 @@ arrayLengthOnArrayRepeatOrInitializeChecks checkInfo =
 
         Nothing ->
             Nothing
+
+
+arrayFoldlChecks : CheckInfo -> Maybe (Error {})
+arrayFoldlChecks checkInfo =
+    emptiableFoldChecks arrayCollection checkInfo
+
+
+arrayFoldrChecks : CheckInfo -> Maybe (Error {})
+arrayFoldrChecks checkInfo =
+    emptiableFoldChecks arrayCollection checkInfo
 
 
 getChecks : EmptiableProperties (IndexableProperties otherProperties) -> CheckInfo -> Maybe (Error {})

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15430,6 +15430,8 @@ arrayTests =
         , arrayAppendTests
         , arrayGetTests
         , arraySetTests
+        , arrayFoldlTests
+        , arrayFoldrTests
         ]
 
 
@@ -17651,6 +17653,184 @@ a = Array.set 100 x (Array.fromList [ b, c, d ])
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array
 a = (Array.fromList [ b, c, d ])
+"""
+                        ]
+        ]
+
+
+arrayFoldlTests : Test
+arrayFoldlTests =
+    describe "Array.foldl"
+        [ test "should not report Array.foldl used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldl
+b = Array.foldl (\\el soFar -> soFar - el)
+c = Array.foldl (\\el soFar -> soFar - el) 20
+d = Array.foldl (\\el soFar -> soFar - el) 20 array
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Array.foldl f initial Array.empty by initial" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldl f initial Array.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.foldl on Array.empty will always return the same given initial accumulator"
+                            , details = [ "You can replace this call by the initial accumulator itself." ]
+                            , under = "Array.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = initial
+"""
+                        ]
+        , test "should replace Array.foldl (always identity) initial array by initial" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldl (always identity) initial array
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.foldl with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by the given initial accumulator." ]
+                            , under = "Array.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = initial
+"""
+                        ]
+        , test "should replace Array.foldl (always identity) initial by always initial" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldl (always identity) initial
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.foldl with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by `always` with the given initial accumulator." ]
+                            , under = "Array.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always initial
+"""
+                        ]
+        , test "should replace Array.foldl (always identity) by always" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldl (always identity)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.foldl with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by `always` because the incoming accumulator will be returned, no matter which array is supplied next." ]
+                            , under = "Array.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always
+"""
+                        ]
+        ]
+
+
+arrayFoldrTests : Test
+arrayFoldrTests =
+    describe "Array.foldr"
+        [ test "should not report Array.foldr used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldr
+b = Array.foldr (\\el soFar -> soFar - el)
+c = Array.foldr (\\el soFar -> soFar - el) 20
+d = Array.foldr (\\el soFar -> soFar - el) 20 array
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Array.foldr f initial Array.empty by initial" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldr f initial Array.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.foldr on Array.empty will always return the same given initial accumulator"
+                            , details = [ "You can replace this call by the initial accumulator itself." ]
+                            , under = "Array.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = initial
+"""
+                        ]
+        , test "should replace Array.foldr (always identity) initial array by initial" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldr (always identity) initial array
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.foldr with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by the given initial accumulator." ]
+                            , under = "Array.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = initial
+"""
+                        ]
+        , test "should replace Array.foldr (always identity) initial by always initial" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldr (always identity) initial
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.foldr with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by `always` with the given initial accumulator." ]
+                            , under = "Array.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always initial
+"""
+                        ]
+        , test "should replace Array.foldr (always identity) by always" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.foldr (always identity)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.foldr with a function that always returns the unchanged accumulator will result in the initial accumulator"
+                            , details = [ "You can replace this call by `always` because the incoming accumulator will be returned, no matter which array is supplied next." ]
+                            , under = "Array.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always
 """
                         ]
         ]


### PR DESCRIPTION
Add `Array.foldl` and `foldr` simplifications listed in #174
```elm
-- The following simplifications for Array.foldl also work for Array.foldr
Array.foldl f initial Array.empty
--> initial

Array.foldl (\_ soFar -> soFar) initial array
--> initial
```