### PR TITLE
Add andThen composition after wrap simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - `Result.andThen f << Ok` to `f`
 - `Json.Decode.andThen f << Json.Decode.succeed` to `f`
 - `Random.andThen f << Random.constant` to `f`
+- `List.concatMap f << List.singleton` to `f`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - `Random.andThen f << Random.constant` to `f`
 - `List.concatMap f << List.singleton` to `f`
 - `Task.andThen f << Task.succeed` to `f`
+- `Task.onError f << Task.fail` to `f`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - `Maybe.andThen f << Just` to `f`
 - `Result.andThen f << Ok` to `f`
 - `Json.Decode.andThen f << Json.Decode.succeed` to `f`
+- `Random.andThen f << Random.constant` to `f`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `Task.onError f << Task.succeed` to `Task.succeed`
 - `Json.Decode.map f << Json.Decode.fail` to `Json.Decode.fail`
 - `Json.Decode.andThen f << Json.Decode.fail` to `Json.Decode.fail`
+- `Maybe.andThen f << Just` to `f`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - `Json.Decode.andThen f << Json.Decode.succeed` to `f`
 - `Random.andThen f << Random.constant` to `f`
 - `List.concatMap f << List.singleton` to `f`
+- `Task.andThen f << Task.succeed` to `f`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - `Json.Decode.andThen f << Json.Decode.fail` to `Json.Decode.fail`
 - `Maybe.andThen f << Just` to `f`
 - `Result.andThen f << Ok` to `f`
+- `Json.Decode.andThen f << Json.Decode.succeed` to `f`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - `Json.Decode.map f << Json.Decode.fail` to `Json.Decode.fail`
 - `Json.Decode.andThen f << Json.Decode.fail` to `Json.Decode.fail`
 - `Maybe.andThen f << Just` to `f`
+- `Result.andThen f << Ok` to `f`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2942,6 +2942,7 @@ compositionIntoChecks =
         , ( Fn.List.sort, ( 1, listSortCompositionChecks ) )
         , ( Fn.List.sortBy, ( 2, listSortByCompositionChecks ) )
         , ( Fn.List.map, ( 2, listMapCompositionChecks ) )
+        , ( Fn.List.concatMap, ( 2, listConcatMapCompositionChecks ) )
         , ( Fn.List.filterMap, ( 2, listFilterMapCompositionChecks ) )
         , ( Fn.List.intersperse, ( 2, listIntersperseCompositionChecks ) )
         , ( Fn.List.concat, ( 1, listConcatCompositionChecks ) )
@@ -5427,6 +5428,11 @@ arrayToIndexedListMapCompositionCheck checkInfo =
 
         _ ->
             Nothing
+
+
+listConcatMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+listConcatMapCompositionChecks =
+    wrapperAndThenCompositionChecks listCollection
 
 
 listMemberChecks : CheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8706,7 +8706,10 @@ resultAndThenChecks =
 
 resultAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 resultAndThenCompositionChecks =
-    unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
+    firstThatConstructsJust
+        [ unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
+        , wrapperAndThenCompositionChecks resultWithOkAsWrap
+        ]
 
 
 withDefaultChecks :

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7027,7 +7027,7 @@ taskAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 taskAndThenCompositionChecks =
     firstThatConstructsJust
         [ unnecessaryCompositionAfterEmptyCheck taskWithSucceedAsWrap
-        , unnecessaryCompositionAfterWrapCheck taskWithSucceedAsWrap
+        , wrapperAndThenCompositionChecks taskWithSucceedAsWrap
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7352,7 +7352,10 @@ jsonDecodeAndThenChecks =
 
 jsonDecodeAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 jsonDecodeAndThenCompositionChecks =
-    unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap
+    firstThatConstructsJust
+        [ unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap
+        , wrapperAndThenCompositionChecks jsonDecoderWithSucceedAsWrap
+        ]
 
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2965,6 +2965,7 @@ compositionIntoChecks =
         , ( Fn.Json.Decode.map, ( 2, jsonDecodeMapCompositionChecks ) )
         , ( Fn.Json.Decode.andThen, ( 2, jsonDecodeAndThenCompositionChecks ) )
         , ( Fn.Random.map, ( 2, randomMapCompositionChecks ) )
+        , ( Fn.Random.andThen, ( 2, randomAndThenCompositionChecks ) )
         ]
 
 
@@ -7557,6 +7558,11 @@ randomAndThenChecks =
         [ wrapperAndThenChecks randomGeneratorWrapper
         , nonEmptiableWrapperAndThenAlwaysChecks randomGeneratorWrapper
         ]
+
+
+randomAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+randomAndThenCompositionChecks =
+    wrapperAndThenCompositionChecks randomGeneratorWrapper
 
 
 nonEmptiableWrapperAndThenAlwaysChecks :

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7057,7 +7057,10 @@ taskOnErrorChecks =
 
 taskOnErrorCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 taskOnErrorCompositionChecks =
-    unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap
+    firstThatConstructsJust
+        [ unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap
+        , wrapperAndThenCompositionChecks taskWithFailAsWrap
+        ]
 
 
 taskSequenceChecks : CheckInfo -> Maybe (Error {})

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -24741,6 +24741,24 @@ import Task
 a = a |> f
 """
                         ]
+        , test "should replace Task.andThen f << Task.succeed by f" <|
+            \() ->
+                """module A exposing (..)
+import Task
+a = Task.andThen f << Task.succeed
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Task.andThen on a succeeding task is the same as applying the function to the value from the succeeding task"
+                            , details = [ "You can replace this composition by the function given to Task.andThen." ]
+                            , under = "Task.andThen"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Task
+a = f
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -19902,6 +19902,22 @@ a = Ok x |> Result.andThen f
 a = x |> f
 """
                         ]
+        , test "should replace Result.andThen f << Ok by f" <|
+            \() ->
+                """module A exposing (..)
+a = Result.andThen f << Ok
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Result.andThen on an okay result is the same as applying the function to the value from the okay result"
+                            , details = [ "You can replace this composition by the function given to Result.andThen." ]
+                            , under = "Result.andThen"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = f
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -27567,6 +27567,24 @@ import Random
 a = x |> f
 """
                         ]
+        , test "should replace Random.andThen f << Random.constant by f" <|
+            \() ->
+                """module A exposing (..)
+import Random
+a = Random.andThen f << Random.constant
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Random.andThen on a constant generator is the same as applying the function to the value from the constant generator"
+                            , details = [ "You can replace this composition by the function given to Random.andThen." ]
+                            , under = "Random.andThen"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Random
+a = f
+"""
+                        ]
         , test "should replace Random.andThen (\\_ -> x) generator by x" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -24909,6 +24909,24 @@ import Task
 a = x |> f
 """
                         ]
+        , test "should replace Task.onError f << Task.fail by f" <|
+            \() ->
+                """module A exposing (..)
+import Task
+a = Task.onError f << Task.fail
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Task.onError on a failing task is the same as applying the function to the value from the failing task"
+                            , details = [ "You can replace this composition by the function given to Task.onError." ]
+                            , under = "Task.onError"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Task
+a = f
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -8690,6 +8690,22 @@ a = [ b c ] |> List.concatMap f
 a = (b c) |> f
 """
                         ]
+        , test "should replace List.concatMap f << List.singleton by f" <|
+            \() ->
+                """module A exposing (..)
+a = List.concatMap f << List.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.concatMap on a singleton list is the same as applying the function to the value from the singleton list"
+                            , details = [ "You can replace this composition by the function given to List.concatMap." ]
+                            , under = "List.concatMap"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = f
+"""
+                        ]
         , test "should replace List.map f >> List.concat by List.concatMap f" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -25734,6 +25734,24 @@ import Json.Decode
 a = a |> f
 """
                         ]
+        , test "should replace Json.Decode.andThen f << Json.Decode.succeed by f" <|
+            \() ->
+                """module A exposing (..)
+import Json.Decode
+a = Json.Decode.andThen f << Json.Decode.succeed
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Json.Decode.andThen on a succeeding decoder is the same as applying the function to the value from the succeeding decoder"
+                            , details = [ "You can replace this composition by the function given to Json.Decode.andThen." ]
+                            , under = "Json.Decode.andThen"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Json.Decode
+a = f
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Adds `andThen f << wrap --> f` composition simplifications.
```elm
Maybe.andThen f << Just --> f
Result.andThen f << Ok --> f
Json.Decode.andThen f << Json.Decode.succeed --> f
Random.andThen f << Random.constant --> f
List.concatMap f << List.singleton --> f
Task.andThen f << Task.succeed --> f
Task.onError f << Task.fail --> f
```
If you think there are `andThen` functions missing in this list, please comment.

Fixing the `List.map` on singleton fix in the next PR.