### PR TITLE
General check and fix cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`
 - Fixed an issue where `Set.intersect Set.empty` would be fixed to `Set.empty`
 - Fixed an issue where `(a |> not) == (b |> not)` would be fixed to `(a |> ) == (b |> )`
+- Fixed an issue where `List.intersperse << List.singleton` would be fixed to `List.singleton`
 
 ## [2.1.2] - 2023-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`
 - Fixed an issue where `Set.intersect Set.empty` would be fixed to `Set.empty`
+- Fixed an issue where `(a |> not) == (b |> not)` would be fixed to `(a |> ) == (b |> )`
 
 ## [2.1.2] - 2023-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Bug fixes:
 - Fixed an issue where `Set.intersect Set.empty` would be fixed to `Set.empty`
 - Fixed an issue where `(a |> not) == (b |> not)` would be fixed to `(a |> ) == (b |> )`
 - Fixed an issue where `List.intersperse << List.singleton` would be fixed to `List.singleton`
+- Fixed an issue where e.g. `List.sortBy f << g` would be fixed to `g`
 
 ## [2.1.2] - 2023-09-28
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4515,7 +4515,7 @@ stringReverseChecks =
 stringReverseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 stringReverseCompositionChecks =
     firstThatConstructsJust
-        [ compositionAfterWrapIsUnnecessaryCheck stringCollection
+        [ compositionAfterWrapIsUnnecessaryCheck { laterArgCount = 1 } stringCollection
         , toggleCompositionChecks
         ]
 
@@ -5114,7 +5114,7 @@ listIntersperseChecks =
 
 listIntersperseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listIntersperseCompositionChecks =
-    compositionAfterWrapIsUnnecessaryCheck listCollection
+    compositionAfterWrapIsUnnecessaryCheck { laterArgCount = 2 } listCollection
 
 
 listHeadChecks : CheckInfo -> Maybe (Error {})
@@ -6402,7 +6402,7 @@ listReverseChecks =
 listReverseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listReverseCompositionChecks =
     firstThatConstructsJust
-        [ compositionAfterWrapIsUnnecessaryCheck listCollection
+        [ compositionAfterWrapIsUnnecessaryCheck { laterArgCount = 1 } listCollection
         , toggleCompositionChecks
         ]
 
@@ -9004,9 +9004,9 @@ pipingIntoCompositionChecks context compositionDirection expressionNode =
                 )
 
 
-compositionAfterWrapIsUnnecessaryCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-compositionAfterWrapIsUnnecessaryCheck wrapper checkInfo =
-    if checkInfo.earlier.fn == wrapper.wrap.fn then
+compositionAfterWrapIsUnnecessaryCheck : { laterArgCount : Int } -> WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+compositionAfterWrapIsUnnecessaryCheck config wrapper checkInfo =
+    if (List.length checkInfo.later.args == (config.laterArgCount - 1)) && (checkInfo.earlier.fn == wrapper.wrap.fn) then
         Just
             { info =
                 { message = qualifiedToString checkInfo.later.fn ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will result in the given " ++ wrapper.represents

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4888,7 +4888,7 @@ listConcatChecks : CheckInfo -> Maybe (Error {})
 listConcatChecks =
     firstThatConstructsJust
         [ unnecessaryCallOnEmptyCheck listCollection
-        , callOnWrapReturnsItsValue listCollection
+        , callOnWrapReturnsItsValueCheck listCollection
         , callOnListWithIrrelevantEmptyElement listCollection
         , \checkInfo ->
             case Node.value checkInfo.firstArg of
@@ -5520,7 +5520,7 @@ listSumChecks : CheckInfo -> Maybe (Error {})
 listSumChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck { resultAsString = \_ -> "0" } listCollection
-        , callOnWrapReturnsItsValue listCollection
+        , callOnWrapReturnsItsValueCheck listCollection
         ]
 
 
@@ -5533,7 +5533,7 @@ listProductChecks : CheckInfo -> Maybe (Error {})
 listProductChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck { resultAsString = \_ -> "1" } listCollection
-        , callOnWrapReturnsItsValue listCollection
+        , callOnWrapReturnsItsValueCheck listCollection
         ]
 
 
@@ -6965,7 +6965,7 @@ subAndCmdBatchChecks :
 subAndCmdBatchChecks batchable =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck { resultAsString = batchable.empty.asString } listCollection
-        , callOnWrapReturnsItsValue listCollection
+        , callOnWrapReturnsItsValueCheck listCollection
         , callOnListWithIrrelevantEmptyElement batchable
         ]
 
@@ -8609,7 +8609,7 @@ withDefaultChecks :
 withDefaultChecks emptiable =
     firstThatConstructsJust
         [ emptiableWithDefaultChecks emptiable
-        , callOnWrapReturnsItsValue emptiable
+        , callOnWrapReturnsItsValueCheck emptiable
         ]
 
 
@@ -9181,13 +9181,13 @@ For example
 Use together with `onWrapAlwaysReturnsIncomingCompositionCheck`
 
 -}
-callOnWrapReturnsItsValue :
+callOnWrapReturnsItsValueCheck :
     { otherProperties
         | wrap : ConstructWithOneArgProperties
     }
     -> CheckInfo
     -> Maybe (Error {})
-callOnWrapReturnsItsValue wrapper checkInfo =
+callOnWrapReturnsItsValueCheck wrapper checkInfo =
     case fullyAppliedLastArg checkInfo of
         Just wrapperArg ->
             case sameInAllBranches (getValueWithNodeRange (wrapper.wrap.getValue checkInfo.lookupTable)) wrapperArg of
@@ -9220,7 +9220,7 @@ For example
 
     Cmd.batch << List.singleton --> identity
 
-Use together with `callOnWrapReturnsItsValue`.
+Use together with `callOnWrapReturnsItsValueCheck`.
 
 -}
 onWrapAlwaysReturnsIncomingCompositionCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8996,17 +8996,6 @@ operationDoesNotChangeResultOfOperationCompositionCheck checkInfo =
         Nothing
 
 
-{-| The last argument of a fully applied function (the given `argCount` specifies what is considered "fully applied").
-
-For example, `fullyAppliedLastArg` on `Array.set 3 "Hitagi"` would return `Nothing`
-while `fullyAppliedLastArg` on `Array.set 3 "Hitagi" arr` would return `Just arr`.
-
--}
-fullyAppliedLastArg : { callInfo | firstArg : Node Expression, argsAfterFirst : List (Node Expression), argCount : Int } -> Maybe (Node Expression)
-fullyAppliedLastArg callInfo =
-    List.drop (callInfo.argCount - 1) (callInfo.firstArg :: callInfo.argsAfterFirst) |> List.head
-
-
 compositionAfterWrapIsUnnecessaryCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 compositionAfterWrapIsUnnecessaryCheck wrapper =
     unnecessaryCompositionAfterCheck wrapper.wrap
@@ -9161,6 +9150,17 @@ unnecessaryCompositionAfterCheck construct checkInfo =
 
     else
         Nothing
+
+
+{-| The last argument of a fully applied function (the given `argCount` specifies what is considered "fully applied").
+
+For example, `fullyAppliedLastArg` on `Array.set 3 "Hitagi"` would return `Nothing`
+while `fullyAppliedLastArg` on `Array.set 3 "Hitagi" arr` would return `Just arr`.
+
+-}
+fullyAppliedLastArg : { callInfo | firstArg : Node Expression, argsAfterFirst : List (Node Expression), argCount : Int } -> Maybe (Node Expression)
+fullyAppliedLastArg callInfo =
+    List.drop (callInfo.argCount - 1) (callInfo.firstArg :: callInfo.argsAfterFirst) |> List.head
 
 
 onlyLastArgIsCurried : { function | args : List (Node Expression), argCount : Int } -> Bool

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3262,7 +3262,7 @@ intDivideChecks =
                         Just
                             (Rule.errorWithFix
                                 { message = "Unnecessary dividing by 1"
-                                , details = [ "You can replace this operation by the left number you divided by 1 using (//)." ]
+                                , details = [ "You can replace this operation by the left integer you divided by 1." ]
                                 }
                                 checkInfo.operatorRange
                                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = checkInfo.leftRange })
@@ -3271,7 +3271,7 @@ intDivideChecks =
                     else if rightNumber == 0 then
                         Just
                             (Rule.errorWithFix
-                                { message = "Dividing by 0 always returns 0"
+                                { message = "Dividing by 0 will result in 0"
                                 , details =
                                     [ "Dividing anything by 0 using (//) gives 0 which means you can replace the whole division operation by 0."
                                     , "Most likely, dividing by 0 was unintentional and you had a different number in mind."

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4949,13 +4949,7 @@ listConcatCompositionChecks =
 
 
 callOnListWithIrrelevantEmptyElement :
-    { otherProperties
-        | empty :
-            { empty
-                | description : Description
-                , is : ModuleNameLookupTable -> Node Expression -> Bool
-            }
-    }
+    { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 callOnListWithIrrelevantEmptyElement emptiableElement checkInfo =
@@ -6644,14 +6638,7 @@ This is pretty similar to `sequenceOrFirstEmptyChecks` where we look at argument
 
 -}
 mapNOrFirstEmptyConstructionChecks :
-    WrapperProperties
-        { otherProperties
-            | empty :
-                { empty
-                    | is : ModuleNameLookupTable -> Node Expression -> Bool
-                    , description : Description
-                }
-        }
+    WrapperProperties { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 mapNOrFirstEmptyConstructionChecks emptiable checkInfo =
@@ -6860,14 +6847,7 @@ Any other argument order is not supported:
 
 -}
 emptiableFoldChecks :
-    TypeProperties
-        { otherProperties
-            | empty :
-                { empty
-                    | is : ModuleNameLookupTable -> Node Expression -> Bool
-                    , description : Description
-                }
-        }
+    TypeProperties { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 emptiableFoldChecks emptiable =
@@ -7043,14 +7023,7 @@ taskSequenceCompositionChecks =
 
 
 sequenceOrFirstEmptyChecks :
-    WrapperProperties
-        { otherProperties
-            | empty :
-                { empty
-                    | is : ModuleNameLookupTable -> Node Expression -> Bool
-                    , description : Description
-                }
-        }
+    WrapperProperties { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 sequenceOrFirstEmptyChecks emptiable checkInfo =
@@ -7688,7 +7661,7 @@ getEmpty lookupTable emptiable expressionNode =
 
 getEmptyExpressionNode :
     ModuleNameLookupTable
-    -> { otherProperties | empty : { empty | is : ModuleNameLookupTable -> Node Expression -> Bool } }
+    -> { otherProperties | empty : TypeSubsetProperties empty }
     -> Node Expression
     -> Maybe (Node Expression)
 getEmptyExpressionNode lookupTable emptiable expressionNode =
@@ -8333,14 +8306,7 @@ subCollection =
 
 
 emptiableMapChecks :
-    TypeProperties
-        { otherProperties
-            | empty :
-                { empty
-                    | description : Description
-                    , is : ModuleNameLookupTable -> Node Expression -> Bool
-                }
-        }
+    TypeProperties { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 emptiableMapChecks emptiable =
@@ -8648,14 +8614,7 @@ resultAndThenChecks =
 
 
 withDefaultChecks :
-    WrapperProperties
-        { otherProperties
-            | empty :
-                { empty
-                    | description : Description
-                    , is : ModuleNameLookupTable -> Node Expression -> Bool
-                }
-        }
+    WrapperProperties { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 withDefaultChecks emptiable =
@@ -8671,13 +8630,7 @@ wrapperWithDefaultChecks wrapper =
 
 
 emptiableWithDefaultChecks :
-    { otherProperties
-        | empty :
-            { empty
-                | description : Description
-                , is : ModuleNameLookupTable -> Node Expression -> Bool
-            }
-    }
+    { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 emptiableWithDefaultChecks emptiable checkInfo =
@@ -8702,14 +8655,7 @@ emptiableWithDefaultChecks emptiable checkInfo =
 
 
 unwrapToMaybeChecks :
-    WrapperProperties
-        { otherProperties
-            | empty :
-                { empty
-                    | is : ModuleNameLookupTable -> Node Expression -> Bool
-                    , description : Description
-                }
-        }
+    WrapperProperties { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 unwrapToMaybeChecks emptiableWrapper =
@@ -9092,13 +9038,7 @@ unnecessaryCallOnCheck constructable checkInfo =
 
 
 unnecessaryCallOnEmptyCheck :
-    { a
-        | empty :
-            { empty
-                | is : ModuleNameLookupTable -> Node Expression -> Bool
-                , description : Description
-            }
-    }
+    { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 unnecessaryCallOnEmptyCheck emptiable =
@@ -9107,14 +9047,7 @@ unnecessaryCallOnEmptyCheck emptiable =
 
 callOnEmptyReturnsCheck :
     { resultAsString : QualifyResources {} -> String }
-    ->
-        { a
-            | empty :
-                { empty
-                    | is : ModuleNameLookupTable -> Node Expression -> Bool
-                    , description : Description
-                }
-        }
+    -> { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 callOnEmptyReturnsCheck config collection checkInfo =
@@ -9641,13 +9574,7 @@ wrapperFromListSingletonCompositionChecks wrapper checkInfo =
 
 
 emptiableToListChecks :
-    { otherProperties
-        | empty :
-            { empty
-                | is : ModuleNameLookupTable -> Node Expression -> Bool
-                , description : Description
-            }
-    }
+    { otherProperties | empty : TypeSubsetProperties empty }
     -> CheckInfo
     -> Maybe (Error {})
 emptiableToListChecks collection =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6488,7 +6488,7 @@ operationDoesNotChangeResultOfOperationCompositionCheck checkInfo =
                 )
                 (List.map2 Tuple.pair checkInfo.later.args checkInfo.earlier.args)
     in
-    if (List.length checkInfo.later.args == (checkInfo.later.argCount - 1)) && (checkInfo.earlier.fn == checkInfo.later.fn) == areAllArgsEqual () then
+    if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == checkInfo.later.fn) == areAllArgsEqual () then
         Just
             { info =
                 { message =
@@ -9149,7 +9149,7 @@ unnecessaryCompositionAfterCheck :
     -> CompositionIntoCheckInfo
     -> Maybe ErrorInfoAndFix
 unnecessaryCompositionAfterCheck construct checkInfo =
-    if (List.length checkInfo.later.args == (checkInfo.later.argCount - 1)) && (checkInfo.earlier.fn == construct.fn) then
+    if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == construct.fn) then
         Just
             { info =
                 { message = qualifiedToString checkInfo.later.fn ++ " on " ++ descriptionForIndefinite construct.description ++ " will result in " ++ descriptionForDefinite "the unchanged" construct.description
@@ -9161,6 +9161,11 @@ unnecessaryCompositionAfterCheck construct checkInfo =
 
     else
         Nothing
+
+
+onlyLastArgIsCurried : { function | args : List (Node Expression), argCount : Int } -> Bool
+onlyLastArgIsCurried functionInfo =
+    List.length functionInfo.args == (functionInfo.argCount - 1)
 
 
 {-| This operation is equivalent to identity when called on a wrapped value.
@@ -9220,7 +9225,7 @@ Use together with `callOnWrapReturnsItsValue`.
 -}
 onWrapAlwaysReturnsIncomingCompositionCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 onWrapAlwaysReturnsIncomingCompositionCheck wrapper checkInfo =
-    if (checkInfo.earlier.fn == wrapper.wrap.fn) && (List.length checkInfo.later.args == (checkInfo.later.argCount - 1)) then
+    if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == wrapper.wrap.fn) then
         Just
             (compositionAlwaysReturnsIncomingError
                 (qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will always result in the value inside")
@@ -9291,7 +9296,7 @@ Use together with `callOnWrapReturnsJustItsValue`.
 -}
 onWrapAlwaysReturnsJustIncomingCompositionCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 onWrapAlwaysReturnsJustIncomingCompositionCheck wrapper checkInfo =
-    if (checkInfo.earlier.fn == wrapper.wrap.fn) && (List.length checkInfo.later.args == (checkInfo.later.argCount - 1)) then
+    if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == wrapper.wrap.fn) then
         Just
             { info =
                 { message = qualifiedToString checkInfo.later.fn ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will always result in Just the value inside"

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4873,7 +4873,7 @@ resultMapErrorCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAnd
 resultMapErrorCompositionChecks =
     firstThatConstructsJust
         [ wrapToMapCompositionChecks resultWithErrAsWrap
-        , compositionFromEmptyReturnsEmptyCheck { laterArgCount = 2 } resultWithErrAsWrap
+        , unnecessaryCompositionAfterEmptyCheck { laterArgCount = 2 } resultWithErrAsWrap
         ]
 
 
@@ -9124,7 +9124,7 @@ Examples
 Use together with `callOnEmptyReturnsEmptyCheck`
 
 -}
-compositionFromEmptyReturnsEmptyCheck :
+unnecessaryCompositionAfterEmptyCheck :
     { laterArgCount : Int }
     ->
         { a
@@ -9136,7 +9136,7 @@ compositionFromEmptyReturnsEmptyCheck :
         }
     -> CompositionIntoCheckInfo
     -> Maybe ErrorInfoAndFix
-compositionFromEmptyReturnsEmptyCheck config emptiable =
+unnecessaryCompositionAfterEmptyCheck config emptiable =
     unnecessaryCompositionAfterCheck config emptiable.empty
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3844,7 +3844,7 @@ numberComparisonChecks operatorFunction operatorCheckInfo =
             Nothing
 
 
-comparisonError : Bool -> QualifyResources { a | parentRange : Range } -> Error {}
+comparisonError : Bool -> QualifyResources { a | parentRange : Range, operator : String } -> Error {}
 comparisonError bool checkInfo =
     let
         boolAsString : String
@@ -3852,9 +3852,9 @@ comparisonError bool checkInfo =
             AstHelpers.boolToString bool
     in
     Rule.errorWithFix
-        { message = "Comparison is always " ++ boolAsString
+        { message = "(" ++ checkInfo.operator ++ ") comparison will result in " ++ boolAsString
         , details =
-            [ "Based on the values and/or the context, we can determine that the value of this operation will always be " ++ boolAsString ++ "."
+            [ "Based on the values and/or the context, we can determine the result. You can replace this operation by " ++ boolAsString ++ "."
             ]
         }
         checkInfo.parentRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3213,8 +3213,8 @@ divisionChecks checkInfo =
     if maybeDivisorNumber == Just 1 then
         Just
             (Rule.errorWithFix
-                { message = "Unnecessary division by 1"
-                , details = [ "Dividing by 1 does not change the value of the number." ]
+                { message = "Unnecessary dividing by 1"
+                , details = [ "You can replace this operation by the left number you divided by 1." ]
                 }
                 checkInfo.operatorRange
                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.left })
@@ -3238,7 +3238,7 @@ divisionChecks checkInfo =
         else
             Just
                 (Rule.errorWithFix
-                    { message = "Dividing 0 always returns 0"
+                    { message = "Dividing 0 will result in 0"
                     , details =
                         [ "Dividing 0 by anything, even infinite numbers, gives 0 which means you can replace the whole division operation by 0."
                         , "Most likely, dividing 0 was unintentional and you had a different number in mind."
@@ -3261,8 +3261,8 @@ intDivideChecks =
                     if rightNumber == 1 then
                         Just
                             (Rule.errorWithFix
-                                { message = "Unnecessary division by 1"
-                                , details = [ "Dividing by 1 using (//) does not change the value of the number." ]
+                                { message = "Unnecessary dividing by 1"
+                                , details = [ "You can replace this operation by the left number you divided by 1 using (//)." ]
                                 }
                                 checkInfo.operatorRange
                                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = checkInfo.leftRange })
@@ -3290,7 +3290,7 @@ intDivideChecks =
             if AstHelpers.getUncomputedNumberValue checkInfo.left == Just 0 then
                 Just
                     (Rule.errorWithFix
-                        { message = "Dividing 0 always returns 0"
+                        { message = "Dividing 0 will result in 0"
                         , details =
                             [ "Dividing 0 by anything using (//), even 0, gives 0 which means you can replace the whole division operation by 0."
                             , "Most likely, dividing 0 was unintentional and you had a different number in mind."

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3078,7 +3078,7 @@ minusChecks checkInfo =
                 { message = "Unnecessary subtraction with 0"
                 , details = [ "Subtracting 0 does not change the value of the number." ]
                 }
-                (errorToRightRange checkInfo)
+                checkInfo.operatorRange
                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.left })
             )
 
@@ -3088,7 +3088,7 @@ minusChecks checkInfo =
                 { message = "Unnecessary subtracting from 0"
                 , details = [ "You can negate the expression on the right like `-n`." ]
                 }
-                (errorToLeftRange checkInfo)
+                checkInfo.operatorRange
                 (replaceBySubExpressionFix checkInfo.parentRange checkInfo.right
                     ++ [ Fix.insertAt checkInfo.parentRange.start "-" ]
                 )
@@ -3226,7 +3226,7 @@ divisionChecks checkInfo =
                 { message = "Unnecessary division by 1"
                 , details = [ "Dividing by 1 does not change the value of the number." ]
                 }
-                (errorToRightRange checkInfo)
+                checkInfo.operatorRange
                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.left })
             )
 
@@ -3254,7 +3254,7 @@ divisionChecks checkInfo =
                         , "Most likely, dividing 0 was unintentional and you had a different number in mind."
                         ]
                     }
-                    (errorToLeftRange checkInfo)
+                    checkInfo.operatorRange
                     (keepOnlyFix { parentRange = checkInfo.parentRange, keep = checkInfo.leftRange })
                 )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4511,7 +4511,7 @@ stringReverseChecks : CheckInfo -> Maybe (Error {})
 stringReverseChecks =
     firstThatConstructsJust
         [ emptiableReverseChecks stringCollection
-        , callOnWrappedDoesNotChangeItCheck stringCollection
+        , unnecessaryCallOnWrappedCheck stringCollection
         ]
 
 
@@ -5111,7 +5111,7 @@ listIntersperseChecks : CheckInfo -> Maybe (Error {})
 listIntersperseChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsEmptyCheck listCollection
-        , callOnWrappedDoesNotChangeItCheck listCollection
+        , unnecessaryCallOnWrappedCheck listCollection
         ]
 
 
@@ -6398,7 +6398,7 @@ listReverseChecks : CheckInfo -> Maybe (Error {})
 listReverseChecks =
     firstThatConstructsJust
         [ emptiableReverseChecks listCollection
-        , callOnWrappedDoesNotChangeItCheck listCollection
+        , unnecessaryCallOnWrappedCheck listCollection
         ]
 
 
@@ -6414,7 +6414,7 @@ listSortChecks : CheckInfo -> Maybe (Error {})
 listSortChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsEmptyCheck listCollection
-        , callOnWrappedDoesNotChangeItCheck listCollection
+        , unnecessaryCallOnWrappedCheck listCollection
         , operationDoesNotChangeResultOfOperationCheck
         ]
 
@@ -6428,7 +6428,7 @@ listSortByChecks : CheckInfo -> Maybe (Error {})
 listSortByChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsEmptyCheck listCollection
-        , callOnWrappedDoesNotChangeItCheck listCollection
+        , unnecessaryCallOnWrappedCheck listCollection
         , \checkInfo ->
             case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
                 Just _ ->
@@ -6455,7 +6455,7 @@ listSortWithChecks : CheckInfo -> Maybe (Error {})
 listSortWithChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsEmptyCheck listCollection
-        , callOnWrappedDoesNotChangeItCheck listCollection
+        , unnecessaryCallOnWrappedCheck listCollection
         , \checkInfo ->
             let
                 alwaysAlwaysOrder : Maybe Order
@@ -9001,8 +9001,8 @@ compositionAfterWrapIsUnnecessaryCheck wrapper =
     unnecessaryCompositionAfterCheck wrapper.wrap
 
 
-callOnWrappedDoesNotChangeItCheck : WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
-callOnWrappedDoesNotChangeItCheck wrapper =
+unnecessaryCallOnWrappedCheck : WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
+unnecessaryCallOnWrappedCheck wrapper =
     unnecessaryCallOnCheck
         { description = wrapper.wrap.description
         , is = \lookupTable expr -> isJust (wrapper.wrap.getValue lookupTable expr)

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3809,12 +3809,6 @@ equalityChecks isEqual =
         ]
 
 
-alwaysSameDetails : List String
-alwaysSameDetails =
-    [ "This condition will always result in the same value. You may have hardcoded a value or mistyped a condition."
-    ]
-
-
 
 -- COMPARISONS
 
@@ -4156,8 +4150,11 @@ orSideChecks side checkInfo =
         Determined True ->
             Just
                 (Rule.errorWithFix
-                    { message = "Comparison is always True"
-                    , details = alwaysSameDetails
+                    { message = "(||) with any side being True will result in True"
+                    , details =
+                        [ "You can replace this operation by True."
+                        , "Maybe you have hardcoded a value or mistyped a condition?"
+                        ]
                     }
                     checkInfo.parentRange
                     (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.node })
@@ -4201,8 +4198,11 @@ andSideChecks side checkInfo =
         Determined False ->
             Just
                 (Rule.errorWithFix
-                    { message = "Comparison is always False"
-                    , details = alwaysSameDetails
+                    { message = "(&&) with any side being False will result in False"
+                    , details =
+                        [ "You can replace this operation by False."
+                        , "Maybe you have hardcoded a value or mistyped a condition?"
+                        ]
                     }
                     checkInfo.parentRange
                     (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.node })

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4088,8 +4088,7 @@ isNegatableOperator op =
 orChecks : OperatorCheckInfo -> Maybe (Error {})
 orChecks =
     firstThatConstructsJust
-        [ \checkInfo -> orSideChecks { node = checkInfo.left, otherNode = checkInfo.right } checkInfo
-        , \checkInfo -> orSideChecks { node = checkInfo.right, otherNode = checkInfo.left } checkInfo
+        [ \checkInfo -> findMap (\side -> orSideChecks side checkInfo) (operationSides checkInfo)
         , findSimilarConditionsError
         ]
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7738,18 +7738,22 @@ emptyAsString qualifyResources emptiable =
 randomGeneratorWrapper : TypeProperties (NonEmptiableProperties (WrapperProperties { mapFn : ( ModuleName, String ) }))
 randomGeneratorWrapper =
     { represents = "random generator"
-    , wrap =
-        { description = A "constant generator"
-        , fn = ( [ "Random" ], "constant" )
-        , getValue =
-            \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Random" ], "constant" ) lookupTable expr)
-        , is =
-            \lookupTable expr ->
-                isJust (AstHelpers.getSpecificFnCall ( [ "Random" ], "constant" ) lookupTable expr)
-        }
+    , wrap = randomGeneratorConstantConstruct
     , empty = { invalid = () }
     , mapFn = ( [ "Random" ], "map" )
+    }
+
+
+randomGeneratorConstantConstruct : ConstructWithOneArgProperties
+randomGeneratorConstantConstruct =
+    { description = A "constant generator"
+    , fn = ( [ "Random" ], "constant" )
+    , getValue =
+        \lookupTable expr ->
+            Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Random" ], "constant" ) lookupTable expr)
+    , is =
+        \lookupTable expr ->
+            isJust (AstHelpers.getSpecificFnCall ( [ "Random" ], "constant" ) lookupTable expr)
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2817,8 +2817,8 @@ compositionChecks =
     [ basicsIdentityCompositionChecks
     , \checkInfo ->
         case
-            ( AstHelpers.getValueOrFunctionOrFunctionCall checkInfo.earlier.node
-            , AstHelpers.getValueOrFunctionOrFunctionCall checkInfo.later.node
+            ( AstHelpers.getValueOrFnOrFnCall checkInfo.earlier.node
+            , AstHelpers.getValueOrFnOrFnCall checkInfo.later.node
             )
         of
             ( Just earlierFnOrCall, Just laterFnOrCall ) ->
@@ -3497,7 +3497,7 @@ would be an incorrect fix. See for example
 -}
 onCallToInverseReturnsItsArgumentCheck : ( ModuleName, String ) -> CheckInfo -> Maybe (Error {})
 onCallToInverseReturnsItsArgumentCheck inverseFn checkInfo =
-    case AstHelpers.getSpecificFunctionCall inverseFn checkInfo.lookupTable checkInfo.firstArg of
+    case AstHelpers.getSpecificFnCall inverseFn checkInfo.lookupTable checkInfo.firstArg of
         Just call ->
             Just
                 (Rule.errorWithFix
@@ -3747,8 +3747,8 @@ equalityChecks isEqual =
                 (operationSides checkInfo)
         , \checkInfo ->
             case
-                ( AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.left
-                , AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.right
+                ( AstHelpers.getSpecificFnCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.left
+                , AstHelpers.getSpecificFnCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.right
                 )
             of
                 ( Just leftNotCall, Just rightNotCall ) ->
@@ -4388,7 +4388,7 @@ tuplePartChecks partConfig =
                 )
                 (AstHelpers.getTuple2 checkInfo.firstArg checkInfo.lookupTable)
         , \checkInfo ->
-            case AstHelpers.getSpecificFunctionCall partConfig.mapUnrelatedFn checkInfo.lookupTable checkInfo.firstArg of
+            case AstHelpers.getSpecificFnCall partConfig.mapUnrelatedFn checkInfo.lookupTable checkInfo.firstArg of
                 Just mapSecondCall ->
                     case mapSecondCall.argsAfterFirst of
                         unmappedTuple :: [] ->
@@ -4407,7 +4407,7 @@ tuplePartChecks partConfig =
                 Nothing ->
                     Nothing
         , \checkInfo ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Tuple" ], "mapBoth" ) checkInfo.lookupTable checkInfo.firstArg of
+            case AstHelpers.getSpecificFnCall ( [ "Tuple" ], "mapBoth" ) checkInfo.lookupTable checkInfo.firstArg of
                 Just tupleMapBothCall ->
                     case tupleMapBothCall.argsAfterFirst of
                         secondMapperArg :: _ :: [] ->
@@ -5156,7 +5156,7 @@ getReplaceAlwaysByItsResultFix lookupTable expressionNode =
                     Nothing
 
         _ ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "always" ) lookupTable expressionNode of
+            case AstHelpers.getSpecificFnCall ( [ "Basics" ], "always" ) lookupTable expressionNode of
                 Just alwaysCall ->
                     Just
                         (replaceBySubExpressionFix alwaysCall.nodeRange alwaysCall.firstArg)
@@ -5338,7 +5338,7 @@ dictToListMapChecks : CheckInfo -> Maybe (Error {})
 dictToListMapChecks listMapCheckInfo =
     case secondArg listMapCheckInfo of
         Just listArgument ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Dict" ], "toList" ) listMapCheckInfo.lookupTable listArgument of
+            case AstHelpers.getSpecificFnCall ( [ "Dict" ], "toList" ) listMapCheckInfo.lookupTable listArgument of
                 Just dictToListCall ->
                     let
                         error : { toEntryAspectList : String, tuplePart : String } -> Error {}
@@ -5373,7 +5373,7 @@ arrayToIndexedListToListMapChecks : CheckInfo -> Maybe (Error {})
 arrayToIndexedListToListMapChecks listMapCheckInfo =
     case secondArg listMapCheckInfo of
         Just listArgument ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Array" ], "toIndexedList" ) listMapCheckInfo.lookupTable listArgument of
+            case AstHelpers.getSpecificFnCall ( [ "Array" ], "toIndexedList" ) listMapCheckInfo.lookupTable listArgument of
                 Just arrayToIndexedList ->
                     if AstHelpers.isTupleSecondAccess listMapCheckInfo.lookupTable listMapCheckInfo.firstArg then
                         let
@@ -5757,7 +5757,7 @@ listFoldAnyDirectionChecks =
                         [ \() ->
                             case maybeListArg of
                                 Just listArg ->
-                                    case AstHelpers.getSpecificFunctionCall ( [ "Set" ], "toList" ) checkInfo.lookupTable listArg of
+                                    case AstHelpers.getSpecificFnCall ( [ "Set" ], "toList" ) checkInfo.lookupTable listArg of
                                         Just setToListCall ->
                                             Just
                                                 (Rule.errorWithFix
@@ -5926,7 +5926,7 @@ listFilterMapChecks =
                             Just list ->
                                 case
                                     traverse
-                                        (AstHelpers.getSpecificFunctionCall ( [ "Maybe" ], "Just" ) checkInfo.lookupTable)
+                                        (AstHelpers.getSpecificFnCall ( [ "Maybe" ], "Just" ) checkInfo.lookupTable)
                                         list
                                 of
                                     Just justCalls ->
@@ -5966,7 +5966,7 @@ emptiableWrapperFilterMapChecks : EmptiableProperties (WrapperProperties { other
 emptiableWrapperFilterMapChecks emptiableWrapper =
     firstThatConstructsJust
         [ \checkInfo ->
-            case constructs (sameInAllBranches (AstHelpers.getSpecificFunctionCall ( [ "Maybe" ], "Just" ) checkInfo.lookupTable)) checkInfo.lookupTable checkInfo.firstArg of
+            case constructs (sameInAllBranches (AstHelpers.getSpecificFnCall ( [ "Maybe" ], "Just" ) checkInfo.lookupTable)) checkInfo.lookupTable checkInfo.firstArg of
                 Determined justCalls ->
                     Just
                         (Rule.errorWithFix
@@ -5983,7 +5983,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
                 Undetermined ->
                     Nothing
         , \checkInfo ->
-            case AstHelpers.getSpecificValueOrFunction ( [ "Maybe" ], "Just" ) checkInfo.lookupTable checkInfo.firstArg of
+            case AstHelpers.getSpecificValueOrFn ( [ "Maybe" ], "Just" ) checkInfo.lookupTable checkInfo.firstArg of
                 Just _ ->
                     Just
                         (alwaysReturnsLastArgError
@@ -5995,7 +5995,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
                 Nothing ->
                     Nothing
         , \checkInfo ->
-            case constructs (sameInAllBranches (AstHelpers.getSpecificValueOrFunction ( [ "Maybe" ], "Nothing" ) checkInfo.lookupTable)) checkInfo.lookupTable checkInfo.firstArg of
+            case constructs (sameInAllBranches (AstHelpers.getSpecificValueOrFn ( [ "Maybe" ], "Nothing" ) checkInfo.lookupTable)) checkInfo.lookupTable checkInfo.firstArg of
                 Determined _ ->
                     Just
                         (alwaysResultsInUnparenthesizedConstantError
@@ -6016,7 +6016,7 @@ mapToOperationWithIdentityCanBeCombinedToOperationChecks config checkInfo =
     case secondArg checkInfo of
         Just mappableArg ->
             if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
-                case AstHelpers.getSpecificFunctionCall config.mapFn checkInfo.lookupTable mappableArg of
+                case AstHelpers.getSpecificFnCall config.mapFn checkInfo.lookupTable mappableArg of
                     Just mapCall ->
                         Just
                             (Rule.errorWithFix
@@ -6088,7 +6088,7 @@ callFromCanBeCombinedCheck :
     -> CheckInfo
     -> Maybe (Error {})
 callFromCanBeCombinedCheck config checkInfo =
-    case AstHelpers.getSpecificFunctionCall config.fromFn checkInfo.lookupTable checkInfo.firstArg of
+    case AstHelpers.getSpecificFnCall config.fromFn checkInfo.lookupTable checkInfo.firstArg of
         Just fromFnCall ->
             Just
                 (Rule.errorWithFix
@@ -6279,10 +6279,10 @@ arrayLengthOnArrayRepeatOrInitializeChecks checkInfo =
         maybeCall =
             firstThatConstructsJust
                 [ \() ->
-                    AstHelpers.getSpecificFunctionCall ( [ "Array" ], "repeat" ) checkInfo.lookupTable checkInfo.firstArg
+                    AstHelpers.getSpecificFnCall ( [ "Array" ], "repeat" ) checkInfo.lookupTable checkInfo.firstArg
                         |> Maybe.map (Tuple.pair "repeat")
                 , \() ->
-                    AstHelpers.getSpecificFunctionCall ( [ "Array" ], "initialize" ) checkInfo.lookupTable checkInfo.firstArg
+                    AstHelpers.getSpecificFnCall ( [ "Array" ], "initialize" ) checkInfo.lookupTable checkInfo.firstArg
                         |> Maybe.map (Tuple.pair "initialize")
                 ]
                 ()
@@ -6498,7 +6498,7 @@ For operations that toggle between 2 states, like `reverse` or `List.Extra.swapA
 -}
 operationDoesNotChangeResultOfOperationCheck : CheckInfo -> Maybe (Error {})
 operationDoesNotChangeResultOfOperationCheck checkInfo =
-    case Maybe.andThen (AstHelpers.getSpecificFunctionCall checkInfo.fn checkInfo.lookupTable) (fullyAppliedLastArg checkInfo) of
+    case Maybe.andThen (AstHelpers.getSpecificFnCall checkInfo.fn checkInfo.lookupTable) (fullyAppliedLastArg checkInfo) of
         Just lastArgCall ->
             let
                 areAllArgsEqual : Bool
@@ -7624,7 +7624,7 @@ randomListChecks =
         , \checkInfo ->
             case secondArg checkInfo of
                 Just elementGeneratorArg ->
-                    case AstHelpers.getSpecificFunctionCall ( [ "Random" ], "constant" ) checkInfo.lookupTable elementGeneratorArg of
+                    case AstHelpers.getSpecificFnCall ( [ "Random" ], "constant" ) checkInfo.lookupTable elementGeneratorArg of
                         Just constantCall ->
                             let
                                 currentAsString : String
@@ -7913,7 +7913,7 @@ randomGeneratorWrapper =
         , fn = ( [ "Random" ], "constant" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Random" ], "constant" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Random" ], "constant" ) lookupTable expr)
         }
     , empty = { invalid = () }
     , mapFn = ( [ "Random" ], "map" )
@@ -7929,7 +7929,7 @@ maybeWithJustAsWrap =
         { description = Constant "Nothing"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificValueOrFunction ( [ "Maybe" ], "Nothing" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificValueOrFn ( [ "Maybe" ], "Nothing" ) lookupTable expr)
         , asString =
             \resources ->
                 qualifiedToString (qualify ( [ "Maybe" ], "Nothing" ) resources)
@@ -7939,7 +7939,7 @@ maybeWithJustAsWrap =
         , fn = ( [ "Maybe" ], "Just" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Maybe" ], "Just" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Maybe" ], "Just" ) lookupTable expr)
         }
     , mapFn = ( [ "Maybe" ], "map" )
     }
@@ -7960,13 +7960,13 @@ resultWithOkAsWrap =
         , fn = ( [ "Result" ], "Ok" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Result" ], "Ok" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Result" ], "Ok" ) lookupTable expr)
         }
     , empty =
         { description = An "error"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificFunctionCall ( [ "Result" ], "Err" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificFnCall ( [ "Result" ], "Err" ) lookupTable expr)
         }
     , mapFn = ( [ "Result" ], "map" )
     }
@@ -7987,13 +7987,13 @@ resultWithErrAsWrap =
         , fn = ( [ "Result" ], "Err" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Result" ], "Err" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Result" ], "Err" ) lookupTable expr)
         }
     , empty =
         { description = An "okay result"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificFunctionCall ( [ "Result" ], "Ok" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificFnCall ( [ "Result" ], "Ok" ) lookupTable expr)
         }
     , mapFn = ( [ "Result" ], "mapError" )
     }
@@ -8014,13 +8014,13 @@ taskWithSucceedAsWrap =
         , fn = ( [ "Task" ], "succeed" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Task" ], "succeed" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Task" ], "succeed" ) lookupTable expr)
         }
     , empty =
         { description = A "failing task"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificFunctionCall ( [ "Task" ], "fail" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificFnCall ( [ "Task" ], "fail" ) lookupTable expr)
         }
     , mapFn = ( [ "Task" ], "map" )
     }
@@ -8041,13 +8041,13 @@ taskWithFailAsWrap =
         , fn = ( [ "Task" ], "fail" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Task" ], "fail" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Task" ], "fail" ) lookupTable expr)
         }
     , empty =
         { description = A "succeeding task"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificFunctionCall ( [ "Task" ], "succeed" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificFnCall ( [ "Task" ], "succeed" ) lookupTable expr)
         }
     , mapFn = ( [ "Task" ], "mapError" )
     }
@@ -8068,13 +8068,13 @@ jsonDecoderWithSucceedAsWrap =
         , fn = ( [ "Json", "Decode" ], "succeed" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Json", "Decode" ], "succeed" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Json", "Decode" ], "succeed" ) lookupTable expr)
         }
     , empty =
         { description = A "failing decoder"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificFunctionCall ( [ "Json", "Decode" ], "fail" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificFnCall ( [ "Json", "Decode" ], "fail" ) lookupTable expr)
         }
     , mapFn = ( [ "Json", "Decode" ], "map" )
     }
@@ -8150,13 +8150,13 @@ stringCollection =
         , fn = ( [ "String" ], "fromChar" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "String" ], "fromChar" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "String" ], "fromChar" ) lookupTable expr)
         }
     , fromListLiteral =
         { description = "String.fromList call"
         , getListRange =
             \lookupTable expr ->
-                AstHelpers.getSpecificFunctionCall ( [ "String" ], "fromList" ) lookupTable expr
+                AstHelpers.getSpecificFnCall ( [ "String" ], "fromList" ) lookupTable expr
                     |> Maybe.andThen (\stringFromListCall -> AstHelpers.getListLiteralRange stringFromListCall.firstArg)
         }
     , unionLeftElementsStayOnTheLeft = True
@@ -8180,7 +8180,7 @@ arrayCollection =
         { description = Constant (qualifiedToString ( [ "Array" ], "empty" ))
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificValueOrFunction ( [ "Array" ], "empty" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificValueOrFn ( [ "Array" ], "empty" ) lookupTable expr)
         , asString =
             \resources ->
                 qualifiedToString (qualify ( [ "Array" ], "empty" ) resources)
@@ -8188,13 +8188,13 @@ arrayCollection =
     , size = { description = "length", determine = arrayDetermineSize }
     , literalElements =
         \lookupTable expr ->
-            AstHelpers.getSpecificFunctionCall ( [ "Array" ], "fromList" ) lookupTable expr
+            AstHelpers.getSpecificFnCall ( [ "Array" ], "fromList" ) lookupTable expr
                 |> Maybe.andThen (\arrayFromListCall -> AstHelpers.getListLiteral arrayFromListCall.firstArg)
     , fromListLiteral =
         { description = "Array.fromList call"
         , getListRange =
             \lookupTable expr ->
-                AstHelpers.getSpecificFunctionCall ( [ "Array" ], "fromList" ) lookupTable expr
+                AstHelpers.getSpecificFnCall ( [ "Array" ], "fromList" ) lookupTable expr
                     |> Maybe.andThen (\call -> AstHelpers.getListLiteralRange call.firstArg)
         }
     , unionLeftElementsStayOnTheLeft = True
@@ -8208,21 +8208,21 @@ arrayDetermineSize :
 arrayDetermineSize resources =
     firstThatConstructsJust
         [ \expressionNode ->
-            case AstHelpers.getSpecificValueOrFunction ( [ "Array" ], "empty" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificValueOrFn ( [ "Array" ], "empty" ) resources.lookupTable expressionNode of
                 Just _ ->
                     Just (Exactly 0)
 
                 Nothing ->
                     Nothing
         , \expressionNode ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Array" ], "fromList" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificFnCall ( [ "Array" ], "fromList" ) resources.lookupTable expressionNode of
                 Just fromListCall ->
                     listDetermineLength resources fromListCall.firstArg
 
                 Nothing ->
                     Nothing
         , \expressionNode ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Array" ], "repeat" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificFnCall ( [ "Array" ], "repeat" ) resources.lookupTable expressionNode of
                 Just repeatCall ->
                     Evaluate.getInt resources repeatCall.firstArg
                         |> Maybe.map (\n -> Exactly (max 0 n))
@@ -8230,7 +8230,7 @@ arrayDetermineSize resources =
                 Nothing ->
                     Nothing
         , \expressionNode ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Array" ], "initialize" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificFnCall ( [ "Array" ], "initialize" ) resources.lookupTable expressionNode of
                 Just repeatCall ->
                     Evaluate.getInt resources repeatCall.firstArg
                         |> Maybe.map (\n -> Exactly (max 0 n))
@@ -8247,7 +8247,7 @@ setCollection =
         { description = Constant (qualifiedToString ( [ "Set" ], "empty" ))
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificValueOrFunction ( [ "Set" ], "empty" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificValueOrFn ( [ "Set" ], "empty" ) lookupTable expr)
         , asString =
             \resources ->
                 qualifiedToString (qualify ( [ "Set" ], "empty" ) resources)
@@ -8258,13 +8258,13 @@ setCollection =
         , fn = ( [ "Set" ], "singleton" )
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFunctionCall ( [ "Set" ], "singleton" ) lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall ( [ "Set" ], "singleton" ) lookupTable expr)
         }
     , fromListLiteral =
         { description = "Set.fromList call"
         , getListRange =
             \lookupTable expr ->
-                AstHelpers.getSpecificFunctionCall ( [ "Set" ], "fromList" ) lookupTable expr
+                AstHelpers.getSpecificFnCall ( [ "Set" ], "fromList" ) lookupTable expr
                     |> Maybe.andThen (\setFromListCall -> AstHelpers.getListLiteralRange setFromListCall.firstArg)
         }
     , unionLeftElementsStayOnTheLeft = True
@@ -8278,21 +8278,21 @@ setDetermineSize :
 setDetermineSize resources =
     firstThatConstructsJust
         [ \expressionNode ->
-            case AstHelpers.getSpecificValueOrFunction ( [ "Set" ], "empty" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificValueOrFn ( [ "Set" ], "empty" ) resources.lookupTable expressionNode of
                 Just _ ->
                     Just (Exactly 0)
 
                 Nothing ->
                     Nothing
         , \expressionNode ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Set" ], "singleton" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificFnCall ( [ "Set" ], "singleton" ) resources.lookupTable expressionNode of
                 Just _ ->
                     Just (Exactly 1)
 
                 Nothing ->
                     Nothing
         , \expressionNode ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Set" ], "fromList" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificFnCall ( [ "Set" ], "fromList" ) resources.lookupTable expressionNode of
                 Just fromListCall ->
                     case AstHelpers.getListLiteral fromListCall.firstArg of
                         Just [] ->
@@ -8324,7 +8324,7 @@ dictCollection =
         { description = Constant (qualifiedToString ( [ "Dict" ], "empty" ))
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificValueOrFunction ( [ "Dict" ], "empty" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificValueOrFn ( [ "Dict" ], "empty" ) lookupTable expr)
         , asString =
             \resources ->
                 qualifiedToString (qualify ( [ "Dict" ], "empty" ) resources)
@@ -8334,7 +8334,7 @@ dictCollection =
         { description = "Dict.fromList call"
         , getListRange =
             \lookupTable expr ->
-                AstHelpers.getSpecificFunctionCall ( [ "Dict" ], "fromList" ) lookupTable expr
+                AstHelpers.getSpecificFnCall ( [ "Dict" ], "fromList" ) lookupTable expr
                     |> Maybe.andThen (\dictFromListCall -> AstHelpers.getListLiteralRange dictFromListCall.firstArg)
         }
     , unionLeftElementsStayOnTheLeft = False
@@ -8348,14 +8348,14 @@ dictDetermineSize :
 dictDetermineSize resources =
     firstThatConstructsJust
         [ \expressionNode ->
-            case AstHelpers.getSpecificValueOrFunction ( [ "Dict" ], "empty" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificValueOrFn ( [ "Dict" ], "empty" ) resources.lookupTable expressionNode of
                 Just _ ->
                     Just (Exactly 0)
 
                 Nothing ->
                     Nothing
         , \expressionNode ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Dict" ], "singleton" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificFnCall ( [ "Dict" ], "singleton" ) resources.lookupTable expressionNode of
                 Just singletonCall ->
                     case singletonCall.argsAfterFirst of
                         _ :: [] ->
@@ -8367,7 +8367,7 @@ dictDetermineSize resources =
                 Nothing ->
                     Nothing
         , \expressionNode ->
-            case AstHelpers.getSpecificFunctionCall ( [ "Dict" ], "fromList" ) resources.lookupTable expressionNode of
+            case AstHelpers.getSpecificFnCall ( [ "Dict" ], "fromList" ) resources.lookupTable expressionNode of
                 Just fromListCall ->
                     case AstHelpers.getListLiteral fromListCall.firstArg of
                         Just [] ->
@@ -8400,7 +8400,7 @@ cmdCollection =
             Constant "Cmd.none"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificValueOrFunction ( [ "Platform", "Cmd" ], "none" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificValueOrFn ( [ "Platform", "Cmd" ], "none" ) lookupTable expr)
         , asString =
             \resources ->
                 qualifiedToString (qualify ( [ "Platform", "Cmd" ], "none" ) resources)
@@ -8416,7 +8416,7 @@ subCollection =
             Constant "Sub.none"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificValueOrFunction ( [ "Platform", "Sub" ], "none" ) lookupTable expr)
+                isJust (AstHelpers.getSpecificValueOrFn ( [ "Platform", "Sub" ], "none" ) lookupTable expr)
         , asString =
             \resources ->
                 qualifiedToString (qualify ( [ "Platform", "Sub" ], "none" ) resources)
@@ -8687,7 +8687,7 @@ wrapperAndThenChecks wrapper =
                 Nothing ->
                     Nothing
         , \checkInfo ->
-            case AstHelpers.getSpecificValueOrFunction wrapper.wrap.fn checkInfo.lookupTable checkInfo.firstArg of
+            case AstHelpers.getSpecificValueOrFn wrapper.wrap.fn checkInfo.lookupTable checkInfo.firstArg of
                 Just _ ->
                     Just
                         (alwaysReturnsLastArgError
@@ -8851,7 +8851,7 @@ fromMaybeChecks config checkInfo =
         Just maybeArg ->
             firstThatConstructsJust
                 [ \() ->
-                    case sameInAllBranches (AstHelpers.getSpecificValueOrFunction ( [ "Maybe" ], "Nothing" ) checkInfo.lookupTable) maybeArg of
+                    case sameInAllBranches (AstHelpers.getSpecificValueOrFn ( [ "Maybe" ], "Nothing" ) checkInfo.lookupTable) maybeArg of
                         Determined _ ->
                             Just
                                 (Rule.errorWithFix
@@ -8871,7 +8871,7 @@ fromMaybeChecks config checkInfo =
                         Undetermined ->
                             Nothing
                 , \() ->
-                    case sameInAllBranches (AstHelpers.getSpecificFunctionCall ( [ "Maybe" ], "Just" ) checkInfo.lookupTable) maybeArg of
+                    case sameInAllBranches (AstHelpers.getSpecificFnCall ( [ "Maybe" ], "Just" ) checkInfo.lookupTable) maybeArg of
                         Determined justCalls ->
                             Just
                                 (Rule.errorWithFix
@@ -10787,7 +10787,7 @@ constructs :
     -> Node Expression
     -> Match specific
 constructs getSpecific lookupTable expressionNode =
-    case AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "always" ) lookupTable expressionNode of
+    case AstHelpers.getSpecificFnCall ( [ "Basics" ], "always" ) lookupTable expressionNode of
         Just alwaysCall ->
             getSpecific alwaysCall.firstArg
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4233,8 +4233,7 @@ orSideChecks side checkInfo =
 andChecks : OperatorCheckInfo -> Maybe (Error {})
 andChecks =
     firstThatConstructsJust
-        [ \checkInfo -> andSideCheck { node = checkInfo.left, otherNode = checkInfo.right } checkInfo
-        , \checkInfo -> andSideCheck { node = checkInfo.right, otherNode = checkInfo.left } checkInfo
+        [ \checkInfo -> findMap (\side -> andSideCheck side checkInfo) (operationSides checkInfo)
         , findSimilarConditionsError
         ]
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9366,7 +9366,7 @@ collectionDiffChecks collection =
             if collection.empty.is checkInfo.lookupTable checkInfo.firstArg then
                 Just
                     (alwaysResultsInUnparenthesizedConstantError
-                        (qualifiedToString checkInfo.fn ++ " on " ++ emptyAsString checkInfo collection)
+                        (qualifiedToString checkInfo.fn ++ " " ++ emptyAsString checkInfo collection)
                         { replacement = collection.empty.asString }
                         checkInfo
                     )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3036,8 +3036,8 @@ addingZeroCheck checkInfo =
                         { message = "Unnecessary addition with 0"
                         , details = [ "Adding 0 does not change the value of the number." ]
                         }
-                        side.errorRange
-                        [ Fix.removeRange side.removeRange ]
+                        (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
+                        (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })
                     )
 
             else
@@ -3134,8 +3134,8 @@ multiplyChecks checkInfo =
                                 { message = "Unnecessary multiplication by 1"
                                 , details = [ "Multiplying by 1 does not change the value of the number." ]
                                 }
-                                side.errorRange
-                                [ Fix.removeRange side.removeRange ]
+                                (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
+                                (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })
                             )
 
                     else if number == 0 then
@@ -3151,7 +3151,7 @@ by explicitly checking for `Basics.isNaN` and `Basics.isInfinite`."""
 Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#isInfinite"""
                                     ]
                                 }
-                                side.errorRange
+                                (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
                                 (if checkInfo.expectNaN then
                                     []
 
@@ -3169,16 +3169,10 @@ Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#
         (operationToSides checkInfo)
 
 
-operationToSides : OperatorCheckInfo -> List { node : Node Expression, removeRange : Range, errorRange : Range }
+operationToSides : OperatorCheckInfo -> List { node : Node Expression, otherNode : Node Expression }
 operationToSides checkInfo =
-    [ { node = checkInfo.right
-      , removeRange = removeRightRange checkInfo
-      , errorRange = errorToRightRange checkInfo
-      }
-    , { node = checkInfo.left
-      , removeRange = removeLeftRange checkInfo
-      , errorRange = errorToLeftRange checkInfo
-      }
+    [ { node = checkInfo.right, otherNode = checkInfo.left }
+    , { node = checkInfo.left, otherNode = checkInfo.right }
     ]
 
 
@@ -3789,8 +3783,8 @@ equalityChecks isEqual =
                                 { message = "Unnecessary comparison with boolean"
                                 , details = [ "The result of the expression will be the same with or without the comparison." ]
                                 }
-                                side.errorRange
-                                [ Fix.removeRange side.removeRange ]
+                                (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
+                                (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })
                             )
 
                     else

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3079,7 +3079,7 @@ minusChecks checkInfo =
                 , details = [ "Subtracting 0 does not change the value of the number." ]
                 }
                 (errorToRightRange checkInfo)
-                [ Fix.removeRange (removeRightRange checkInfo) ]
+                (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.left })
             )
 
     else if AstHelpers.getUncomputedNumberValue checkInfo.left == Just 0 then

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9379,8 +9379,8 @@ collectionDiffChecks collection =
                     if collection.empty.is checkInfo.lookupTable collectionArg then
                         Just
                             (Rule.errorWithFix
-                                { message = "Diffing a " ++ collection.represents ++ " with " ++ emptyAsString checkInfo collection ++ " will result in the " ++ collection.represents ++ " itself"
-                                , details = [ "You can replace this call by the " ++ collection.represents ++ " itself." ]
+                                { message = "Unnecessary " ++ qualifiedToString checkInfo.fn ++ " with " ++ emptyAsString checkInfo collection
+                                , details = [ "You can replace this call by the given first " ++ collection.represents ++ "." ]
                                 }
                                 checkInfo.fnRange
                                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg })
@@ -9415,7 +9415,7 @@ collectionUnionChecks collection =
                         Just
                             (Rule.errorWithFix
                                 { message = "Unnecessary " ++ qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " with " ++ descriptionForIndefinite collection.empty.description
-                                , details = [ "You can replace this call by the " ++ collection.represents ++ " itself." ]
+                                , details = [ "You can replace this call by the given first " ++ collection.represents ++ "." ]
                                 }
                                 checkInfo.fnRange
                                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg })

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3322,19 +3322,15 @@ plusplusChecks =
         , \checkInfo ->
             findMap (\side -> appendEmptyCheck side listCollection checkInfo) (operationSides checkInfo)
         , \checkInfo ->
-            findMap
-                (\side ->
-                    collectionUnionWithLiteralsChecks listCollection
-                        { lookupTable = checkInfo.lookupTable
-                        , extractSourceCode = checkInfo.extractSourceCode
-                        , parentRange = checkInfo.parentRange
-                        , first = side.node
-                        , second = side.otherNode
-                        , operationRange = checkInfo.operatorRange
-                        , operation = "++"
-                        }
-                )
-                (operationSides checkInfo)
+            collectionUnionWithLiteralsChecks listCollection
+                { lookupTable = checkInfo.lookupTable
+                , extractSourceCode = checkInfo.extractSourceCode
+                , parentRange = checkInfo.parentRange
+                , first = checkInfo.left
+                , second = checkInfo.right
+                , operationRange = checkInfo.operatorRange
+                , operation = "++"
+                }
         , \checkInfo ->
             collectionUnionWithLiteralsChecks stringCollection
                 { lookupTable = checkInfo.lookupTable

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6488,7 +6488,7 @@ operationDoesNotChangeResultOfOperationCompositionCheck checkInfo =
                 )
                 (List.map2 Tuple.pair checkInfo.later.args checkInfo.earlier.args)
     in
-    if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == checkInfo.later.fn) == areAllArgsEqual () then
+    if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == checkInfo.later.fn) && areAllArgsEqual () then
         Just
             { info =
                 { message =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2943,8 +2943,8 @@ compositionIntoChecks =
         ]
 
 
-removeAlongWithOtherFunctionCheck : CheckInfo -> Maybe (Error {})
-removeAlongWithOtherFunctionCheck checkInfo =
+toggleCallChecks : CheckInfo -> Maybe (Error {})
+toggleCallChecks checkInfo =
     onCallToInverseReturnsItsArgumentCheck checkInfo.fn checkInfo
 
 
@@ -3779,7 +3779,7 @@ toggleCompositionChecks checkInfo =
 
 basicsNegateChecks : CheckInfo -> Maybe (Error {})
 basicsNegateChecks =
-    removeAlongWithOtherFunctionCheck
+    toggleCallChecks
 
 
 
@@ -3790,7 +3790,7 @@ basicsNotChecks : CheckInfo -> Maybe (Error {})
 basicsNotChecks =
     firstThatConstructsJust
         [ notOnKnownBoolCheck
-        , removeAlongWithOtherFunctionCheck
+        , toggleCallChecks
         , isNotOnBooleanOperatorCheck
         ]
 
@@ -6562,7 +6562,7 @@ emptiableReverseChecks : EmptiableProperties otherProperties -> CheckInfo -> May
 emptiableReverseChecks emptiable =
     firstThatConstructsJust
         [ callOnEmptyReturnsEmptyCheck emptiable
-        , removeAlongWithOtherFunctionCheck
+        , toggleCallChecks
         ]
 
 
@@ -6607,7 +6607,7 @@ Examples of such functions:
 
 Note that `update` or `setWhere` operations for example _can_ have an effect even after the same operation has already been applied.
 
-For operations that toggle between 2 states, like `reverse` or `List.Extra.swapAt i j`, use `removeAlongWithOtherFunctionCheck`
+For operations that toggle between 2 states, like `reverse` or `List.Extra.swapAt i j`, use `toggleCallChecks`
 
 -}
 operationDoesNotChangeResultOfOperationCheck : CheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4518,7 +4518,7 @@ stringReverseChecks =
 stringReverseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 stringReverseCompositionChecks =
     firstThatConstructsJust
-        [ compositionAfterWrapIsUnnecessaryCheck { laterArgCount = 1 } stringCollection
+        [ compositionAfterWrapIsUnnecessaryCheck stringCollection
         , toggleCompositionChecks
         ]
 
@@ -4876,7 +4876,7 @@ resultMapErrorCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAnd
 resultMapErrorCompositionChecks =
     firstThatConstructsJust
         [ wrapToMapCompositionChecks resultWithErrAsWrap
-        , unnecessaryCompositionAfterEmptyCheck { laterArgCount = 2 } resultWithErrAsWrap
+        , unnecessaryCompositionAfterEmptyCheck resultWithErrAsWrap
         ]
 
 
@@ -4944,7 +4944,7 @@ listConcatCompositionChecks =
     firstThatConstructsJust
         [ compositionFromCanBeCombinedCheck
             { fromFn = ( [ "List" ], "map" ), combinedFn = ( [ "List" ], "concatMap" ) }
-        , onWrapAlwaysReturnsIncomingCompositionCheck { operationArgCount = 1 } listCollection
+        , onWrapAlwaysReturnsIncomingCompositionCheck listCollection
         ]
 
 
@@ -5117,7 +5117,7 @@ listIntersperseChecks =
 
 listIntersperseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listIntersperseCompositionChecks =
-    compositionAfterWrapIsUnnecessaryCheck { laterArgCount = 2 } listCollection
+    compositionAfterWrapIsUnnecessaryCheck listCollection
 
 
 listHeadChecks : CheckInfo -> Maybe (Error {})
@@ -5526,7 +5526,7 @@ listSumChecks =
 
 sumCompositionChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 sumCompositionChecks wrapper =
-    onWrapAlwaysReturnsIncomingCompositionCheck { operationArgCount = 1 } wrapper
+    onWrapAlwaysReturnsIncomingCompositionCheck wrapper
 
 
 listProductChecks : CheckInfo -> Maybe (Error {})
@@ -5539,7 +5539,7 @@ listProductChecks =
 
 productCompositionChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 productCompositionChecks wrapper =
-    onWrapAlwaysReturnsIncomingCompositionCheck { operationArgCount = 1 } wrapper
+    onWrapAlwaysReturnsIncomingCompositionCheck wrapper
 
 
 listMinimumChecks : CheckInfo -> Maybe (Error {})
@@ -5552,7 +5552,7 @@ listMinimumChecks =
 
 minimumCompositionChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 minimumCompositionChecks wrapper =
-    onWrapAlwaysReturnsJustIncomingCompositionCheck { operationArgCount = 1 } wrapper
+    onWrapAlwaysReturnsJustIncomingCompositionCheck wrapper
 
 
 listMaximumChecks : CheckInfo -> Maybe (Error {})
@@ -5565,7 +5565,7 @@ listMaximumChecks =
 
 maximumCompositionChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 maximumCompositionChecks wrapper =
-    onWrapAlwaysReturnsJustIncomingCompositionCheck { operationArgCount = 1 } wrapper
+    onWrapAlwaysReturnsJustIncomingCompositionCheck wrapper
 
 
 listFoldlChecks : CheckInfo -> Maybe (Error {})
@@ -6405,7 +6405,7 @@ listReverseChecks =
 listReverseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listReverseCompositionChecks =
     firstThatConstructsJust
-        [ compositionAfterWrapIsUnnecessaryCheck { laterArgCount = 1 } listCollection
+        [ compositionAfterWrapIsUnnecessaryCheck listCollection
         , toggleCompositionChecks
         ]
 
@@ -6421,7 +6421,7 @@ listSortChecks =
 
 listSortCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listSortCompositionChecks =
-    operationDoesNotChangeResultOfOperationCompositionCheck { argCount = 1 }
+    operationDoesNotChangeResultOfOperationCompositionCheck
 
 
 {-| Condense applying the same function with equal arguments (except the last one) twice in sequence into one.
@@ -6477,8 +6477,8 @@ operationDoesNotChangeResultOfOperationCheck checkInfo =
             Nothing
 
 
-operationDoesNotChangeResultOfOperationCompositionCheck : { argCount : Int } -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-operationDoesNotChangeResultOfOperationCompositionCheck config checkInfo =
+operationDoesNotChangeResultOfOperationCompositionCheck : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+operationDoesNotChangeResultOfOperationCompositionCheck checkInfo =
     let
         areAllArgsEqual : () -> Bool
         areAllArgsEqual () =
@@ -6488,11 +6488,11 @@ operationDoesNotChangeResultOfOperationCompositionCheck config checkInfo =
                 )
                 (List.map2 Tuple.pair checkInfo.later.args checkInfo.earlier.args)
     in
-    if (List.length checkInfo.later.args == (config.argCount - 1)) && (checkInfo.earlier.fn == checkInfo.later.fn) == areAllArgsEqual () then
+    if (List.length checkInfo.later.args == (checkInfo.later.argCount - 1)) && (checkInfo.earlier.fn == checkInfo.later.fn) == areAllArgsEqual () then
         Just
             { info =
                 { message =
-                    case config.argCount of
+                    case checkInfo.later.argCount of
                         1 ->
                             "Unnecessary " ++ qualifiedToString checkInfo.later.fn ++ " after " ++ qualifiedToString checkInfo.earlier.fn
 
@@ -6542,7 +6542,7 @@ listSortByChecks =
 
 listSortByCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listSortByCompositionChecks =
-    operationDoesNotChangeResultOfOperationCompositionCheck { argCount = 2 }
+    operationDoesNotChangeResultOfOperationCompositionCheck
 
 
 listSortWithChecks : CheckInfo -> Maybe (Error {})
@@ -7066,7 +7066,7 @@ subAndCmdBatchChecks batchable =
 
 batchCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 batchCompositionChecks =
-    onWrapAlwaysReturnsIncomingCompositionCheck { operationArgCount = 1 } listCollection
+    onWrapAlwaysReturnsIncomingCompositionCheck listCollection
 
 
 
@@ -8709,7 +8709,7 @@ withDefaultChecks emptiable =
 
 wrapperWithDefaultChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 wrapperWithDefaultChecks wrapper =
-    onWrapAlwaysReturnsIncomingCompositionCheck { operationArgCount = 2 } wrapper
+    onWrapAlwaysReturnsIncomingCompositionCheck wrapper
 
 
 emptiableWithDefaultChecks :
@@ -8766,7 +8766,7 @@ unwrapToMaybeChecks emptiableWrapper =
 resultToMaybeCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 resultToMaybeCompositionChecks =
     firstThatConstructsJust
-        [ onWrapAlwaysReturnsJustIncomingCompositionCheck { operationArgCount = 1 } resultWithOkAsWrap
+        [ onWrapAlwaysReturnsJustIncomingCompositionCheck resultWithOkAsWrap
         , \checkInfo ->
             case checkInfo.earlier.fn of
                 ( [ "Result" ], "Err" ) ->
@@ -9007,9 +9007,9 @@ pipingIntoCompositionChecks context compositionDirection expressionNode =
                 )
 
 
-compositionAfterWrapIsUnnecessaryCheck : { laterArgCount : Int } -> WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-compositionAfterWrapIsUnnecessaryCheck config wrapper =
-    unnecessaryCompositionAfterCheck config wrapper.wrap
+compositionAfterWrapIsUnnecessaryCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+compositionAfterWrapIsUnnecessaryCheck wrapper =
+    unnecessaryCompositionAfterCheck wrapper.wrap
 
 
 callOnWrappedDoesNotChangeItCheck : WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
@@ -9128,32 +9128,28 @@ Use together with `callOnEmptyReturnsEmptyCheck`
 
 -}
 unnecessaryCompositionAfterEmptyCheck :
-    { laterArgCount : Int }
-    ->
-        { a
-            | empty :
-                { empty
-                    | description : Description
-                    , fn : ( ModuleName, String )
-                }
-        }
+    { a
+        | empty :
+            { empty
+                | description : Description
+                , fn : ( ModuleName, String )
+            }
+    }
     -> CompositionIntoCheckInfo
     -> Maybe ErrorInfoAndFix
-unnecessaryCompositionAfterEmptyCheck config emptiable =
-    unnecessaryCompositionAfterCheck config emptiable.empty
+unnecessaryCompositionAfterEmptyCheck emptiable =
+    unnecessaryCompositionAfterCheck emptiable.empty
 
 
 unnecessaryCompositionAfterCheck :
-    { laterArgCount : Int }
-    ->
-        { construct
-            | description : Description
-            , fn : ( ModuleName, String )
-        }
+    { construct
+        | description : Description
+        , fn : ( ModuleName, String )
+    }
     -> CompositionIntoCheckInfo
     -> Maybe ErrorInfoAndFix
-unnecessaryCompositionAfterCheck config construct checkInfo =
-    if (List.length checkInfo.later.args == (config.laterArgCount - 1)) && (checkInfo.earlier.fn == construct.fn) then
+unnecessaryCompositionAfterCheck construct checkInfo =
+    if (List.length checkInfo.later.args == (checkInfo.later.argCount - 1)) && (checkInfo.earlier.fn == construct.fn) then
         Just
             { info =
                 { message = qualifiedToString checkInfo.later.fn ++ " on " ++ descriptionForIndefinite construct.description ++ " will result in " ++ descriptionForDefinite "the unchanged" construct.description
@@ -9222,9 +9218,9 @@ For example
 Use together with `callOnWrapReturnsItsValue`.
 
 -}
-onWrapAlwaysReturnsIncomingCompositionCheck : { operationArgCount : Int } -> WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-onWrapAlwaysReturnsIncomingCompositionCheck config wrapper checkInfo =
-    if (checkInfo.earlier.fn == wrapper.wrap.fn) && (List.length checkInfo.later.args == (config.operationArgCount - 1)) then
+onWrapAlwaysReturnsIncomingCompositionCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+onWrapAlwaysReturnsIncomingCompositionCheck wrapper checkInfo =
+    if (checkInfo.earlier.fn == wrapper.wrap.fn) && (List.length checkInfo.later.args == (checkInfo.later.argCount - 1)) then
         Just
             (compositionAlwaysReturnsIncomingError
                 (qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will always result in the value inside")
@@ -9293,9 +9289,9 @@ For example
 Use together with `callOnWrapReturnsJustItsValue`.
 
 -}
-onWrapAlwaysReturnsJustIncomingCompositionCheck : { operationArgCount : Int } -> WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-onWrapAlwaysReturnsJustIncomingCompositionCheck config wrapper checkInfo =
-    if (checkInfo.earlier.fn == wrapper.wrap.fn) && (List.length checkInfo.later.args == (config.operationArgCount - 1)) then
+onWrapAlwaysReturnsJustIncomingCompositionCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+onWrapAlwaysReturnsJustIncomingCompositionCheck wrapper checkInfo =
+    if (checkInfo.earlier.fn == wrapper.wrap.fn) && (List.length checkInfo.later.args == (checkInfo.later.argCount - 1)) then
         Just
             { info =
                 { message = qualifiedToString checkInfo.later.fn ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will always result in Just the value inside"

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3203,16 +3203,6 @@ andBetweenRange ranges =
             { start = ranges.included.start, end = ranges.excluded.start }
 
 
-errorToLeftRange : { checkInfo | leftRange : Range, operatorRange : Range } -> Range
-errorToLeftRange checkInfo =
-    { start = checkInfo.leftRange.start, end = checkInfo.operatorRange.end }
-
-
-errorToRightRange : { checkInfo | rightRange : Range, operatorRange : Range } -> Range
-errorToRightRange checkInfo =
-    { start = checkInfo.operatorRange.start, end = checkInfo.rightRange.end }
-
-
 divisionChecks : OperatorCheckInfo -> Maybe (Error {})
 divisionChecks checkInfo =
     let

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3043,7 +3043,7 @@ addingZeroCheck checkInfo =
             else
                 Nothing
         )
-        (operationToSides checkInfo)
+        (operationSides checkInfo)
 
 
 addingOppositesCheck : OperatorCheckInfo -> Maybe (Error {})
@@ -3166,11 +3166,11 @@ Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#
                 Nothing ->
                     Nothing
         )
-        (operationToSides checkInfo)
+        (operationSides checkInfo)
 
 
-operationToSides : OperatorCheckInfo -> List { node : Node Expression, otherNode : Node Expression }
-operationToSides checkInfo =
+operationSides : OperatorCheckInfo -> List { node : Node Expression, otherNode : Node Expression }
+operationSides checkInfo =
     [ { node = checkInfo.right, otherNode = checkInfo.left }
     , { node = checkInfo.left, otherNode = checkInfo.right }
     ]
@@ -3790,7 +3790,7 @@ equalityChecks isEqual =
                     else
                         Nothing
                 )
-                (operationToSides checkInfo)
+                (operationSides checkInfo)
         , \checkInfo ->
             case
                 Maybe.map2 Tuple.pair

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9003,20 +9003,20 @@ compositionAfterWrapIsUnnecessaryCheck wrapper =
 
 callOnWrappedDoesNotChangeItCheck : WrapperProperties otherProperties -> CheckInfo -> Maybe (Error {})
 callOnWrappedDoesNotChangeItCheck wrapper =
-    callOnDoesNotChangeItCheck
+    unnecessaryCallOnCheck
         { description = wrapper.wrap.description
         , is = \lookupTable expr -> isJust (wrapper.wrap.getValue lookupTable expr)
         }
 
 
-callOnDoesNotChangeItCheck :
+unnecessaryCallOnCheck :
     { a
         | description : Description
         , is : ModuleNameLookupTable -> Node Expression -> Bool
     }
     -> CheckInfo
     -> Maybe (Error {})
-callOnDoesNotChangeItCheck constructable checkInfo =
+unnecessaryCallOnCheck constructable checkInfo =
     case fullyAppliedLastArg checkInfo of
         Just constructableArg ->
             let
@@ -9059,7 +9059,7 @@ callOnEmptyReturnsEmptyCheck :
     -> CheckInfo
     -> Maybe (Error {})
 callOnEmptyReturnsEmptyCheck emptiable =
-    callOnDoesNotChangeItCheck emptiable.empty
+    unnecessaryCallOnCheck emptiable.empty
 
 
 callOnEmptyReturnsCheck :

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4518,7 +4518,7 @@ stringReverseChecks =
 stringReverseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 stringReverseCompositionChecks =
     firstThatConstructsJust
-        [ compositionAfterWrapIsUnnecessaryCheck stringCollection
+        [ unnecessaryCompositionAfterWrapCheck stringCollection
         , toggleCompositionChecks
         ]
 
@@ -5117,7 +5117,7 @@ listIntersperseChecks =
 
 listIntersperseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listIntersperseCompositionChecks =
-    compositionAfterWrapIsUnnecessaryCheck listCollection
+    unnecessaryCompositionAfterWrapCheck listCollection
 
 
 listHeadChecks : CheckInfo -> Maybe (Error {})
@@ -6405,7 +6405,7 @@ listReverseChecks =
 listReverseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listReverseCompositionChecks =
     firstThatConstructsJust
-        [ compositionAfterWrapIsUnnecessaryCheck listCollection
+        [ unnecessaryCompositionAfterWrapCheck listCollection
         , toggleCompositionChecks
         ]
 
@@ -8996,8 +8996,8 @@ operationDoesNotChangeResultOfOperationCompositionCheck checkInfo =
         Nothing
 
 
-compositionAfterWrapIsUnnecessaryCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-compositionAfterWrapIsUnnecessaryCheck wrapper =
+unnecessaryCompositionAfterWrapCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+unnecessaryCompositionAfterWrapCheck wrapper =
     unnecessaryCompositionAfterCheck wrapper.wrap
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4233,13 +4233,13 @@ orSideChecks side checkInfo =
 andChecks : OperatorCheckInfo -> Maybe (Error {})
 andChecks =
     firstThatConstructsJust
-        [ \checkInfo -> findMap (\side -> andSideCheck side checkInfo) (operationSides checkInfo)
+        [ \checkInfo -> findMap (\side -> andSideChecks side checkInfo) (operationSides checkInfo)
         , findSimilarConditionsError
         ]
 
 
-andSideCheck : { node : Node Expression, otherNode : Node Expression } -> OperatorCheckInfo -> Maybe (Error {})
-andSideCheck side checkInfo =
+andSideChecks : { node : Node Expression, otherNode : Node Expression } -> OperatorCheckInfo -> Maybe (Error {})
+andSideChecks side checkInfo =
     case Evaluate.getBoolean checkInfo side.node of
         Determined True ->
             Just

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3176,33 +3176,6 @@ operationSides checkInfo =
     ]
 
 
-{-| Takes the ranges of two neighboring elements and
-returns a range that includes the specified element and everything between them.
-
-This is useful when you can't use `replaceBySubExpressionFix` and `keepOnlyFix` because there is no
-existing node that could be kept.
-
-For example, you might want to remove `|> identity` in `f |> g |> identity`. `elm-syntax` might represent this as (simplified)
-
-    Op (Var "f") "|>" (Op (Var "g") "|>" (Var "identity"))
-
-In practice, you will check this syntax tree recursively, leading to situations where we only know
-
-  - the previous/next element which we want to keep
-  - and the current element which we want to remove
-
--}
-andBetweenRange : { excluded : Range, included : Range } -> Range
-andBetweenRange ranges =
-    case Range.compare ranges.excluded ranges.included of
-        LT ->
-            { start = ranges.excluded.end, end = ranges.included.end }
-
-        -- GT | EQ ->
-        _ ->
-            { start = ranges.included.start, end = ranges.excluded.start }
-
-
 divisionChecks : OperatorCheckInfo -> Maybe (Error {})
 divisionChecks checkInfo =
     let
@@ -10388,6 +10361,33 @@ rangeBetweenExclusive ( aRange, bRange ) =
         -- EQ | LT
         _ ->
             { start = aRange.end, end = bRange.start }
+
+
+{-| Takes the ranges of two neighboring elements and
+returns a range that includes the specified element and everything between them.
+
+This is useful when you can't use `replaceBySubExpressionFix` and `keepOnlyFix` because there is no
+existing node that could be kept.
+
+For example, you might want to remove `|> identity` in `f |> g |> identity`. `elm-syntax` might represent this as (simplified)
+
+    Op (Var "f") "|>" (Op (Var "g") "|>" (Var "identity"))
+
+In practice, you will check this syntax tree recursively, leading to situations where we only know
+
+  - the previous/next element which we want to keep
+  - and the current element which we want to remove
+
+-}
+andBetweenRange : { excluded : Range, included : Range } -> Range
+andBetweenRange ranges =
+    case Range.compare ranges.excluded ranges.included of
+        LT ->
+            { start = ranges.excluded.end, end = ranges.included.end }
+
+        -- GT | EQ ->
+        _ ->
+            { start = ranges.included.start, end = ranges.excluded.start }
 
 
 rangeContainsLocation : Location -> Range -> Bool

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3243,7 +3243,7 @@ divisionChecks checkInfo =
                 , details = [ "Dividing by 1 does not change the value of the number." ]
                 }
                 (errorToRightRange checkInfo)
-                [ Fix.removeRange (removeRightRange checkInfo) ]
+                (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.left })
             )
 
     else if not checkInfo.expectNaN && (AstHelpers.getUncomputedNumberValue checkInfo.left == Just 0) then

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3337,37 +3337,35 @@ plusplusChecks =
                 _ ->
                     Nothing
         , \checkInfo ->
-            case AstHelpers.getListLiteral checkInfo.left of
-                Just [] ->
-                    Just
-                        (Rule.errorWithFix
-                            (concatenateEmptyErrorInfo { represents = "list", emptyDescription = "[]" })
-                            checkInfo.operatorRange
-                            (keepOnlyFix
-                                { keep = checkInfo.rightRange
-                                , parentRange = checkInfo.parentRange
-                                }
-                            )
+            if listCollection.empty.is checkInfo.lookupTable checkInfo.left then
+                Just
+                    (Rule.errorWithFix
+                        (concatenateEmptyErrorInfo { represents = "list", emptyDescription = "[]" })
+                        checkInfo.operatorRange
+                        (keepOnlyFix
+                            { keep = checkInfo.rightRange
+                            , parentRange = checkInfo.parentRange
+                            }
                         )
+                    )
 
-                _ ->
-                    Nothing
+            else
+                Nothing
         , \checkInfo ->
-            case AstHelpers.getListLiteral checkInfo.right of
-                Just [] ->
-                    Just
-                        (Rule.errorWithFix
-                            (concatenateEmptyErrorInfo { represents = "list", emptyDescription = "[]" })
-                            checkInfo.operatorRange
-                            (keepOnlyFix
-                                { keep = checkInfo.leftRange
-                                , parentRange = checkInfo.parentRange
-                                }
-                            )
+            if listCollection.empty.is checkInfo.lookupTable checkInfo.right then
+                Just
+                    (Rule.errorWithFix
+                        (concatenateEmptyErrorInfo { represents = "list", emptyDescription = "[]" })
+                        checkInfo.operatorRange
+                        (keepOnlyFix
+                            { keep = checkInfo.leftRange
+                            , parentRange = checkInfo.parentRange
+                            }
                         )
+                    )
 
-                _ ->
-                    Nothing
+            else
+                Nothing
         , \checkInfo ->
             collectionUnionWithLiteralsChecks listCollection
                 { lookupTable = checkInfo.lookupTable

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4169,7 +4169,7 @@ orSideChecks side checkInfo =
                     { message = "Unnecessary check for || False"
                     , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " bool." ]
                     }
-                    checkInfo.parentRange
+                    (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
                     (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })
                 )
 
@@ -4194,7 +4194,7 @@ andSideChecks side checkInfo =
                     { message = "Unnecessary check for && True"
                     , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " bool." ]
                     }
-                    checkInfo.parentRange
+                    (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
                     (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })
                 )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4526,7 +4526,7 @@ stringReverseCompositionChecks =
 stringSliceChecks : CheckInfo -> Maybe (Error {})
 stringSliceChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck stringCollection
+        [ unnecessaryCallOnEmptyCheck stringCollection
         , \checkInfo ->
             case secondArg checkInfo of
                 Just endArg ->
@@ -4598,7 +4598,7 @@ stringSliceChecks =
 stringLeftChecks : CheckInfo -> Maybe (Error {})
 stringLeftChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck stringCollection
+        [ unnecessaryCallOnEmptyCheck stringCollection
         , \checkInfo ->
             case Evaluate.getInt checkInfo checkInfo.firstArg of
                 Just length ->
@@ -4645,7 +4645,7 @@ callWithNonPositiveIntCanBeReplacedByCheck config checkInfo =
 stringRightChecks : CheckInfo -> Maybe (Error {})
 stringRightChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck stringCollection
+        [ unnecessaryCallOnEmptyCheck stringCollection
         , \checkInfo ->
             case Evaluate.getInt checkInfo checkInfo.firstArg of
                 Just length ->
@@ -4742,7 +4742,7 @@ stringRepeatChecks =
 stringReplaceChecks : CheckInfo -> Maybe (Error {})
 stringReplaceChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck stringCollection
+        [ unnecessaryCallOnEmptyCheck stringCollection
         , \checkInfo ->
             case secondArg checkInfo of
                 Just replacementArg ->
@@ -4887,7 +4887,7 @@ resultMapErrorCompositionChecks =
 listConcatChecks : CheckInfo -> Maybe (Error {})
 listConcatChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck listCollection
+        [ unnecessaryCallOnEmptyCheck listCollection
         , callOnWrapReturnsItsValue listCollection
         , callOnListWithIrrelevantEmptyElement listCollection
         , \checkInfo ->
@@ -5042,7 +5042,7 @@ operationWithIdentityCanBeReplacedChecks config checkInfo =
 listIndexedMapChecks : CheckInfo -> Maybe (Error {})
 listIndexedMapChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck listCollection
+        [ unnecessaryCallOnEmptyCheck listCollection
         , operationWithExtraArgChecks { operationWithoutExtraArg = ( [ "List" ], "map" ) }
         ]
 
@@ -5110,7 +5110,7 @@ getReplaceAlwaysByItsResultFix lookupTable expressionNode =
 listIntersperseChecks : CheckInfo -> Maybe (Error {})
 listIntersperseChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck listCollection
+        [ unnecessaryCallOnEmptyCheck listCollection
         , unnecessaryCallOnWrappedCheck listCollection
         ]
 
@@ -5949,7 +5949,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
                 Undetermined ->
                     Nothing
         , mapToOperationWithIdentityCanBeCombinedToOperationChecks { mapFn = emptiableWrapper.mapFn }
-        , callOnEmptyReturnsEmptyCheck emptiableWrapper
+        , unnecessaryCallOnEmptyCheck emptiableWrapper
         ]
 
 
@@ -6163,7 +6163,7 @@ arrayInitializeChecks =
 arrayIndexedMapChecks : CheckInfo -> Maybe (Error {})
 arrayIndexedMapChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck arrayCollection
+        [ unnecessaryCallOnEmptyCheck arrayCollection
         , operationWithExtraArgChecks { operationWithoutExtraArg = ( [ "Array" ], "map" ) }
         ]
 
@@ -6320,7 +6320,7 @@ indexAccessChecks collection checkInfo n =
 setChecks : CollectionProperties (EmptiableProperties (FromListProperties (IndexableProperties otherProperties))) -> CheckInfo -> Maybe (Error {})
 setChecks collection =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck collection
+        [ unnecessaryCallOnEmptyCheck collection
         , \checkInfo ->
             case Evaluate.getInt checkInfo checkInfo.firstArg of
                 Just n ->
@@ -6389,7 +6389,7 @@ setOnKnownElementChecks collection checkInfo n replacementArgRange =
 emptiableReverseChecks : EmptiableProperties otherProperties -> CheckInfo -> Maybe (Error {})
 emptiableReverseChecks emptiable =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck emptiable
+        [ unnecessaryCallOnEmptyCheck emptiable
         , toggleCallChecks
         ]
 
@@ -6413,7 +6413,7 @@ listReverseCompositionChecks =
 listSortChecks : CheckInfo -> Maybe (Error {})
 listSortChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck listCollection
+        [ unnecessaryCallOnEmptyCheck listCollection
         , unnecessaryCallOnWrappedCheck listCollection
         , operationDoesNotChangeResultOfOperationCheck
         ]
@@ -6427,7 +6427,7 @@ listSortCompositionChecks =
 listSortByChecks : CheckInfo -> Maybe (Error {})
 listSortByChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck listCollection
+        [ unnecessaryCallOnEmptyCheck listCollection
         , unnecessaryCallOnWrappedCheck listCollection
         , \checkInfo ->
             case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
@@ -6454,7 +6454,7 @@ listSortByCompositionChecks =
 listSortWithChecks : CheckInfo -> Maybe (Error {})
 listSortWithChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck listCollection
+        [ unnecessaryCallOnEmptyCheck listCollection
         , unnecessaryCallOnWrappedCheck listCollection
         , \checkInfo ->
             let
@@ -6516,7 +6516,7 @@ listTakeChecks =
 
                 Nothing ->
                     Nothing
-        , callOnEmptyReturnsEmptyCheck listCollection
+        , unnecessaryCallOnEmptyCheck listCollection
         ]
 
 
@@ -6535,7 +6535,7 @@ listDropChecks =
 
                 _ ->
                     Nothing
-        , callOnEmptyReturnsEmptyCheck listCollection
+        , unnecessaryCallOnEmptyCheck listCollection
         ]
 
 
@@ -7003,7 +7003,7 @@ taskMapNChecks =
 taskAndThenChecks : CheckInfo -> Maybe (Error {})
 taskAndThenChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck taskWithSucceedAsWrap
+        [ unnecessaryCallOnEmptyCheck taskWithSucceedAsWrap
         , wrapperAndThenChecks taskWithSucceedAsWrap
         ]
 
@@ -7024,7 +7024,7 @@ taskMapErrorCompositionChecks =
 taskOnErrorChecks : CheckInfo -> Maybe (Error {})
 taskOnErrorChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck taskWithFailAsWrap
+        [ unnecessaryCallOnEmptyCheck taskWithFailAsWrap
         , wrapperAndThenChecks taskWithFailAsWrap
         ]
 
@@ -7325,7 +7325,7 @@ jsonDecodeMapNChecks =
 jsonDecodeAndThenChecks : CheckInfo -> Maybe (Error {})
 jsonDecodeAndThenChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck jsonDecoderWithSucceedAsWrap
+        [ unnecessaryCallOnEmptyCheck jsonDecoderWithSucceedAsWrap
         , wrapperAndThenChecks jsonDecoderWithSucceedAsWrap
         ]
 
@@ -8294,7 +8294,7 @@ emptiableMapChecks :
 emptiableMapChecks emptiable =
     firstThatConstructsJust
         [ mapIdentityChecks emptiable
-        , callOnEmptyReturnsEmptyCheck emptiable
+        , unnecessaryCallOnEmptyCheck emptiable
         ]
 
 
@@ -8490,7 +8490,7 @@ emptiableAndThenChecks :
     -> Maybe (Error {})
 emptiableAndThenChecks emptiable =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck emptiable
+        [ unnecessaryCallOnEmptyCheck emptiable
         , \checkInfo ->
             case constructs (sameInAllBranches (getEmpty checkInfo.lookupTable emptiable)) checkInfo.lookupTable checkInfo.firstArg of
                 Determined _ ->
@@ -8590,7 +8590,7 @@ maybeAndThenChecks =
 resultAndThenChecks : CheckInfo -> Maybe (Error {})
 resultAndThenChecks =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck resultWithOkAsWrap
+        [ unnecessaryCallOnEmptyCheck resultWithOkAsWrap
         , wrapperAndThenChecks resultWithOkAsWrap
         ]
 
@@ -9048,7 +9048,7 @@ unnecessaryCallOnCheck constructable checkInfo =
             Nothing
 
 
-callOnEmptyReturnsEmptyCheck :
+unnecessaryCallOnEmptyCheck :
     { a
         | empty :
             { empty
@@ -9058,7 +9058,7 @@ callOnEmptyReturnsEmptyCheck :
     }
     -> CheckInfo
     -> Maybe (Error {})
-callOnEmptyReturnsEmptyCheck emptiable =
+unnecessaryCallOnEmptyCheck emptiable =
     unnecessaryCallOnCheck emptiable.empty
 
 
@@ -9113,7 +9113,7 @@ Examples
     Task.mapError << Task.succeed
     --> Task.succeed
 
-Use together with `callOnEmptyReturnsEmptyCheck`
+Use together with `unnecessaryCallOnEmptyCheck`
 
 -}
 unnecessaryCompositionAfterEmptyCheck :
@@ -9312,7 +9312,7 @@ onWrapAlwaysReturnsJustIncomingCompositionCheck wrapper checkInfo =
 emptiableFilterChecks : EmptiableProperties otherProperties -> CheckInfo -> Maybe (Error {})
 emptiableFilterChecks emptiable =
     firstThatConstructsJust
-        [ callOnEmptyReturnsEmptyCheck emptiable
+        [ unnecessaryCallOnEmptyCheck emptiable
         , \checkInfo ->
             case Evaluate.isAlwaysBoolean checkInfo checkInfo.firstArg of
                 Determined True ->
@@ -9338,7 +9338,7 @@ emptiableFilterChecks emptiable =
 
 collectionRemoveChecks : CollectionProperties (EmptiableProperties otherProperties) -> CheckInfo -> Maybe (Error {})
 collectionRemoveChecks collection =
-    callOnEmptyReturnsEmptyCheck collection
+    unnecessaryCallOnEmptyCheck collection
 
 
 collectionIntersectChecks : CollectionProperties (EmptiableProperties otherProperties) -> CheckInfo -> Maybe (Error {})
@@ -9355,7 +9355,7 @@ collectionIntersectChecks collection =
 
             else
                 Nothing
-        , callOnEmptyReturnsEmptyCheck collection
+        , unnecessaryCallOnEmptyCheck collection
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3171,8 +3171,8 @@ Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#
 
 operationSides : OperatorCheckInfo -> List { node : Node Expression, otherNode : Node Expression }
 operationSides checkInfo =
-    [ { node = checkInfo.right, otherNode = checkInfo.left }
-    , { node = checkInfo.left, otherNode = checkInfo.right }
+    [ { node = checkInfo.left, otherNode = checkInfo.right }
+    , { node = checkInfo.right, otherNode = checkInfo.left }
     ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3033,8 +3033,8 @@ addingZeroCheck checkInfo =
             if AstHelpers.getUncomputedNumberValue side.node == Just 0 then
                 Just
                     (Rule.errorWithFix
-                        { message = "Unnecessary addition with 0"
-                        , details = [ "Adding 0 does not change the value of the number." ]
+                        { message = "Unnecessary adding 0"
+                        , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " number you added 0 to." ]
                         }
                         (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
                         (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })
@@ -3056,8 +3056,8 @@ addingOppositesCheck checkInfo =
             Normalize.ConfirmedEquality ->
                 Just
                     (Rule.errorWithFix
-                        { message = "Addition always results in 0"
-                        , details = [ "These two expressions have an equal absolute value but an opposite sign. This means adding them they will cancel out to 0." ]
+                        { message = "Adding opposite numbers will result in 0"
+                        , details = [ "Adding two numbers with an equal absolute value and an opposite sign will cancel each other out. You can replace this operation by 0." ]
                         }
                         checkInfo.parentRange
                         [ Fix.replaceRangeBy checkInfo.parentRange "0" ]
@@ -3075,8 +3075,8 @@ minusChecks checkInfo =
     if AstHelpers.getUncomputedNumberValue checkInfo.right == Just 0 then
         Just
             (Rule.errorWithFix
-                { message = "Unnecessary subtraction with 0"
-                , details = [ "Subtracting 0 does not change the value of the number." ]
+                { message = "Unnecessary subtracting 0"
+                , details = [ "You can replace this operation by the left number you subtracted 0 from." ]
                 }
                 checkInfo.operatorRange
                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.left })
@@ -3085,8 +3085,8 @@ minusChecks checkInfo =
     else if AstHelpers.getUncomputedNumberValue checkInfo.left == Just 0 then
         Just
             (Rule.errorWithFix
-                { message = "Unnecessary subtracting from 0"
-                , details = [ "You can negate the expression on the right like `-n`." ]
+                { message = "Subtracting from 0 is the same as negating"
+                , details = [ "You can replace this operation by the negated right number you subtracted from 0, like `-n`." ]
                 }
                 checkInfo.operatorRange
                 (replaceBySubExpressionFix checkInfo.parentRange checkInfo.right
@@ -3108,8 +3108,8 @@ checkIfMinusResultsInZero checkInfo =
             Normalize.ConfirmedEquality ->
                 Just
                     (Rule.errorWithFix
-                        { message = "Subtraction always results in 0"
-                        , details = [ "These two expressions have the same value, which means they will cancel add when subtracting one by the other." ]
+                        { message = "Subtracting equal numbers will result in 0"
+                        , details = [ "You can replace this operation by 0." ]
                         }
                         checkInfo.parentRange
                         [ Fix.replaceRangeBy checkInfo.parentRange "0" ]
@@ -3169,10 +3169,10 @@ Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#
         (operationSides checkInfo)
 
 
-operationSides : OperatorCheckInfo -> List { node : Node Expression, otherNode : Node Expression }
+operationSides : OperatorCheckInfo -> List { node : Node Expression, otherNode : Node Expression, otherDescription : String }
 operationSides checkInfo =
-    [ { node = checkInfo.left, otherNode = checkInfo.right }
-    , { node = checkInfo.right, otherNode = checkInfo.left }
+    [ { node = checkInfo.left, otherNode = checkInfo.right, otherDescription = "right" }
+    , { node = checkInfo.right, otherNode = checkInfo.left, otherDescription = "left" }
     ]
 
 
@@ -4183,7 +4183,7 @@ listConditions operatorToLookFor redundantConditionResolution expressionNode =
             [ ( redundantConditionResolution, expressionNode ) ]
 
 
-orSideChecks : { node : Node Expression, otherNode : Node Expression } -> OperatorCheckInfo -> Maybe (Error {})
+orSideChecks : { side | node : Node Expression, otherNode : Node Expression } -> OperatorCheckInfo -> Maybe (Error {})
 orSideChecks side checkInfo =
     case Evaluate.getBoolean checkInfo side.node of
         Determined True ->
@@ -4218,7 +4218,7 @@ andChecks =
         ]
 
 
-andSideChecks : { node : Node Expression, otherNode : Node Expression } -> OperatorCheckInfo -> Maybe (Error {})
+andSideChecks : { side | node : Node Expression, otherNode : Node Expression } -> OperatorCheckInfo -> Maybe (Error {})
 andSideChecks side checkInfo =
     case Evaluate.getBoolean checkInfo side.node of
         Determined True ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2943,11 +2943,6 @@ compositionIntoChecks =
         ]
 
 
-toggleCallChecks : CheckInfo -> Maybe (Error {})
-toggleCallChecks checkInfo =
-    onCallToInverseReturnsItsArgumentCheck checkInfo.fn checkInfo
-
-
 findOperatorRange :
     { extractSourceCode : Range -> String
     , commentRanges : List Range
@@ -3514,6 +3509,16 @@ consChecks =
         ]
 
 
+toggleCallChecks : CheckInfo -> Maybe (Error {})
+toggleCallChecks checkInfo =
+    onCallToInverseReturnsItsArgumentCheck checkInfo.fn checkInfo
+
+
+toggleCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+toggleCompositionChecks checkInfo =
+    inversesCompositionCheck checkInfo.later.fn checkInfo
+
+
 {-| Chaining two operations that are inverses of each other and therefore cancel each other out.
 For example
 
@@ -3766,11 +3771,6 @@ getFullComposition expressionNode =
 
         _ ->
             Nothing
-
-
-toggleCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-toggleCompositionChecks checkInfo =
-    inversesCompositionCheck checkInfo.later.fn checkInfo
 
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3203,19 +3203,9 @@ andBetweenRange ranges =
             { start = ranges.included.start, end = ranges.excluded.start }
 
 
-removeLeftRange : { checkInfo | leftRange : Range, rightRange : Range } -> Range
-removeLeftRange checkInfo =
-    { start = checkInfo.leftRange.start, end = checkInfo.rightRange.start }
-
-
 errorToLeftRange : { checkInfo | leftRange : Range, operatorRange : Range } -> Range
 errorToLeftRange checkInfo =
     { start = checkInfo.leftRange.start, end = checkInfo.operatorRange.end }
-
-
-removeRightRange : { checkInfo | leftRange : Range, rightRange : Range } -> Range
-removeRightRange checkInfo =
-    { start = checkInfo.leftRange.end, end = checkInfo.rightRange.end }
 
 
 errorToRightRange : { checkInfo | rightRange : Range, operatorRange : Range } -> Range

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3131,8 +3131,8 @@ multiplyChecks checkInfo =
                     if number == 1 then
                         Just
                             (Rule.errorWithFix
-                                { message = "Unnecessary multiplication by 1"
-                                , details = [ "Multiplying by 1 does not change the value of the number." ]
+                                { message = "Unnecessary multiplying by 1"
+                                , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " number you multiplied by 0." ]
                                 }
                                 (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
                                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3747,11 +3747,11 @@ equalityChecks isEqual =
                 (operationSides checkInfo)
         , \checkInfo ->
             case
-                Maybe.map2 Tuple.pair
-                    (AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.left)
-                    (AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.right)
+                ( AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.left
+                , AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.right
+                )
             of
-                Just ( leftNotCall, rightNotCall ) ->
+                ( Just leftNotCall, Just rightNotCall ) ->
                     Just
                         (Rule.errorWithFix
                             { message = "Unnecessary `not` on both sides of (" ++ checkInfo.operator ++ ")"

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3754,8 +3754,8 @@ equalityChecks isEqual =
                 Just ( leftNot, rightNot ) ->
                     Just
                         (Rule.errorWithFix
-                            { message = "Unnecessary negation on both sides"
-                            , details = [ "Since both sides are negated using `not`, they are redundant and can be removed." ]
+                            { message = "Unnecessary `not` on both sides of (" ++ checkInfo.operator ++ ")"
+                            , details = [ "You can replace the bool on each side by the value given to `not`." ]
                             }
                             checkInfo.operatorRange
                             [ Fix.removeRange leftNot.fnRange, Fix.removeRange rightNot.fnRange ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10428,13 +10428,6 @@ leftBoundaryRange range =
     }
 
 
-rightBoundaryRange : Range -> Range
-rightBoundaryRange range =
-    { start = { row = range.end.row, column = range.end.column - 1 }
-    , end = range.end
-    }
-
-
 {-| Shortcut for `alwaysResultsInConstantError` with `replacementNeedsParens = False`.
 
 If you want to replace to something like `Just []`,

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3764,46 +3764,48 @@ equalityChecks isEqual =
                         )
 
                 _ ->
+                    Nothing
+        , \checkInfo ->
+            let
+                inferred : Infer.Inferred
+                inferred =
+                    Tuple.first checkInfo.inferredConstants
+
+                normalizeAndInfer : Node Expression -> Node Expression
+                normalizeAndInfer expressionNode =
                     let
-                        inferred : Infer.Inferred
-                        inferred =
-                            Tuple.first checkInfo.inferredConstants
-
-                        normalizeAndInfer : Node Expression -> Node Expression
-                        normalizeAndInfer expressionNode =
-                            let
-                                normalizedExpressionNode : Node Expression
-                                normalizedExpressionNode =
-                                    Normalize.normalize checkInfo expressionNode
-                            in
-                            case Infer.get (Node.value normalizedExpressionNode) inferred of
-                                Just expr ->
-                                    Node Range.emptyRange expr
-
-                                Nothing ->
-                                    normalizedExpressionNode
-
-                        normalizedLeft : Node Expression
-                        normalizedLeft =
-                            normalizeAndInfer checkInfo.left
-
-                        normalizedRight : Node Expression
-                        normalizedRight =
-                            normalizeAndInfer checkInfo.right
+                        normalizedExpressionNode : Node Expression
+                        normalizedExpressionNode =
+                            Normalize.normalize checkInfo expressionNode
                     in
-                    case Normalize.compareWithoutNormalization normalizedLeft normalizedRight of
-                        Normalize.ConfirmedEquality ->
-                            if checkInfo.expectNaN then
-                                Nothing
+                    case Infer.get (Node.value normalizedExpressionNode) inferred of
+                        Just expr ->
+                            Node Range.emptyRange expr
 
-                            else
-                                Just (comparisonError isEqual checkInfo)
+                        Nothing ->
+                            normalizedExpressionNode
 
-                        Normalize.ConfirmedInequality ->
-                            Just (comparisonError (not isEqual) checkInfo)
+                normalizedLeft : Node Expression
+                normalizedLeft =
+                    normalizeAndInfer checkInfo.left
 
-                        Normalize.Unconfirmed ->
-                            Nothing
+                normalizedRight : Node Expression
+                normalizedRight =
+                    normalizeAndInfer checkInfo.right
+            in
+            case Normalize.compareWithoutNormalization normalizedLeft normalizedRight of
+                Normalize.ConfirmedEquality ->
+                    if checkInfo.expectNaN then
+                        Nothing
+
+                    else
+                        Just (comparisonError isEqual checkInfo)
+
+                Normalize.ConfirmedInequality ->
+                    Just (comparisonError (not isEqual) checkInfo)
+
+                Normalize.Unconfirmed ->
+                    Nothing
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2948,18 +2948,6 @@ removeAlongWithOtherFunctionCheck checkInfo =
     onCallToInverseReturnsItsArgumentCheck checkInfo.fn checkInfo
 
 
-doubleToggleErrorInfo : ( ModuleName, String ) -> { message : String, details : List String }
-doubleToggleErrorInfo toggle =
-    let
-        toggleFullyQualifiedAsString : String
-        toggleFullyQualifiedAsString =
-            qualifiedToString toggle
-    in
-    { message = "Unnecessary double " ++ toggleFullyQualifiedAsString
-    , details = [ "Chaining " ++ toggleFullyQualifiedAsString ++ " with " ++ toggleFullyQualifiedAsString ++ " makes both functions cancel each other out." ]
-    }
-
-
 findOperatorRange :
     { extractSourceCode : Range -> String
     , commentRanges : List Range

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2786,10 +2786,10 @@ operatorApplicationChecks =
         , ( "&&", andChecks )
         , ( "==", equalityChecks True )
         , ( "/=", equalityChecks False )
-        , ( "<", comparisonChecks (<) )
-        , ( ">", comparisonChecks (>) )
-        , ( "<=", comparisonChecks (<=) )
-        , ( ">=", comparisonChecks (>=) )
+        , ( "<", numberComparisonChecks (<) )
+        , ( ">", numberComparisonChecks (>) )
+        , ( "<=", numberComparisonChecks (<=) )
+        , ( ">=", numberComparisonChecks (>=) )
         ]
 
 
@@ -3830,8 +3830,8 @@ unnecessaryDetails =
 -- COMPARISONS
 
 
-comparisonChecks : (Float -> Float -> Bool) -> OperatorCheckInfo -> Maybe (Error {})
-comparisonChecks operatorFunction operatorCheckInfo =
+numberComparisonChecks : (Float -> Float -> Bool) -> OperatorCheckInfo -> Maybe (Error {})
+numberComparisonChecks operatorFunction operatorCheckInfo =
     case
         Maybe.map2 operatorFunction
             (Normalize.getNumberValue operatorCheckInfo.left)

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3815,17 +3815,6 @@ alwaysSameDetails =
     ]
 
 
-unnecessaryMessage : String
-unnecessaryMessage =
-    "Part of the expression is unnecessary"
-
-
-unnecessaryDetails : List String
-unnecessaryDetails =
-    [ "A part of this condition is unnecessary. You can remove it and it would not impact the behavior of the program."
-    ]
-
-
 
 -- COMPARISONS
 
@@ -4161,7 +4150,7 @@ listConditions operatorToLookFor redundantConditionResolution expressionNode =
             [ ( redundantConditionResolution, expressionNode ) ]
 
 
-orSideChecks : { side | node : Node Expression, otherNode : Node Expression } -> OperatorCheckInfo -> Maybe (Error {})
+orSideChecks : { side | node : Node Expression, otherNode : Node Expression, otherDescription : String } -> OperatorCheckInfo -> Maybe (Error {})
 orSideChecks side checkInfo =
     case Evaluate.getBoolean checkInfo side.node of
         Determined True ->
@@ -4177,8 +4166,8 @@ orSideChecks side checkInfo =
         Determined False ->
             Just
                 (Rule.errorWithFix
-                    { message = unnecessaryMessage
-                    , details = unnecessaryDetails
+                    { message = "Unnecessary check for || False"
+                    , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " bool." ]
                     }
                     checkInfo.parentRange
                     (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })
@@ -4196,14 +4185,14 @@ andChecks =
         ]
 
 
-andSideChecks : { side | node : Node Expression, otherNode : Node Expression } -> OperatorCheckInfo -> Maybe (Error {})
+andSideChecks : { side | node : Node Expression, otherNode : Node Expression, otherDescription : String } -> OperatorCheckInfo -> Maybe (Error {})
 andSideChecks side checkInfo =
     case Evaluate.getBoolean checkInfo side.node of
         Determined True ->
             Just
                 (Rule.errorWithFix
-                    { message = unnecessaryMessage
-                    , details = unnecessaryDetails
+                    { message = "Unnecessary check for && True"
+                    , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " bool." ]
                     }
                     checkInfo.parentRange
                     (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3135,7 +3135,7 @@ multiplyChecks checkInfo =
                         Just
                             (Rule.errorWithFix
                                 { message = "Unnecessary multiplying by 1"
-                                , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " number you multiplied by 0." ]
+                                , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " number you multiplied by 1." ]
                                 }
                                 (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
                                 (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range side.otherNode })

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3757,7 +3757,7 @@ equalityChecks isEqual =
                             { message = "Unnecessary negation on both sides"
                             , details = [ "Since both sides are negated using `not`, they are redundant and can be removed." ]
                             }
-                            checkInfo.parentRange
+                            checkInfo.operatorRange
                             [ Fix.removeRange leftNot.fnRange, Fix.removeRange rightNot.fnRange ]
                         )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3751,14 +3751,16 @@ equalityChecks isEqual =
                     (AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.left)
                     (AstHelpers.getSpecificFunctionCall ( [ "Basics" ], "not" ) checkInfo.lookupTable checkInfo.right)
             of
-                Just ( leftNot, rightNot ) ->
+                Just ( leftNotCall, rightNotCall ) ->
                     Just
                         (Rule.errorWithFix
                             { message = "Unnecessary `not` on both sides of (" ++ checkInfo.operator ++ ")"
                             , details = [ "You can replace the bool on each side by the value given to `not`." ]
                             }
                             checkInfo.operatorRange
-                            [ Fix.removeRange leftNot.fnRange, Fix.removeRange rightNot.fnRange ]
+                            (replaceBySubExpressionFix leftNotCall.nodeRange leftNotCall.firstArg
+                                ++ replaceBySubExpressionFix rightNotCall.nodeRange rightNotCall.firstArg
+                            )
                         )
 
                 _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10418,9 +10418,7 @@ endWithoutBoundary range =
 
 removeBoundariesFix : Node a -> List Fix
 removeBoundariesFix (Node nodeRange _) =
-    [ Fix.removeRange (leftBoundaryRange nodeRange)
-    , Fix.removeRange (rightBoundaryRange nodeRange)
-    ]
+    keepOnlyFix { parentRange = nodeRange, keep = rangeWithoutBoundaries nodeRange }
 
 
 leftBoundaryRange : Range -> Range

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -3262,8 +3262,8 @@ a = not x == not y
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary negation on both sides"
-                            , details = [ "Since both sides are negated using `not`, they are redundant and can be removed." ]
+                            { message = "Unnecessary `not` on both sides of (==)"
+                            , details = [ "You can replace the bool on each side by the value given to `not`." ]
                             , under = "=="
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -3278,8 +3278,8 @@ a = not x /= not y
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary negation on both sides"
-                            , details = [ "Since both sides are negated using `not`, they are redundant and can be removed." ]
+                            { message = "Unnecessary `not` on both sides of (/=)"
+                            , details = [ "You can replace the bool on each side by the value given to `not`." ]
                             , under = "/="
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10710,6 +10710,22 @@ a = List.isEmpty (List.singleton x)
 a = False
 """
                         ]
+        , test "should replace List.isEmpty (a |> List.singleton) by False" <|
+            \() ->
+                """module A exposing (..)
+a = List.isEmpty (b |> List.singleton)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.isEmpty on this list will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.isEmpty"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = False
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -19423,6 +19423,22 @@ a = Ok z |> Result.mapError f
 a = Ok z
 """
                         ]
+        , test "should replace Result.mapError f << Ok by Ok" <|
+            \() ->
+                """module A exposing (..)
+a = Result.mapError f << Ok
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Result.mapError on an okay result will result in the unchanged okay result"
+                            , details = [ "You can replace this composition by Ok." ]
+                            , under = "Result.mapError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Ok
+"""
+                        ]
         , test "should replace Result.mapError identity x by x" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -2783,7 +2783,7 @@ a = n // 1
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary dividing by 1"
-                            , details = [ "You can replace this operation by the left number you divided by 1 using (//)." ]
+                            , details = [ "You can replace this operation by the left integer you divided by 1." ]
                             , under = "//"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2799,7 +2799,7 @@ a = n // m // 1
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary dividing by 1"
-                            , details = [ "You can replace this operation by the left number you divided by 1 using (//)." ]
+                            , details = [ "You can replace this operation by the left integer you divided by 1." ]
                             , under = "//"
                             }
                             |> Review.Test.atExactly { start = { row = 2, column = 12 }, end = { row = 2, column = 14 } }
@@ -2834,7 +2834,7 @@ a = n // 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dividing by 0 always returns 0"
+                            { message = "Dividing by 0 will result in 0"
                             , details =
                                 [ "Dividing anything by 0 using (//) gives 0 which means you can replace the whole division operation by 0."
                                 , "Most likely, dividing by 0 was unintentional and you had a different number in mind."

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1071,7 +1071,7 @@ unnecessaryDetails =
 
 sameThingOnBothSidesDetails : String -> List String
 sameThingOnBothSidesDetails value =
-    [ "Based on the values and/or the context, we can determine that the value of this operation will always be " ++ value ++ "."
+    [ "Based on the values and/or the context, we can determine the result. You can replace this operation by " ++ value ++ "."
     ]
 
 
@@ -3061,7 +3061,7 @@ a = 1 < 2
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = comparisonIsAlwaysMessage "True"
+                            { message = "(<) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "1 < 2"
                             }
@@ -3077,7 +3077,7 @@ a = 1 < 2 + 3
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = comparisonIsAlwaysMessage "True"
+                            { message = "(<) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "1 < 2 + 3"
                             }
@@ -3093,7 +3093,7 @@ a = 2 < 1
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = comparisonIsAlwaysMessage "False"
+                            { message = "(<) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "2 < 1"
                             }
@@ -3109,7 +3109,7 @@ a = 1 > 2
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = comparisonIsAlwaysMessage "False"
+                            { message = "(>) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "1 > 2"
                             }
@@ -3125,7 +3125,7 @@ a = 1 >= 2
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = comparisonIsAlwaysMessage "False"
+                            { message = "(>=) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "1 >= 2"
                             }
@@ -3141,7 +3141,7 @@ a = 1 <= 2
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = comparisonIsAlwaysMessage "True"
+                            { message = "(<=) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "1 <= 2"
                             }
@@ -3310,7 +3310,7 @@ a = x == x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "x == x"
                             }
@@ -3333,7 +3333,7 @@ a = x == (x)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "x == (x)"
                             }
@@ -3349,7 +3349,7 @@ a = x /= x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(/=) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "x /= x"
                             }
@@ -3365,7 +3365,7 @@ a = List.map (\\a -> a.value) things == List.map (\\a -> a.value) things
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "List.map (\\a -> a.value) things == List.map (\\a -> a.value) things"
                             }
@@ -3381,7 +3381,7 @@ a = (f b) == (f <| b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(f b) == (f <| b)"
                             }
@@ -3397,7 +3397,7 @@ a = (f b c) == (f b <| c)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(f b c) == (f b <| c)"
                             }
@@ -3413,7 +3413,7 @@ a = (f b) == (b |> f)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(f b) == (b |> f)"
                             }
@@ -3429,7 +3429,7 @@ a = (f b c) == (c |> f b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(f b c) == (c |> f b)"
                             }
@@ -3445,7 +3445,7 @@ a = (f b c) == (c |> (b |> f))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(f b c) == (c |> (b |> f))"
                             }
@@ -3461,7 +3461,7 @@ a = (let x = 1 in f b c) == (c |> (let x = 1 in f b))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(let x = 1 in f b c) == (c |> (let x = 1 in f b))"
                             }
@@ -3477,7 +3477,7 @@ a = (if cond then f b c else g d c) == (c |> (if cond then f b else g d))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(if cond then f b c else g d c) == (c |> (if cond then f b else g d))"
                             }
@@ -3501,7 +3501,7 @@ a = (case x of
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = """(case x of
         X -> f b c
@@ -3525,7 +3525,7 @@ a = (b.c) == (.c b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(b.c) == (.c b)"
                             }
@@ -3541,7 +3541,7 @@ a = (b.c) == (.c <| b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(b.c) == (.c <| b)"
                             }
@@ -3557,7 +3557,7 @@ a = "a" == "b"
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "\"a\" == \"b\""
                             }
@@ -3573,7 +3573,7 @@ a = 'a' == 'b'
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "'a' == 'b'"
                             }
@@ -3589,7 +3589,7 @@ a = "a" /= "b"
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(/=) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "\"a\" /= \"b\""
                             }
@@ -3605,7 +3605,7 @@ a = 1 == 2
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "1 == 2"
                             }
@@ -3621,7 +3621,7 @@ a = 1 == 2.0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "1 == 2.0"
                             }
@@ -3637,7 +3637,7 @@ a = 1.0 == 2
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "1.0 == 2"
                             }
@@ -3653,7 +3653,7 @@ a = 0x10 == 2
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "0x10 == 2"
                             }
@@ -3669,7 +3669,7 @@ a = 1 + 3 == 2 + 5
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "1 + 3 == 2 + 5"
                             }
@@ -3685,7 +3685,7 @@ a = 1 - 3 == 2 - 5
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "1 - 3 == 2 - 5"
                             }
@@ -3701,7 +3701,7 @@ a = 2 * 3 == 2 * 5
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "2 * 3 == 2 * 5"
                             }
@@ -3717,7 +3717,7 @@ a = 1 / 3 == 2 / 5
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "1 / 3 == 2 / 5"
                             }
@@ -3733,7 +3733,7 @@ a = () == x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "() == x"
                             }
@@ -3749,7 +3749,7 @@ a = x == ()
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "x == ()"
                             }
@@ -3765,7 +3765,7 @@ a = [ 1 ] == [ 1, 1 ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "[ 1 ] == [ 1, 1 ]"
                             }
@@ -3781,7 +3781,7 @@ a = [ 1, 2 ] == [ 1, 1 ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "[ 1, 2 ] == [ 1, 1 ]"
                             }
@@ -3797,7 +3797,7 @@ a = [ 1, 2 - 1 ] == [ 1, 1 ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "[ 1, 2 - 1 ] == [ 1, 1 ]"
                             }
@@ -3813,7 +3813,7 @@ a = (1) == (2)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "(1) == (2)"
                             }
@@ -3829,7 +3829,7 @@ a = ( 1, 2 ) == ( 1, 1 )
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "( 1, 2 ) == ( 1, 1 )"
                             }
@@ -3845,7 +3845,7 @@ a = { a = 1, b = 2 } == { b = 1, a = 1 }
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "{ a = 1, b = 2 } == { b = 1, a = 1 }"
                             }
@@ -3861,7 +3861,7 @@ a = { x | a = 1 } == { x | a = 2 }
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "{ x | a = 1 } == { x | a = 2 }"
                             }
@@ -3877,7 +3877,7 @@ a = { x | a = 1 } == { x | a = 1 }
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "{ x | a = 1 } == { x | a = 1 }"
                             }
@@ -3900,7 +3900,7 @@ a = { x | a = 1 } == { y | a = 2 }
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "{ x | a = 1 } == { y | a = 2 }"
                             }
@@ -3941,7 +3941,7 @@ b = 1
                     |> Review.Test.expectErrorsForModules
                         [ ( "A"
                           , [ Review.Test.error
-                                { message = "Comparison is always True"
+                                { message = "(==) comparison will result in True"
                                 , details = sameThingOnBothSidesDetails "True"
                                 , under = "B.b == b"
                                 }
@@ -3961,7 +3961,7 @@ a = List.map fn 1 == map fn (2 - 1)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "List.map fn 1 == map fn (2 - 1)"
                             }
@@ -3986,7 +3986,7 @@ a = (if 1 then 2 else 3) == (if 2 - 1 then 3 - 1 else 4 - 1)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(if 1 then 2 else 3) == (if 2 - 1 then 3 - 1 else 4 - 1)"
                             }
@@ -4009,7 +4009,7 @@ a = -1 == -(2 - 1)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "-1 == -(2 - 1)"
                             }
@@ -4025,7 +4025,7 @@ a = ({ a = 1 }).a == ({ a = 2 - 1 }).a
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "({ a = 1 }).a == ({ a = 2 - 1 }).a"
                             }
@@ -4059,7 +4059,7 @@ a = (1 |> fn) == (2 - 1 |> fn)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "(1 |> fn) == (2 - 1 |> fn)"
                             }
@@ -4583,7 +4583,7 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "x == 1"
                             }
@@ -4614,7 +4614,7 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "x == \"b\""
                             }
@@ -4645,7 +4645,7 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "item.name == \"Sulfuras, Hand of Ragnaros\""
                             }
@@ -4675,7 +4675,7 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(==) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "x == 2"
                             }
@@ -4773,7 +4773,7 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
+                            { message = "(/=) comparison will result in False"
                             , details = sameThingOnBothSidesDetails "False"
                             , under = "x /= 1"
                             }
@@ -4802,7 +4802,7 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "x == 1"
                             }
@@ -4910,7 +4910,7 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
+                            { message = "(==) comparison will result in True"
                             , details = sameThingOnBothSidesDetails "True"
                             , under = "x == 1"
                             }
@@ -4989,7 +4989,6 @@ a =
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
-                        -- TODO Order of the errors seem to matter here. Should be fixed in `elm-review`
                         [ Review.Test.error
                             { message = "Comparison is always False"
                             , details = alwaysSameDetails

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1115,7 +1115,7 @@ a = False || x
                         [ Review.Test.error
                             { message = "Unnecessary check for || False"
                             , details = [ "You can replace this operation by the right bool." ]
-                            , under = "False || x"
+                            , under = "False ||"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = x
@@ -1131,7 +1131,7 @@ a = x || False
                         [ Review.Test.error
                             { message = "Unnecessary check for || False"
                             , details = [ "You can replace this operation by the left bool." ]
-                            , under = "x || False"
+                            , under = "|| False"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = x
@@ -1147,7 +1147,7 @@ a = x || (False)
                         [ Review.Test.error
                             { message = "Unnecessary check for || False"
                             , details = [ "You can replace this operation by the left bool." ]
-                            , under = "x || (False)"
+                            , under = "|| (False)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = x
@@ -1340,7 +1340,7 @@ a = True && x
                         [ Review.Test.error
                             { message = "Unnecessary check for && True"
                             , details = [ "You can replace this operation by the right bool." ]
-                            , under = "True && x"
+                            , under = "True &&"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = x
@@ -1356,7 +1356,7 @@ a = x && True
                         [ Review.Test.error
                             { message = "Unnecessary check for && True"
                             , details = [ "You can replace this operation by the left bool." ]
-                            , under = "x && True"
+                            , under = "&& True"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = x
@@ -4420,7 +4420,7 @@ a =
                         [ Review.Test.error
                             { message = "Unnecessary check for && True"
                             , details = [ "You can replace this operation by the right bool." ]
-                            , under = "x && y"
+                            , under = "x &&"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a =

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -3264,7 +3264,7 @@ a = not x == not y
                         [ Review.Test.error
                             { message = "Unnecessary negation on both sides"
                             , details = [ "Since both sides are negated using `not`, they are redundant and can be removed." ]
-                            , under = "not x == not y"
+                            , under = "=="
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a =  x ==  y
@@ -3280,7 +3280,7 @@ a = not x /= not y
                         [ Review.Test.error
                             { message = "Unnecessary negation on both sides"
                             , details = [ "Since both sides are negated using `not`, they are redundant and can be removed." ]
-                            , under = "not x /= not y"
+                            , under = "/="
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a =  x /=  y

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14580,6 +14580,7 @@ listIntersperseTests =
                 """module A exposing (..)
 a = List.intersperse 2 list
 b = List.intersperse y [ 1, 2, 3 ]
+c = List.intersperse << List.singleton
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -6902,7 +6902,7 @@ a = String.append string ""
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary String.append with \"\""
-                            , details = [ "You can replace this call by the string itself." ]
+                            , details = [ "You can replace this call by the given first string." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6918,7 +6918,7 @@ a = "" |> String.append string
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary String.append with \"\""
-                            , details = [ "You can replace this call by the string itself." ]
+                            , details = [ "You can replace this call by the given first string." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -6934,7 +6934,7 @@ a = "" |> String.append string
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary String.append with \"\""
-                            , details = [ "You can replace this call by the string itself." ]
+                            , details = [ "You can replace this call by the given first string." ]
                             , under = "String.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8094,7 +8094,7 @@ a = List.append list []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary List.append with []"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by the given first list." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8110,7 +8110,7 @@ a = List.append list <| []
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary List.append with []"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by the given first list." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -8126,7 +8126,7 @@ a = [] |> List.append list
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary List.append with []"
-                            , details = [ "You can replace this call by the list itself." ]
+                            , details = [ "You can replace this call by the given first list." ]
                             , under = "List.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17334,7 +17334,7 @@ a = Array.append array Array.empty
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Array.append with Array.empty"
-                            , details = [ "You can replace this call by the array itself." ]
+                            , details = [ "You can replace this call by the given first array." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17352,7 +17352,7 @@ a = Array.append array <| Array.empty
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Array.append with Array.empty"
-                            , details = [ "You can replace this call by the array itself." ]
+                            , details = [ "You can replace this call by the given first array." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -17370,7 +17370,7 @@ a = Array.empty |> Array.append array
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Array.append with Array.empty"
-                            , details = [ "You can replace this call by the array itself." ]
+                            , details = [ "You can replace this call by the given first array." ]
                             , under = "Array.append"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21720,8 +21720,8 @@ a = Set.diff set Set.empty
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Diffing a set with Set.empty will result in the set itself"
-                            , details = [ "You can replace this call by the set itself." ]
+                            { message = "Unnecessary Set.diff with Set.empty"
+                            , details = [ "You can replace this call by the given first set." ]
                             , under = "Set.diff"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21738,8 +21738,8 @@ a = Set.empty |> Set.diff set
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Diffing a set with Set.empty will result in the set itself"
-                            , details = [ "You can replace this call by the set itself." ]
+                            { message = "Unnecessary Set.diff with Set.empty"
+                            , details = [ "You can replace this call by the given first set." ]
                             , under = "Set.diff"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21789,7 +21789,7 @@ a = Set.union set Set.empty
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Set.union with Set.empty"
-                            , details = [ "You can replace this call by the set itself." ]
+                            , details = [ "You can replace this call by the given first set." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21807,7 +21807,7 @@ a = Set.empty |> Set.union set
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Set.union with Set.empty"
-                            , details = [ "You can replace this call by the set itself." ]
+                            , details = [ "You can replace this call by the given first set." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -21825,7 +21825,7 @@ a = Set.empty |> Set.union set
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Set.union with Set.empty"
-                            , details = [ "You can replace this call by the set itself." ]
+                            , details = [ "You can replace this call by the given first set." ]
                             , under = "Set.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -23081,8 +23081,8 @@ a = Dict.diff dict Dict.empty
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Diffing a dict with Dict.empty will result in the dict itself"
-                            , details = [ "You can replace this call by the dict itself." ]
+                            { message = "Unnecessary Dict.diff with Dict.empty"
+                            , details = [ "You can replace this call by the given first dict." ]
                             , under = "Dict.diff"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -23099,8 +23099,8 @@ a = Dict.empty |> Dict.diff dict
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Diffing a dict with Dict.empty will result in the dict itself"
-                            , details = [ "You can replace this call by the dict itself." ]
+                            { message = "Unnecessary Dict.diff with Dict.empty"
+                            , details = [ "You can replace this call by the given first dict." ]
                             , under = "Dict.diff"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -23150,7 +23150,7 @@ a = Dict.union dict Dict.empty
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Dict.union with Dict.empty"
-                            , details = [ "You can replace this call by the dict itself." ]
+                            , details = [ "You can replace this call by the given first dict." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -23168,7 +23168,7 @@ a = Dict.empty |> Dict.union dict
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Dict.union with Dict.empty"
-                            , details = [ "You can replace this call by the dict itself." ]
+                            , details = [ "You can replace this call by the given first dict." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -23186,7 +23186,7 @@ a = Dict.empty |> Dict.union dict
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary Dict.union with Dict.empty"
-                            , details = [ "You can replace this call by the dict itself." ]
+                            , details = [ "You can replace this call by the given first dict." ]
                             , under = "Dict.union"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -2431,8 +2431,8 @@ a = n * 1
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary multiplication by 1"
-                            , details = [ "Multiplying by 1 does not change the value of the number." ]
+                            { message = "Unnecessary multiplying by 1"
+                            , details = [ "You can replace this operation by the left number you multiplied by 0." ]
                             , under = "* 1"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2447,8 +2447,8 @@ a = n * 1.0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary multiplication by 1"
-                            , details = [ "Multiplying by 1 does not change the value of the number." ]
+                            { message = "Unnecessary multiplying by 1"
+                            , details = [ "You can replace this operation by the left number you multiplied by 0." ]
                             , under = "* 1.0"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2463,8 +2463,8 @@ a = 1 * n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary multiplication by 1"
-                            , details = [ "Multiplying by 1 does not change the value of the number." ]
+                            { message = "Unnecessary multiplying by 1"
+                            , details = [ "You can replace this operation by the right number you multiplied by 0." ]
                             , under = "1 *"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1052,11 +1052,6 @@ booleanTests =
         ]
 
 
-alwaysSameDetails : List String
-alwaysSameDetails =
-    [ "This condition will always result in the same value. You may have hardcoded a value or mistyped a condition."
-    ]
-
 sameThingOnBothSidesDetails : String -> List String
 sameThingOnBothSidesDetails value =
     [ "Based on the values and/or the context, we can determine the result. You can replace this operation by " ++ value ++ "."
@@ -1081,8 +1076,11 @@ a = True || x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
-                            , details = alwaysSameDetails
+                            { message = "(||) with any side being True will result in True"
+                            , details =
+                                [ "You can replace this operation by True."
+                                , "Maybe you have hardcoded a value or mistyped a condition?"
+                                ]
                             , under = "True || x"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1097,8 +1095,11 @@ a = x || True
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
-                            , details = alwaysSameDetails
+                            { message = "(||) with any side being True will result in True"
+                            , details =
+                                [ "You can replace this operation by True."
+                                , "Maybe you have hardcoded a value or mistyped a condition?"
+                                ]
                             , under = "x || True"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1161,8 +1162,11 @@ a = (True) || x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always True"
-                            , details = alwaysSameDetails
+                            { message = "(||) with any side being True will result in True"
+                            , details =
+                                [ "You can replace this operation by True."
+                                , "Maybe you have hardcoded a value or mistyped a condition?"
+                                ]
                             , under = "(True) || x"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1370,8 +1374,11 @@ a = False && x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
-                            , details = alwaysSameDetails
+                            { message = "(&&) with any side being False will result in False"
+                            , details =
+                                [ "You can replace this operation by False."
+                                , "Maybe you have hardcoded a value or mistyped a condition?"
+                                ]
                             , under = "False && x"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1386,8 +1393,11 @@ a = x && False
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
-                            , details = alwaysSameDetails
+                            { message = "(&&) with any side being False will result in False"
+                            , details =
+                                [ "You can replace this operation by False."
+                                , "Maybe you have hardcoded a value or mistyped a condition?"
+                                ]
                             , under = "x && False"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -4973,8 +4983,11 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Comparison is always False"
-                            , details = alwaysSameDetails
+                            { message = "(&&) with any side being False will result in False"
+                            , details =
+                                [ "You can replace this operation by False."
+                                , "Maybe you have hardcoded a value or mistyped a condition?"
+                                ]
                             , under = "a && b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -2625,8 +2625,8 @@ a = n / 1
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary division by 1"
-                            , details = [ "Dividing by 1 does not change the value of the number." ]
+                            { message = "Unnecessary dividing by 1"
+                            , details = [ "You can replace this operation by the left number you divided by 1." ]
                             , under = "/"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2641,8 +2641,8 @@ a = n / 1.0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary division by 1"
-                            , details = [ "Dividing by 1 does not change the value of the number." ]
+                            { message = "Unnecessary dividing by 1"
+                            , details = [ "You can replace this operation by the left number you divided by 1." ]
                             , under = "/"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2657,7 +2657,7 @@ a = 0 / n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dividing 0 always returns 0"
+                            { message = "Dividing 0 will result in 0"
                             , details =
                                 [ "Dividing 0 by anything, even infinite numbers, gives 0 which means you can replace the whole division operation by 0."
                                 , "Most likely, dividing 0 was unintentional and you had a different number in mind."
@@ -2676,7 +2676,7 @@ a = 0.0 / n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dividing 0 always returns 0"
+                            { message = "Dividing 0 will result in 0"
                             , details =
                                 [ "Dividing 0 by anything, even infinite numbers, gives 0 which means you can replace the whole division operation by 0."
                                 , "Most likely, dividing 0 was unintentional and you had a different number in mind."
@@ -2782,8 +2782,8 @@ a = n // 1
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary division by 1"
-                            , details = [ "Dividing by 1 using (//) does not change the value of the number." ]
+                            { message = "Unnecessary dividing by 1"
+                            , details = [ "You can replace this operation by the left number you divided by 1 using (//)." ]
                             , under = "//"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2798,8 +2798,8 @@ a = n // m // 1
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary division by 1"
-                            , details = [ "Dividing by 1 using (//) does not change the value of the number." ]
+                            { message = "Unnecessary dividing by 1"
+                            , details = [ "You can replace this operation by the left number you divided by 1 using (//)." ]
                             , under = "//"
                             }
                             |> Review.Test.atExactly { start = { row = 2, column = 12 }, end = { row = 2, column = 14 } }
@@ -2815,7 +2815,7 @@ a = 0 // n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dividing 0 always returns 0"
+                            { message = "Dividing 0 will result in 0"
                             , details =
                                 [ "Dividing 0 by anything using (//), even 0, gives 0 which means you can replace the whole division operation by 0."
                                 , "Most likely, dividing 0 was unintentional and you had a different number in mind."

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -2425,7 +2425,7 @@ a = n * 1
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary multiplying by 1"
-                            , details = [ "You can replace this operation by the left number you multiplied by 0." ]
+                            , details = [ "You can replace this operation by the left number you multiplied by 1." ]
                             , under = "* 1"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2441,7 +2441,7 @@ a = n * 1.0
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary multiplying by 1"
-                            , details = [ "You can replace this operation by the left number you multiplied by 0." ]
+                            , details = [ "You can replace this operation by the left number you multiplied by 1." ]
                             , under = "* 1.0"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2457,7 +2457,7 @@ a = 1 * n
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "Unnecessary multiplying by 1"
-                            , details = [ "You can replace this operation by the right number you multiplied by 0." ]
+                            , details = [ "You can replace this operation by the right number you multiplied by 1." ]
                             , under = "1 *"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -21702,7 +21702,7 @@ a = Set.diff Set.empty set
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.diff on Set.empty will always result in Set.empty"
+                            { message = "Set.diff Set.empty will always result in Set.empty"
                             , details = [ "You can replace this call by Set.empty." ]
                             , under = "Set.diff"
                             }
@@ -23063,7 +23063,7 @@ a = Dict.diff Dict.empty dict
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.diff on Dict.empty will always result in Dict.empty"
+                            { message = "Dict.diff Dict.empty will always result in Dict.empty"
                             , details = [ "You can replace this call by Dict.empty." ]
                             , under = "Dict.diff"
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1075,11 +1075,6 @@ sameThingOnBothSidesDetails value =
     ]
 
 
-comparisonIsAlwaysMessage : String -> String
-comparisonIsAlwaysMessage value =
-    "Comparison is always " ++ value
-
-
 orTests : Test
 orTests =
     describe "||"

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13548,6 +13548,8 @@ listSortByTests =
 a = List.sortBy fn
 b = List.sortBy fn list
 c = List.sortBy << List.sortBy fn
+c = List.sortBy f << List.sortWith g
+c = List.sortBy f << List.sort
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -3267,7 +3267,23 @@ a = not x == not y
                             , under = "=="
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a =  x ==  y
+a = x == y
+"""
+                        ]
+        , test "should simplify (x |> f |> not) == (y |> g |> not) to (x |> f) == (y |> g)" <|
+            \() ->
+                """module A exposing (..)
+a = (x |> f |> not) == (y |> g |> not)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary `not` on both sides of (==)"
+                            , details = [ "You can replace the bool on each side by the value given to `not`." ]
+                            , under = "=="
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (x |> f) == (y |> g)
 """
                         ]
         , test "should simplify not x /= not y to x /= y" <|
@@ -3283,7 +3299,7 @@ a = not x /= not y
                             , under = "/="
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a =  x /=  y
+a = x /= y
 """
                         ]
         , test "should simplify x == x to True" <|

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -2229,8 +2229,8 @@ a = n + 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary addition with 0"
-                            , details = [ "Adding 0 does not change the value of the number." ]
+                            { message = "Unnecessary adding 0"
+                            , details = [ "You can replace this operation by the left number you added 0 to." ]
                             , under = "+ 0"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2245,8 +2245,8 @@ a = n + 0.0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary addition with 0"
-                            , details = [ "Adding 0 does not change the value of the number." ]
+                            { message = "Unnecessary adding 0"
+                            , details = [ "You can replace this operation by the left number you added 0 to." ]
                             , under = "+ 0.0"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2261,8 +2261,8 @@ a = 0 + n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary addition with 0"
-                            , details = [ "Adding 0 does not change the value of the number." ]
+                            { message = "Unnecessary adding 0"
+                            , details = [ "You can replace this operation by the right number you added 0 to." ]
                             , under = "0 +"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2277,8 +2277,8 @@ a = n + (-n)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Addition always results in 0"
-                            , details = [ "These two expressions have an equal absolute value but an opposite sign. This means adding them they will cancel out to 0." ]
+                            { message = "Adding opposite numbers will result in 0"
+                            , details = [ "Adding two numbers with an equal absolute value and an opposite sign will cancel each other out. You can replace this operation by 0." ]
                             , under = "n + (-n)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2293,8 +2293,8 @@ a = -n + n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Addition always results in 0"
-                            , details = [ "These two expressions have an equal absolute value but an opposite sign. This means adding them they will cancel out to 0." ]
+                            { message = "Adding opposite numbers will result in 0"
+                            , details = [ "Adding two numbers with an equal absolute value and an opposite sign will cancel each other out. You can replace this operation by 0." ]
                             , under = "-n + n"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2330,8 +2330,8 @@ a = n - 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary subtraction with 0"
-                            , details = [ "Subtracting 0 does not change the value of the number." ]
+                            { message = "Unnecessary subtracting 0"
+                            , details = [ "You can replace this operation by the left number you subtracted 0 from." ]
                             , under = "-"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2346,8 +2346,8 @@ a = n - 0.0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary subtraction with 0"
-                            , details = [ "Subtracting 0 does not change the value of the number." ]
+                            { message = "Unnecessary subtracting 0"
+                            , details = [ "You can replace this operation by the left number you subtracted 0 from." ]
                             , under = "-"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2362,8 +2362,8 @@ a = 0 - n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary subtracting from 0"
-                            , details = [ "You can negate the expression on the right like `-n`." ]
+                            { message = "Subtracting from 0 is the same as negating"
+                            , details = [ "You can replace this operation by the negated right number you subtracted from 0, like `-n`." ]
                             , under = "-"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2378,8 +2378,8 @@ a = 0 - List.length list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary subtracting from 0"
-                            , details = [ "You can negate the expression on the right like `-n`." ]
+                            { message = "Subtracting from 0 is the same as negating"
+                            , details = [ "You can replace this operation by the negated right number you subtracted from 0, like `-n`." ]
                             , under = "-"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2394,8 +2394,8 @@ a = n - n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Subtraction always results in 0"
-                            , details = [ "These two expressions have the same value, which means they will cancel add when subtracting one by the other." ]
+                            { message = "Subtracting equal numbers will result in 0"
+                            , details = [ "You can replace this operation by 0." ]
                             , under = "n - n"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -2332,7 +2332,7 @@ a = n - 0
                         [ Review.Test.error
                             { message = "Unnecessary subtraction with 0"
                             , details = [ "Subtracting 0 does not change the value of the number." ]
-                            , under = "- 0"
+                            , under = "-"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = n
@@ -2348,7 +2348,7 @@ a = n - 0.0
                         [ Review.Test.error
                             { message = "Unnecessary subtraction with 0"
                             , details = [ "Subtracting 0 does not change the value of the number." ]
-                            , under = "- 0.0"
+                            , under = "-"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = n
@@ -2364,7 +2364,7 @@ a = 0 - n
                         [ Review.Test.error
                             { message = "Unnecessary subtracting from 0"
                             , details = [ "You can negate the expression on the right like `-n`." ]
-                            , under = "0 -"
+                            , under = "-"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = -n
@@ -2380,7 +2380,7 @@ a = 0 - List.length list
                         [ Review.Test.error
                             { message = "Unnecessary subtracting from 0"
                             , details = [ "You can negate the expression on the right like `-n`." ]
-                            , under = "0 -"
+                            , under = "-"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = -(List.length list)
@@ -2627,7 +2627,7 @@ a = n / 1
                         [ Review.Test.error
                             { message = "Unnecessary division by 1"
                             , details = [ "Dividing by 1 does not change the value of the number." ]
-                            , under = "/ 1"
+                            , under = "/"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = n
@@ -2643,7 +2643,7 @@ a = n / 1.0
                         [ Review.Test.error
                             { message = "Unnecessary division by 1"
                             , details = [ "Dividing by 1 does not change the value of the number." ]
-                            , under = "/ 1.0"
+                            , under = "/"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = n
@@ -2662,7 +2662,7 @@ a = 0 / n
                                 [ "Dividing 0 by anything, even infinite numbers, gives 0 which means you can replace the whole division operation by 0."
                                 , "Most likely, dividing 0 was unintentional and you had a different number in mind."
                                 ]
-                            , under = "0 /"
+                            , under = "/"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 0
@@ -2681,7 +2681,7 @@ a = 0.0 / n
                                 [ "Dividing 0 by anything, even infinite numbers, gives 0 which means you can replace the whole division operation by 0."
                                 , "Most likely, dividing 0 was unintentional and you had a different number in mind."
                                 ]
-                            , under = "0.0 /"
+                            , under = "/"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = 0.0

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -5603,8 +5603,8 @@ a = "a" ++ ""
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary concatenation with \"\""
-                            , details = [ "You should remove the concatenation with the empty string." ]
+                            { message = "Unnecessary appending \"\""
+                            , details = [ "You can replace this operation by the left string." ]
                             , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5626,8 +5626,8 @@ a = "" ++ "a"
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary concatenation with \"\""
-                            , details = [ "You should remove the concatenation with the empty string." ]
+                            { message = "Unnecessary appending \"\""
+                            , details = [ "You can replace this operation by the right string." ]
                             , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5674,8 +5674,8 @@ a = [] ++ something
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary concatenation with []"
-                            , details = [ "You should remove the concatenation with the empty list." ]
+                            { message = "Unnecessary appending []"
+                            , details = [ "You can replace this operation by the right list." ]
                             , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -5690,8 +5690,8 @@ a = something ++ []
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary concatenation with []"
-                            , details = [ "You should remove the concatenation with the empty list." ]
+                            { message = "Unnecessary appending []"
+                            , details = [ "You can replace this operation by the left list." ]
                             , under = "++"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1057,18 +1057,6 @@ alwaysSameDetails =
     [ "This condition will always result in the same value. You may have hardcoded a value or mistyped a condition."
     ]
 
-
-unnecessaryMessage : String
-unnecessaryMessage =
-    "Part of the expression is unnecessary"
-
-
-unnecessaryDetails : List String
-unnecessaryDetails =
-    [ "A part of this condition is unnecessary. You can remove it and it would not impact the behavior of the program."
-    ]
-
-
 sameThingOnBothSidesDetails : String -> List String
 sameThingOnBothSidesDetails value =
     [ "Based on the values and/or the context, we can determine the result. You can replace this operation by " ++ value ++ "."
@@ -1125,8 +1113,8 @@ a = False || x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = unnecessaryMessage
-                            , details = unnecessaryDetails
+                            { message = "Unnecessary check for || False"
+                            , details = [ "You can replace this operation by the right bool." ]
                             , under = "False || x"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1141,8 +1129,8 @@ a = x || False
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = unnecessaryMessage
-                            , details = unnecessaryDetails
+                            { message = "Unnecessary check for || False"
+                            , details = [ "You can replace this operation by the left bool." ]
                             , under = "x || False"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1157,8 +1145,8 @@ a = x || (False)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = unnecessaryMessage
-                            , details = unnecessaryDetails
+                            { message = "Unnecessary check for || False"
+                            , details = [ "You can replace this operation by the left bool." ]
                             , under = "x || (False)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1350,8 +1338,8 @@ a = True && x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = unnecessaryMessage
-                            , details = unnecessaryDetails
+                            { message = "Unnecessary check for && True"
+                            , details = [ "You can replace this operation by the right bool." ]
                             , under = "True && x"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1366,8 +1354,8 @@ a = x && True
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = unnecessaryMessage
-                            , details = unnecessaryDetails
+                            { message = "Unnecessary check for && True"
+                            , details = [ "You can replace this operation by the left bool." ]
                             , under = "x && True"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -4430,8 +4418,8 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Part of the expression is unnecessary"
-                            , details = [ "A part of this condition is unnecessary. You can remove it and it would not impact the behavior of the program." ]
+                            { message = "Unnecessary check for && True"
+                            , details = [ "You can replace this operation by the right bool." ]
                             , under = "x && y"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1106,7 +1106,7 @@ a = True || x
 a = True
 """
                         ]
-        , test "should simplify 'x || True' to x" <|
+        , test "should simplify 'x || True' to True" <|
             \() ->
                 """module A exposing (..)
 a = x || True
@@ -1114,8 +1114,8 @@ a = x || True
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = unnecessaryMessage
-                            , details = unnecessaryDetails
+                            { message = "Comparison is always True"
+                            , details = alwaysSameDetails
                             , under = "x || True"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -7157,8 +7157,8 @@ a = String.reverse << String.fromChar
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.reverse on a single-char string will result in the given string"
-                            , details = [ "You can replace this call by String.fromChar." ]
+                            { message = "String.reverse on a single-char string will result in the unchanged single-char string"
+                            , details = [ "You can replace this composition by String.fromChar." ]
                             , under = "String.reverse"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -7173,8 +7173,8 @@ a = String.fromChar >> String.reverse
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "String.reverse on a single-char string will result in the given string"
-                            , details = [ "You can replace this call by String.fromChar." ]
+                            { message = "String.reverse on a single-char string will result in the unchanged single-char string"
+                            , details = [ "You can replace this composition by String.fromChar." ]
                             , under = "String.reverse"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -14170,8 +14170,8 @@ a = List.reverse << List.singleton
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.reverse on a singleton list will result in the given list"
-                            , details = [ "You can replace this call by List.singleton." ]
+                            { message = "List.reverse on a singleton list will result in the unchanged singleton list"
+                            , details = [ "You can replace this composition by List.singleton." ]
                             , under = "List.reverse"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -14186,8 +14186,8 @@ a = List.singleton >> List.reverse
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.reverse on a singleton list will result in the given list"
-                            , details = [ "You can replace this call by List.singleton." ]
+                            { message = "List.reverse on a singleton list will result in the unchanged singleton list"
+                            , details = [ "You can replace this composition by List.singleton." ]
                             , under = "List.reverse"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -14656,8 +14656,8 @@ a = List.intersperse s << List.singleton
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.intersperse on a singleton list will result in the given list"
-                            , details = [ "You can replace this call by List.singleton." ]
+                            { message = "List.intersperse on a singleton list will result in the unchanged singleton list"
+                            , details = [ "You can replace this composition by List.singleton." ]
                             , under = "List.intersperse"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -14672,8 +14672,8 @@ a = List.singleton >> List.intersperse s
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.intersperse on a singleton list will result in the given list"
-                            , details = [ "You can replace this call by List.singleton." ]
+                            { message = "List.intersperse on a singleton list will result in the unchanged singleton list"
+                            , details = [ "You can replace this composition by List.singleton." ]
                             , under = "List.intersperse"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)


### PR DESCRIPTION
- [x] Supply all `checkInfo` arguments implicitly
- [x] group related type properties
- [x] remove fixToLeft/RightRange in favor of keepOnlyFix / replaceBySubExpressionFix
- [x] remove errorToLeft/RightRange in favor of operatorRange / Range.combine of fn and side
- [x] tweak operation error infos
  - [x] `(-)`, `(+)`, `(*)`, `(/)`, `(//)`, `(++)`, `(<)`, `(<=)`, `(>)`, `(>=)`, `(&&)`, `(||)`, `(&&)`, `(==)`, `(/=)`
  - [x] `unnecessaryMessage`, `unnecessaryDetails`, `alwaysSameDetails` and other error helpers
- [x] lean more into `operationSides`
- [x] Add `unnecessaryCompositionAfterEmptyCheck`
- [x] Add `last.argCount` to `CompositionIntoCheckInfo`
- [x] allow `ConstructWithOneArg` as `empty` directly by requiring an extra `is` property
- [x] `listDetermineLength` use `getSpecificFnCall` for singleton


Note that `unnecessaryCompositionAfterEmptyCheck` enables new simplifications, e.g. `Task.map f << Task.fail --> Task.fail` which are deliberately not included in this PR.

Switching to `Fn.Array.map` will be the next PR