### PR TITLE
Simplify existing checks using `fullyAppliedLastArg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 - `Array.toIndexedList Array.empty` to `[]`
 - `List.map Tuple.second (Array.toIndexedList array)` to `Array.toList array`
 
+Bug fixes:
+- Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`
+- Fixed an issue where `Set.intersect Set.empty` would be fixed to `Set.empty`
+
 ## [2.1.2] - 2023-09-28
 
 Lots of new simplifications, especially for `Array` and `Task`.

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4805,7 +4805,7 @@ stringReverseChecks : CheckInfo -> Maybe (Error {})
 stringReverseChecks checkInfo =
     firstThatConstructsJust
         [ \() -> emptiableReverseChecks stringCollection checkInfo
-        , \() -> callOnWrappedDoesNotChangeItCheck checkInfo.firstArg stringCollection checkInfo
+        , \() -> callOnWrappedDoesNotChangeItCheck stringCollection checkInfo
         ]
         ()
 
@@ -5442,13 +5442,7 @@ listIntersperseChecks : CheckInfo -> Maybe (Error {})
 listIntersperseChecks checkInfo =
     firstThatConstructsJust
         [ \() -> callOnEmptyReturnsEmptyCheck listCollection checkInfo
-        , \() ->
-            case secondArg checkInfo of
-                Just listArg ->
-                    callOnWrappedDoesNotChangeItCheck listArg listCollection checkInfo
-
-                Nothing ->
-                    Nothing
+        , \() -> callOnWrappedDoesNotChangeItCheck listCollection checkInfo
         ]
         ()
 
@@ -6791,7 +6785,7 @@ listReverseChecks : CheckInfo -> Maybe (Error {})
 listReverseChecks checkInfo =
     firstThatConstructsJust
         [ \() -> emptiableReverseChecks listCollection checkInfo
-        , \() -> callOnWrappedDoesNotChangeItCheck checkInfo.firstArg listCollection checkInfo
+        , \() -> callOnWrappedDoesNotChangeItCheck listCollection checkInfo
         ]
         ()
 
@@ -6809,7 +6803,7 @@ listSortChecks : CheckInfo -> Maybe (Error {})
 listSortChecks checkInfo =
     firstThatConstructsJust
         [ \() -> callOnEmptyReturnsEmptyCheck listCollection checkInfo
-        , \() -> callOnWrappedDoesNotChangeItCheck checkInfo.firstArg listCollection checkInfo
+        , \() -> callOnWrappedDoesNotChangeItCheck listCollection checkInfo
         , \() -> operationDoesNotChangeResultOfOperationCheck checkInfo
         ]
         ()
@@ -6918,13 +6912,7 @@ listSortByChecks : CheckInfo -> Maybe (Error {})
 listSortByChecks checkInfo =
     firstThatConstructsJust
         [ \() -> callOnEmptyReturnsEmptyCheck listCollection checkInfo
-        , \() ->
-            case secondArg checkInfo of
-                Just listArg ->
-                    callOnWrappedDoesNotChangeItCheck listArg listCollection checkInfo
-
-                Nothing ->
-                    Nothing
+        , \() -> callOnWrappedDoesNotChangeItCheck listCollection checkInfo
         , \() ->
             case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
                 Just _ ->
@@ -6953,13 +6941,7 @@ listSortWithChecks : CheckInfo -> Maybe (Error {})
 listSortWithChecks checkInfo =
     firstThatConstructsJust
         [ \() -> callOnEmptyReturnsEmptyCheck listCollection checkInfo
-        , \() ->
-            case secondArg checkInfo of
-                Just listArg ->
-                    callOnWrappedDoesNotChangeItCheck listArg listCollection checkInfo
-
-                Nothing ->
-                    Nothing
+        , \() -> callOnWrappedDoesNotChangeItCheck listCollection checkInfo
         , \() ->
             let
                 alwaysAlwaysOrder : Maybe Order
@@ -9465,14 +9447,18 @@ compositionAfterWrapIsUnnecessaryCheck wrapper checkInfo =
         Nothing
 
 
-callOnWrappedDoesNotChangeItCheck : Node Expression -> WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
-callOnWrappedDoesNotChangeItCheck wrapperArg wrapper checkInfo =
-    callOnDoesNotChangeItCheck
-        { description = wrapper.wrap.description
-        , is = \lookupTable expr -> isJust (wrapper.wrap.getValue lookupTable expr)
-        }
-        wrapperArg
-        checkInfo
+callOnWrappedDoesNotChangeItCheck : WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
+callOnWrappedDoesNotChangeItCheck wrapper checkInfo =
+    Maybe.andThen
+        (\wrapperArg ->
+            callOnDoesNotChangeItCheck
+                { description = wrapper.wrap.description
+                , is = \lookupTable expr -> isJust (wrapper.wrap.getValue lookupTable expr)
+                }
+                wrapperArg
+                checkInfo
+        )
+        (fullyAppliedLastArg checkInfo)
 
 
 callOnDoesNotChangeItCheck :

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6141,11 +6141,6 @@ listAllChecks checkInfo =
 
 emptiableAllChecks : EmptiableProperties otherProperties -> CheckInfo -> Maybe (Error {})
 emptiableAllChecks emptiable checkInfo =
-    let
-        maybeEmptiableArg : Maybe (Node Expression)
-        maybeEmptiableArg =
-            secondArg checkInfo
-    in
     firstThatConstructsJust
         [ \() ->
             callOnEmptyReturnsCheck
@@ -6199,21 +6194,12 @@ listAnyChecks checkInfo =
 
 emptiableAnyChecks : EmptiableProperties otherProperties -> CheckInfo -> Maybe (Error {})
 emptiableAnyChecks emptiable checkInfo =
-    let
-        maybeEmptiableArg : Maybe (Node Expression)
-        maybeEmptiableArg =
-            secondArg checkInfo
-    in
     firstThatConstructsJust
         [ \() ->
-            Maybe.andThen
-                (\listArg ->
-                    callOnEmptyReturnsCheck
-                        { resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "False" ) res) }
-                        emptiable
-                        checkInfo
-                )
-                maybeEmptiableArg
+            callOnEmptyReturnsCheck
+                { resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "False" ) res) }
+                emptiable
+                checkInfo
         , \() ->
             case Evaluate.isAlwaysBoolean checkInfo checkInfo.firstArg of
                 Determined False ->
@@ -6638,14 +6624,9 @@ getChecks : EmptiableProperties (IndexableProperties otherProperties) -> CheckIn
 getChecks collection checkInfo =
     firstThatConstructsJust
         [ \() ->
-            case checkInfo.secondArg of
-                Just arg ->
-                    callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString }
-                        collection
-                        checkInfo
-
-                Nothing ->
-                    Nothing
+            callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString }
+                collection
+                checkInfo
         , \() ->
             Evaluate.getInt checkInfo checkInfo.firstArg
                 |> Maybe.andThen (indexAccessChecks collection checkInfo)
@@ -6987,11 +6968,6 @@ listSortWithChecks checkInfo =
 
 listTakeChecks : CheckInfo -> Maybe (Error {})
 listTakeChecks checkInfo =
-    let
-        maybeListArg : Maybe (Node Expression)
-        maybeListArg =
-            secondArg checkInfo
-    in
     firstThatConstructsJust
         [ \() ->
             case Evaluate.getInt checkInfo checkInfo.firstArg of
@@ -9684,11 +9660,6 @@ onWrapAlwaysReturnsJustIncomingCompositionCheck config wrapper checkInfo =
 
 emptiableFilterChecks : EmptiableProperties otherProperties -> CheckInfo -> Maybe (Error {})
 emptiableFilterChecks emptiable checkInfo =
-    let
-        maybeEmptiableArg : Maybe (Node Expression)
-        maybeEmptiableArg =
-            secondArg checkInfo
-    in
     firstThatConstructsJust
         [ \() -> callOnEmptyReturnsEmptyCheck emptiable checkInfo
         , \() ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5214,7 +5214,7 @@ listConcatChecks checkInfo =
     firstThatConstructsJust
         [ \() -> callOnEmptyReturnsEmptyCheck listCollection checkInfo
         , \() -> callOnWrapReturnsItsValue listCollection checkInfo
-        , \() -> irrelevantEmptyElementInGivenListArgCheck checkInfo.firstArg listCollection checkInfo
+        , \() -> callOnListWithIrrelevantEmptyElement checkInfo.firstArg listCollection checkInfo
         , \() ->
             case Node.value checkInfo.firstArg of
                 Expression.ListExpr list ->
@@ -5279,7 +5279,7 @@ listConcatCompositionChecks checkInfo =
         ()
 
 
-irrelevantEmptyElementInGivenListArgCheck :
+callOnListWithIrrelevantEmptyElement :
     Node Expression
     ->
         { otherProperties
@@ -5291,7 +5291,7 @@ irrelevantEmptyElementInGivenListArgCheck :
         }
     -> CheckInfo
     -> Maybe (Error {})
-irrelevantEmptyElementInGivenListArgCheck listArg emptiableElement checkInfo =
+callOnListWithIrrelevantEmptyElement listArg emptiableElement checkInfo =
     case AstHelpers.getListLiteral listArg of
         Just list ->
             case findMapNeighboring (getEmpty checkInfo.lookupTable emptiableElement) list of
@@ -6236,7 +6236,7 @@ listFilterMapChecks checkInfo =
                 case secondArg checkInfo of
                     Just listArg ->
                         firstThatConstructsJust
-                            [ \() -> irrelevantEmptyElementInGivenListArgCheck listArg maybeWithJustAsWrap checkInfo
+                            [ \() -> callOnListWithIrrelevantEmptyElement listArg maybeWithJustAsWrap checkInfo
                             , \() ->
                                 case AstHelpers.getListLiteral listArg of
                                     Just list ->
@@ -7462,7 +7462,7 @@ subAndCmdBatchChecks batchable checkInfo =
     firstThatConstructsJust
         [ \() -> callOnEmptyReturnsCheck { resultAsString = batchable.empty.asString } listCollection checkInfo
         , \() -> callOnWrapReturnsItsValue listCollection checkInfo
-        , \() -> irrelevantEmptyElementInGivenListArgCheck checkInfo.firstArg batchable checkInfo
+        , \() -> callOnListWithIrrelevantEmptyElement checkInfo.firstArg batchable checkInfo
         ]
         ()
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6791,7 +6791,7 @@ listReverseChecks : CheckInfo -> Maybe (Error {})
 listReverseChecks checkInfo =
     firstThatConstructsJust
         [ \() -> emptiableReverseChecks listCollection checkInfo
-        , \() -> callOnSingletonListDoesNotChangeItCheck checkInfo.firstArg checkInfo
+        , \() -> callOnWrappedDoesNotChangeItCheck checkInfo.firstArg listCollection checkInfo
         ]
         ()
 
@@ -6809,7 +6809,7 @@ listSortChecks : CheckInfo -> Maybe (Error {})
 listSortChecks checkInfo =
     firstThatConstructsJust
         [ \() -> callOnEmptyReturnsEmptyCheck listCollection checkInfo
-        , \() -> callOnSingletonListDoesNotChangeItCheck checkInfo.firstArg checkInfo
+        , \() -> callOnWrappedDoesNotChangeItCheck checkInfo.firstArg listCollection checkInfo
         , \() -> operationDoesNotChangeResultOfOperationCheck checkInfo
         ]
         ()
@@ -6921,7 +6921,7 @@ listSortByChecks checkInfo =
         , \() ->
             case secondArg checkInfo of
                 Just listArg ->
-                    callOnSingletonListDoesNotChangeItCheck listArg checkInfo
+                    callOnWrappedDoesNotChangeItCheck listArg listCollection checkInfo
 
                 Nothing ->
                     Nothing
@@ -6956,7 +6956,7 @@ listSortWithChecks checkInfo =
         , \() ->
             case secondArg checkInfo of
                 Just listArg ->
-                    callOnSingletonListDoesNotChangeItCheck listArg checkInfo
+                    callOnWrappedDoesNotChangeItCheck listArg listCollection checkInfo
 
                 Nothing ->
                     Nothing
@@ -9463,11 +9463,6 @@ compositionAfterWrapIsUnnecessaryCheck wrapper checkInfo =
 
     else
         Nothing
-
-
-callOnSingletonListDoesNotChangeItCheck : Node Expression -> CheckInfo -> Maybe (Error {})
-callOnSingletonListDoesNotChangeItCheck listArg checkInfo =
-    callOnWrappedDoesNotChangeItCheck listArg listCollection checkInfo
 
 
 callOnWrappedDoesNotChangeItCheck : Node Expression -> WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4738,7 +4738,7 @@ stringFromListChecks : CheckInfo -> Maybe (Error {})
 stringFromListChecks checkInfo =
     firstThatConstructsJust
         [ \() ->
-            callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> emptyStringAsString }
+            callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString }
                 listCollection
                 checkInfo
         , \() -> wrapperFromListSingletonChecks stringCollection checkInfo
@@ -4759,7 +4759,7 @@ stringFromListCompositionChecks checkInfo =
 stringConcatChecks : CheckInfo -> Maybe (Error {})
 stringConcatChecks checkInfo =
     firstThatConstructsJust
-        [ \() -> callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> emptyStringAsString } listCollection checkInfo
+        [ \() -> callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection checkInfo
         , \() ->
             groupingOnSpecificFnCallCanBeCombinedCheck
                 { specificFn = ( [ "List" ], "repeat" ), combinedFn = ( [ "String" ], "repeat" ) }
@@ -4789,14 +4789,14 @@ stringConcatCompositionChecks checkInfo =
 
 stringWordsChecks : CheckInfo -> Maybe (Error {})
 stringWordsChecks checkInfo =
-    callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> "[]" }
+    callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString }
         stringCollection
         checkInfo
 
 
 stringLinesChecks : CheckInfo -> Maybe (Error {})
 stringLinesChecks checkInfo =
-    callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> "[]" }
+    callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString }
         stringCollection
         checkInfo
 
@@ -4975,11 +4975,7 @@ stringJoinChecks : CheckInfo -> Maybe (Error {})
 stringJoinChecks checkInfo =
     firstThatConstructsJust
         [ \() ->
-            Maybe.andThen
-                (\listArg ->
-                    callOnEmptyReturnsCheck { on = listArg, resultAsString = \_ -> emptyStringAsString } listCollection checkInfo
-                )
-                (secondArg checkInfo)
+            callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection checkInfo
         , \() ->
             case Node.value checkInfo.firstArg of
                 Expression.Literal "" ->
@@ -5486,7 +5482,7 @@ listHeadChecks checkInfo =
     in
     firstThatConstructsJust
         [ \() ->
-            callOnEmptyReturnsCheck { on = listArg, resultAsString = maybeWithJustAsWrap.empty.asString } listCollection checkInfo
+            callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection checkInfo
         , \() ->
             Maybe.map
                 (\listArgHead ->
@@ -5546,7 +5542,7 @@ listTailChecks checkInfo =
     in
     firstThatConstructsJust
         [ \() ->
-            callOnEmptyReturnsCheck { on = listArg, resultAsString = maybeWithJustAsWrap.empty.asString } listCollection checkInfo
+            callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection checkInfo
         , \() ->
             case Node.value (AstHelpers.removeParens listArg) of
                 Expression.ListExpr ((Node headRange _) :: (Node tailFirstRange _) :: _) ->
@@ -5795,7 +5791,7 @@ listMemberChecks checkInfo =
             firstThatConstructsJust
                 [ \() ->
                     callOnEmptyReturnsCheck
-                        { on = listArg, resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "False" ) res) }
+                        { resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "False" ) res) }
                         listCollection
                         checkInfo
                 , \() ->
@@ -5889,7 +5885,7 @@ listSumChecks : CheckInfo -> Maybe (Error {})
 listSumChecks checkInfo =
     firstThatConstructsJust
         [ \() ->
-            callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> "0" } listCollection checkInfo
+            callOnEmptyReturnsCheck { resultAsString = \_ -> "0" } listCollection checkInfo
         , \() -> callOnWrapReturnsItsValue checkInfo.firstArg listCollection checkInfo
         ]
         ()
@@ -5904,7 +5900,7 @@ listProductChecks : CheckInfo -> Maybe (Error {})
 listProductChecks checkInfo =
     firstThatConstructsJust
         [ \() ->
-            callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> "1" } listCollection checkInfo
+            callOnEmptyReturnsCheck { resultAsString = \_ -> "1" } listCollection checkInfo
         , \() -> callOnWrapReturnsItsValue checkInfo.firstArg listCollection checkInfo
         ]
         ()
@@ -5919,7 +5915,7 @@ listMinimumChecks : CheckInfo -> Maybe (Error {})
 listMinimumChecks checkInfo =
     firstThatConstructsJust
         [ \() ->
-            callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = maybeWithJustAsWrap.empty.asString } listCollection checkInfo
+            callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection checkInfo
         , \() -> callOnWrapReturnsJustItsValue listCollection checkInfo
         ]
         ()
@@ -5934,7 +5930,7 @@ listMaximumChecks : CheckInfo -> Maybe (Error {})
 listMaximumChecks checkInfo =
     firstThatConstructsJust
         [ \() ->
-            callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = maybeWithJustAsWrap.empty.asString } listCollection checkInfo
+            callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection checkInfo
         , \() -> callOnWrapReturnsJustItsValue listCollection checkInfo
         ]
         ()
@@ -6172,14 +6168,10 @@ emptiableAllChecks emptiable checkInfo =
     in
     firstThatConstructsJust
         [ \() ->
-            Maybe.andThen
-                (\listArg ->
-                    callOnEmptyReturnsCheck
-                        { on = listArg, resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "True" ) res) }
-                        emptiable
-                        checkInfo
-                )
-                maybeEmptiableArg
+            callOnEmptyReturnsCheck
+                { resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "True" ) res) }
+                emptiable
+                checkInfo
         , \() ->
             case Evaluate.isAlwaysBoolean checkInfo checkInfo.firstArg of
                 Determined True ->
@@ -6237,7 +6229,7 @@ emptiableAnyChecks emptiable checkInfo =
             Maybe.andThen
                 (\listArg ->
                     callOnEmptyReturnsCheck
-                        { on = listArg, resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "False" ) res) }
+                        { resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "False" ) res) }
                         emptiable
                         checkInfo
                 )
@@ -6539,7 +6531,7 @@ arrayToListCompositionChecks checkInfo =
 
 arrayToIndexedListChecks : CheckInfo -> Maybe (Error {})
 arrayToIndexedListChecks checkInfo =
-    callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = listCollection.empty.asString } arrayCollection checkInfo
+    callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } arrayCollection checkInfo
 
 
 arrayFromListChecks : CheckInfo -> Maybe (Error {})
@@ -6680,7 +6672,7 @@ getChecks collection checkInfo =
         [ \() ->
             case checkInfo.secondArg of
                 Just arg ->
-                    callOnEmptyReturnsCheck { on = arg, resultAsString = maybeWithJustAsWrap.empty.asString }
+                    callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString }
                         collection
                         checkInfo
 
@@ -7357,7 +7349,7 @@ mapNOrFirstEmptyConstructionChecks emptiable checkInfo =
 
 listUnzipChecks : CheckInfo -> Maybe (Error {})
 listUnzipChecks checkInfo =
-    callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> "( [], [] )" } listCollection checkInfo
+    callOnEmptyReturnsCheck { resultAsString = \_ -> "( [], [] )" } listCollection checkInfo
 
 
 setFromListChecks : CheckInfo -> Maybe (Error {})
@@ -7527,9 +7519,7 @@ subAndCmdBatchChecks :
 subAndCmdBatchChecks batchable checkInfo =
     firstThatConstructsJust
         [ \() ->
-            callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = batchable.empty.asString }
-                listCollection
-                checkInfo
+            callOnEmptyReturnsCheck { resultAsString = batchable.empty.asString } listCollection checkInfo
         , \() -> callOnWrapReturnsItsValue checkInfo.firstArg listCollection checkInfo
         , \() -> irrelevantEmptyElementInGivenListArgCheck checkInfo.firstArg batchable checkInfo
         ]
@@ -7688,11 +7678,8 @@ wrapperSequenceChecks wrapper checkInfo =
     firstThatConstructsJust
         [ \() ->
             callOnEmptyReturnsCheck
-                { on = checkInfo.firstArg
-                , resultAsString =
-                    \res ->
-                        qualifiedToString (qualify wrapper.wrap.fn res)
-                            ++ " []"
+                { resultAsString =
+                    \res -> qualifiedToString (qualify wrapper.wrap.fn res) ++ " []"
                 }
                 listCollection
                 checkInfo
@@ -9267,7 +9254,7 @@ unwrapToMaybeChecks emptiableWrapper checkInfo =
         [ \() -> callOnWrapReturnsJustItsValue emptiableWrapper checkInfo
         , \() ->
             callOnEmptyReturnsCheck
-                { on = checkInfo.firstArg, resultAsString = \res -> qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) res) }
+                { resultAsString = \res -> qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) res) }
                 emptiableWrapper
                 checkInfo
         ]
@@ -9603,9 +9590,7 @@ callOnEmptyReturnsEmptyCheck emptiableArg emptiable checkInfo =
 
 
 callOnEmptyReturnsCheck :
-    { on : Node Expression
-    , resultAsString : QualifyResources {} -> String
-    }
+    { resultAsString : QualifyResources {} -> String }
     ->
         { a
             | empty :
@@ -9617,25 +9602,30 @@ callOnEmptyReturnsCheck :
     -> CheckInfo
     -> Maybe (Error {})
 callOnEmptyReturnsCheck config collection checkInfo =
-    if collection.empty.is checkInfo.lookupTable config.on then
-        let
-            resultDescription : String
-            resultDescription =
-                config.resultAsString defaultQualifyResources
-        in
-        Just
-            (Rule.errorWithFix
-                { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on " ++ descriptionForIndefinite collection.empty.description ++ " will result in " ++ resultDescription
-                , details = [ "You can replace this call by " ++ resultDescription ++ "." ]
-                }
-                checkInfo.fnRange
-                [ Fix.replaceRangeBy checkInfo.parentRange
-                    (config.resultAsString (extractQualifyResources checkInfo))
-                ]
-            )
+    case fullyAppliedLastArg checkInfo of
+        Just lastArg ->
+            if collection.empty.is checkInfo.lookupTable lastArg then
+                let
+                    resultDescription : String
+                    resultDescription =
+                        config.resultAsString defaultQualifyResources
+                in
+                Just
+                    (Rule.errorWithFix
+                        { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on " ++ descriptionForIndefinite collection.empty.description ++ " will result in " ++ resultDescription
+                        , details = [ "You can replace this call by " ++ resultDescription ++ "." ]
+                        }
+                        checkInfo.fnRange
+                        [ Fix.replaceRangeBy checkInfo.parentRange
+                            (config.resultAsString (extractQualifyResources checkInfo))
+                        ]
+                    )
 
-    else
-        Nothing
+            else
+                Nothing
+
+        Nothing ->
+            Nothing
 
 
 {-| This operation is equivalent to identity when called on a wrapped value.
@@ -9993,14 +9983,10 @@ collectionInsertChecks collection checkInfo =
 
 collectionMemberChecks : CollectionProperties otherProperties -> CheckInfo -> Maybe (Error {})
 collectionMemberChecks collection checkInfo =
-    Maybe.andThen
-        (\collectionArg ->
-            callOnEmptyReturnsCheck
-                { on = collectionArg, resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "False" ) res) }
-                collection
-                checkInfo
-        )
-        (secondArg checkInfo)
+    callOnEmptyReturnsCheck
+        { resultAsString = \res -> qualifiedToString (qualify ( [ "Basics" ], "False" ) res) }
+        collection
+        checkInfo
 
 
 collectionIsEmptyChecks : CollectionProperties otherProperties -> CheckInfo -> Maybe (Error {})
@@ -10045,10 +10031,7 @@ collectionSizeChecks collection checkInfo =
 
 collectionFromListChecks : CollectionProperties otherProperties -> CheckInfo -> Maybe (Error {})
 collectionFromListChecks collection checkInfo =
-    callOnEmptyReturnsCheck
-        { on = checkInfo.firstArg
-        , resultAsString = collection.empty.asString
-        }
+    callOnEmptyReturnsCheck { resultAsString = collection.empty.asString }
         listCollection
         checkInfo
 
@@ -10100,7 +10083,7 @@ emptiableToListChecks :
     -> CheckInfo
     -> Maybe (Error {})
 emptiableToListChecks collection checkInfo =
-    callOnEmptyReturnsCheck { on = checkInfo.firstArg, resultAsString = \_ -> "[]" } collection checkInfo
+    callOnEmptyReturnsCheck { resultAsString = \_ -> "[]" } collection checkInfo
 
 
 collectionPartitionChecks : CollectionProperties otherProperties -> CheckInfo -> Maybe (Error {})
@@ -10112,17 +10095,10 @@ collectionPartitionChecks collection checkInfo =
     in
     firstThatConstructsJust
         [ \() ->
-            case secondArg checkInfo of
-                Just collectionArg ->
-                    callOnEmptyReturnsCheck
-                        { on = collectionArg
-                        , resultAsString = \res -> "( " ++ collection.empty.asString res ++ ", " ++ collection.empty.asString res ++ " )"
-                        }
-                        collection
-                        checkInfo
-
-                Nothing ->
-                    Nothing
+            callOnEmptyReturnsCheck
+                { resultAsString = \res -> "( " ++ collection.empty.asString res ++ ", " ++ collection.empty.asString res ++ " )" }
+                collection
+                checkInfo
         , \() ->
             case Evaluate.isAlwaysBoolean checkInfo checkInfo.firstArg of
                 Determined True ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9812,7 +9812,17 @@ collectionRemoveChecks collection checkInfo =
 collectionIntersectChecks : CollectionProperties otherProperties -> CheckInfo -> Maybe (Error {})
 collectionIntersectChecks collection checkInfo =
     firstThatConstructsJust
-        [ \() -> callOnEmptyReturnsEmptyCheck checkInfo.firstArg collection checkInfo
+        [ \() ->
+            if collection.empty.is checkInfo.lookupTable checkInfo.firstArg then
+                Just
+                    (alwaysResultsInUnparenthesizedConstantError
+                        (qualifiedToString checkInfo.fn ++ " on " ++ collection.empty.asString defaultQualifyResources)
+                        { replacement = collection.empty.asString }
+                        checkInfo
+                    )
+
+            else
+                Nothing
         , \() ->
             Maybe.andThen
                 (\collectionArg -> callOnEmptyReturnsEmptyCheck collectionArg collection checkInfo)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -21526,7 +21526,9 @@ setIntersectTests =
             \() ->
                 """module A exposing (..)
 import Set
-a = Set.intersect set set
+a0 = Set.intersect
+a1 = Set.intersect set0
+a2 = Set.intersect set0 set1
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -21539,13 +21541,31 @@ a = Set.intersect Set.empty set
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.intersect on Set.empty will result in Set.empty"
+                            { message = "Set.intersect on Set.empty will always result in Set.empty"
                             , details = [ "You can replace this call by Set.empty." ]
                             , under = "Set.intersect"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Set
 a = Set.empty
+"""
+                        ]
+        , test "should replace Set.intersect Set.empty by always Set.empty" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.intersect Set.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.intersect on Set.empty will always result in Set.empty"
+                            , details = [ "You can replace this call by always Set.empty." ]
+                            , under = "Set.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = always Set.empty
 """
                         ]
         , test "should replace Set.intersect set Set.empty by Set.empty" <|
@@ -22882,13 +22902,31 @@ a = Dict.intersect Dict.empty dict
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.intersect on Dict.empty will result in Dict.empty"
+                            { message = "Dict.intersect on Dict.empty will always result in Dict.empty"
                             , details = [ "You can replace this call by Dict.empty." ]
                             , under = "Dict.intersect"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
 a = Dict.empty
+"""
+                        ]
+        , test "should replace Dict.intersect Dict.empty by Dict.empty" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.intersect Dict.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.intersect on Dict.empty will always result in Dict.empty"
+                            , details = [ "You can replace this call by always Dict.empty." ]
+                            , under = "Dict.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = always Dict.empty
 """
                         ]
         , test "should replace Dict.intersect dict Dict.empty by Dict.empty" <|


### PR DESCRIPTION
Many general checks/fixes were still taking the last arg as an argument instead of inferring it.

Through changing this, I also discovered a bug in `intersect` where `intersect empty` would be fixed to `empty` instead of `always empty`.

In a follow-up PR, I'd like to make a general fix/check cleanup.