### PR TITLE
Add Array.toList simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `Array.foldl f initial Array.empty` to `initial` (same for `Array.foldr`)
 - `Array.foldl (\_ soFar -> soFar) initial array` to `initial` (same for `Array.foldr`)
 - `Array.toList Array.empty` to `[]`
+- `Array.toList (Array.repeat n a)` to `List.repeat n a`
 - `Array.toIndexedList Array.empty` to `[]`
 - `List.map Tuple.second (Array.toIndexedList array)` to `Array.toList array`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `Maybe.map2 f (Just a) (Just b)` to `Just (f a b)` (same for all Maybe.mapN)
 - `Array.foldl f initial Array.empty` to `initial` (same for `Array.foldr`)
 - `Array.foldl (\_ soFar -> soFar) initial array` to `initial` (same for `Array.foldr`)
+- `Array.toList Array.empty` to `[]`
 - `Array.toIndexedList Array.empty` to `[]`
 - `List.map Tuple.second (Array.toIndexedList array)` to `Array.toList array`
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -780,6 +780,9 @@ Destructuring using case expressions
     Array.toList (Array.fromList list)
     --> list
 
+    Array.toList Array.empty
+    --> []
+
     Array.map f Array.empty -- same for Array.filter
     --> Array.empty
 
@@ -6480,7 +6483,11 @@ listRepeatChecks checkInfo =
 
 arrayToListChecks : CheckInfo -> Maybe (Error {})
 arrayToListChecks checkInfo =
-    onCallToInverseReturnsItsArgumentCheck ( [ "Array" ], "fromList" ) checkInfo
+    firstThatConstructsJust
+        [ \() -> callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } arrayCollection checkInfo
+        , \() -> onCallToInverseReturnsItsArgumentCheck ( [ "Array" ], "fromList" ) checkInfo
+        ]
+        ()
 
 
 arrayToListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6490,32 +6490,9 @@ arrayToListChecks checkInfo =
         [ \() -> callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } arrayCollection checkInfo
         , \() -> onCallToInverseReturnsItsArgumentCheck ( [ "Array" ], "fromList" ) checkInfo
         , \() ->
-            let
-                specificFn : ( ModuleName, String )
-                specificFn =
-                    ( [ "Array" ], "repeat" )
-            in
-            case AstHelpers.getSpecificFunctionCall specificFn checkInfo.lookupTable checkInfo.firstArg of
-                Just arrayRepeatCall ->
-                    let
-                        combinedFn : ( ModuleName, String )
-                        combinedFn =
-                            ( [ "List" ], "repeat" )
-                    in
-                    Just
-                        (Rule.errorWithFix
-                            { message = qualifiedToString checkInfo.fn ++ " on " ++ qualifiedToString specificFn ++ " can be combined into " ++ qualifiedToString combinedFn
-                            , details = [ "You can replace these two operations by " ++ qualifiedToString combinedFn ++ " with the same arguments given to " ++ qualifiedToString specificFn ++ " which is meant for this exact purpose." ]
-                            }
-                            checkInfo.fnRange
-                            (Fix.replaceRangeBy arrayRepeatCall.fnRange
-                                (qualifiedToString (qualify combinedFn checkInfo))
-                                :: keepOnlyFix { parentRange = checkInfo.parentRange, keep = arrayRepeatCall.nodeRange }
-                            )
-                        )
-
-                Nothing ->
-                    Nothing
+            callFromCanBeCombinedCheck
+                { fromFn = ( [ "Array" ], "repeat" ), combinedFn = ( [ "List" ], "repeat" ) }
+                checkInfo
         ]
         ()
 
@@ -6525,32 +6502,9 @@ arrayToListCompositionChecks checkInfo =
     firstThatConstructsJust
         [ \() -> inversesCompositionCheck ( [ "Array" ], "fromList" ) checkInfo
         , \() ->
-            let
-                specificFn : ( ModuleName, String )
-                specificFn =
-                    ( [ "Array" ], "repeat" )
-            in
-            if checkInfo.earlier.fn == specificFn then
-                let
-                    combinedFn : ( ModuleName, String )
-                    combinedFn =
-                        ( [ "List" ], "repeat" )
-                in
-                Just
-                    { info =
-                        { message = qualifiedToString checkInfo.later.fn ++ " on " ++ qualifiedToString specificFn ++ " can be combined into " ++ qualifiedToString combinedFn
-                        , details = [ "You can replace these two operations by " ++ qualifiedToString combinedFn ++ " with the same arguments given to " ++ qualifiedToString specificFn ++ " which is meant for this exact purpose." ]
-                        }
-                    , fix =
-                        [ Fix.replaceRangeBy
-                            checkInfo.earlier.fnRange
-                            (qualifiedToString (qualify combinedFn checkInfo))
-                        , Fix.removeRange checkInfo.later.removeRange
-                        ]
-                    }
-
-            else
-                Nothing
+            compositionFromCanBeCombinedCheck
+                { fromFn = ( [ "Array" ], "repeat" ), combinedFn = ( [ "List" ], "repeat" ) }
+                checkInfo
         ]
         ()
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6404,8 +6404,8 @@ callFromCanBeCombinedCheck config checkInfo =
         Just fromFnCall ->
             Just
                 (Rule.errorWithFix
-                    { message = qualifiedToString checkInfo.fn ++ " on " ++ qualifiedToString config.fromFn ++ " can be combined into " ++ qualifiedToString config.combinedFn
-                    , details = [ "You can replace these two operations by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.fromFn ++ " which is meant for this exact purpose." ]
+                    { message = qualifiedToString config.fromFn ++ ", then " ++ qualifiedToString checkInfo.fn ++ " can be combined into " ++ qualifiedToString config.combinedFn
+                    , details = [ "You can replace this call by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.fromFn ++ " which is meant for this exact purpose." ]
                     }
                     checkInfo.fnRange
                     (Fix.replaceRangeBy
@@ -6433,8 +6433,8 @@ compositionFromCanBeCombinedCheck config checkInfo =
     if checkInfo.earlier.fn == config.fromFn then
         Just
             { info =
-                { message = qualifiedToString checkInfo.later.fn ++ " on " ++ qualifiedToString config.fromFn ++ " can be combined into " ++ qualifiedToString config.combinedFn
-                , details = [ "You can replace these two operations by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.fromFn ++ " which is meant for this exact purpose." ]
+                { message = qualifiedToString config.fromFn ++ ", then " ++ qualifiedToString checkInfo.later.fn ++ " can be combined into " ++ qualifiedToString config.combinedFn
+                , details = [ "You can replace this composition by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.fromFn ++ " which is meant for this exact purpose." ]
                 }
             , fix =
                 [ Fix.replaceRangeBy

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5943,8 +5943,8 @@ a = String.concat (List.repeat n str)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.concat on List.repeat can be combined into String.repeat"
-                            , details = [ "You can replace these two operations by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
+                            { message = "List.repeat, then String.concat can be combined into String.repeat"
+                            , details = [ "You can replace this call by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
                             , under = "String.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5959,8 +5959,8 @@ a = str |> List.repeat n |> String.concat
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.concat on List.repeat can be combined into String.repeat"
-                            , details = [ "You can replace these two operations by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
+                            { message = "List.repeat, then String.concat can be combined into String.repeat"
+                            , details = [ "You can replace this call by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
                             , under = "String.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5975,8 +5975,8 @@ a = String.concat << List.repeat n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.concat on List.repeat can be combined into String.repeat"
-                            , details = [ "You can replace these two operations by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
+                            { message = "List.repeat, then String.concat can be combined into String.repeat"
+                            , details = [ "You can replace this composition by String.repeat with the same arguments given to List.repeat which is meant for this exact purpose." ]
                             , under = "String.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5991,8 +5991,8 @@ a = String.concat (List.intersperse str strings)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.concat on List.intersperse can be combined into String.join"
-                            , details = [ "You can replace these two operations by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
+                            { message = "List.intersperse, then String.concat can be combined into String.join"
+                            , details = [ "You can replace this call by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
                             , under = "String.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6007,8 +6007,8 @@ a = str |> List.intersperse str |> String.concat
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.concat on List.intersperse can be combined into String.join"
-                            , details = [ "You can replace these two operations by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
+                            { message = "List.intersperse, then String.concat can be combined into String.join"
+                            , details = [ "You can replace this call by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
                             , under = "String.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6023,8 +6023,8 @@ a = String.concat << List.intersperse str
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.concat on List.intersperse can be combined into String.join"
-                            , details = [ "You can replace these two operations by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
+                            { message = "List.intersperse, then String.concat can be combined into String.join"
+                            , details = [ "You can replace this composition by String.join with the same arguments given to List.intersperse which is meant for this exact purpose." ]
                             , under = "String.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8313,8 +8313,8 @@ a = List.concat (List.map f x)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.concat on List.map can be combined into List.concatMap"
-                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
+                            { message = "List.map, then List.concat can be combined into List.concatMap"
+                            , details = [ "You can replace this call by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8329,8 +8329,8 @@ a = List.concat <| List.map f <| x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.concat on List.map can be combined into List.concatMap"
-                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
+                            { message = "List.map, then List.concat can be combined into List.concatMap"
+                            , details = [ "You can replace this call by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8345,8 +8345,8 @@ a = x |> List.map f |> List.concat
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.concat on List.map can be combined into List.concatMap"
-                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
+                            { message = "List.map, then List.concat can be combined into List.concatMap"
+                            , details = [ "You can replace this call by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8679,8 +8679,8 @@ a = List.map f >> List.concat
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.concat on List.map can be combined into List.concatMap"
-                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
+                            { message = "List.map, then List.concat can be combined into List.concatMap"
+                            , details = [ "You can replace this composition by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8695,8 +8695,8 @@ a = List.concat << List.map f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.concat on List.map can be combined into List.concatMap"
-                            , details = [ "You can replace these two operations by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
+                            { message = "List.map, then List.concat can be combined into List.concatMap"
+                            , details = [ "You can replace this composition by List.concatMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.concat"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15737,8 +15737,8 @@ a = b |> Array.repeat n |> Array.toList
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.toList on Array.repeat can be combined into List.repeat"
-                            , details = [ "You can replace these two operations by List.repeat with the same arguments given to Array.repeat which is meant for this exact purpose." ]
+                            { message = "Array.repeat, then Array.toList can be combined into List.repeat"
+                            , details = [ "You can replace this call by List.repeat with the same arguments given to Array.repeat which is meant for this exact purpose." ]
                             , under = "Array.toList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -15755,8 +15755,8 @@ a = Array.repeat n >> Array.toList
                     |> Review.Test.run (rule defaults)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.toList on Array.repeat can be combined into List.repeat"
-                            , details = [ "You can replace these two operations by List.repeat with the same arguments given to Array.repeat which is meant for this exact purpose." ]
+                            { message = "Array.repeat, then Array.toList can be combined into List.repeat"
+                            , details = [ "You can replace this composition by List.repeat with the same arguments given to Array.repeat which is meant for this exact purpose." ]
                             , under = "Array.toList"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15530,6 +15530,24 @@ e = Array.toList << (f << Array.fromList)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+        , test "should replace Array.toList Array.empty by []" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.toList Array.empty
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.toList on Array.empty will result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "Array.toList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = []
+"""
+                        ]
         , test "should replace x |> f |> Array.fromList |> Array.toList by x |> f" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15728,6 +15728,42 @@ import Array
 a = (f >> g)
 """
                         ]
+        , test "should replace a |> Array.repeat n |> Array.toList by a |> List.repeat n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = b |> Array.repeat n |> Array.toList
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.toList on Array.repeat can be combined into List.repeat"
+                            , details = [ "You can replace these two operations by List.repeat with the same arguments given to Array.repeat which is meant for this exact purpose." ]
+                            , under = "Array.toList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = b |> List.repeat n
+"""
+                        ]
+        , test "should replace Array.repeat n >> Array.toList by List.repeat n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.repeat n >> Array.toList
+"""
+                    |> Review.Test.run (rule defaults)
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.toList on Array.repeat can be combined into List.repeat"
+                            , details = [ "You can replace these two operations by List.repeat with the same arguments given to Array.repeat which is meant for this exact purpose." ]
+                            , under = "Array.toList"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = List.repeat n
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Add `Array.toList` simplifications listed in #174 
```elm
Array.toList Array.empty
--> []

Array.toList (Array.repeat n a)
--> List.repeat n a
```
including composition

Luckily, I was able to re-use an existing helper for the repeat.