### PR TITLE
Add script to run code generation

### DIFF
--- a/codegen.sh
+++ b/codegen.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+npx elm-codegen install
+
+# Runs elm make to make sure the dependencies have been downloaded to ELM_HOME
+# and can be read by elm-codegen.
+(cd review/ && elm make src/ReviewConfig.elm)
+
+ELM_HOME="${ELM_HOME:-$HOME/.elm}"
+echo $ELM_HOME
+
+codegen() {
+  # $1 : package name
+  # $2 : package version
+  docsJsonFile="$ELM_HOME/0.19.1/packages/elm/$1/$2/docs.json"
+  elm-codegen run codegen/Generate.elm --flags-from=$docsJsonFile --output=src
+}
+
+codegen "core" "1.0.5"
+codegen "html" "1.0.0"
+codegen "json" "1.1.3"
+codegen "parser" "1.1.0"
+codegen "random" "1.0.0"
+
+elm-format --yes src/Fn/

--- a/codegen/Generate.elm
+++ b/codegen/Generate.elm
@@ -38,18 +38,14 @@ moduleDocsToFile moduleDocs =
         moduleName : List String
         moduleName =
             moduleDocs.name |> String.split "."
-
-        values : List String
-        values =
-            List.map .name moduleDocs.values
     in
     Elm.file ("Fn" :: moduleName)
-        (List.map (\name -> declaration moduleName ( name, name )) values
+        (List.map (\{ name } -> declaration moduleName ( name, name )) moduleDocs.values
             ++ (moduleDocs.unions
                     |> List.concatMap .tags
                     |> List.map
                         (\( tagName, _ ) ->
-                            declaration moduleName ( tagDeclarationName values (stringFirstCharToLower tagName), tagName )
+                            declaration moduleName ( stringFirstCharToLower tagName ++ "Variant", tagName )
                         )
                )
         )
@@ -64,15 +60,6 @@ declaration moduleName ( declarationName, originalName ) =
             )
             (Elm.string originalName)
         )
-
-
-tagDeclarationName : List String -> String -> String
-tagDeclarationName values tagName =
-    if List.member tagName values then
-        tagName ++ "Variant"
-
-    else
-        tagName
 
 
 stringFirstCharToLower : String -> String

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "elm-review-simplify",
       "hasInstallScript": true,
       "dependencies": {
+        "elm-codegen": "^0.5.0",
         "elm-doc-preview": "^5.0.3",
         "elm-review": "^2.8.1",
         "elm-test": "^0.19.1-revision6",
@@ -553,6 +554,43 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "node_modules/elm-codegen": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/elm-codegen/-/elm-codegen-0.5.0.tgz",
+      "integrity": "sha512-n4l/LnUZzTjGtWBTjVtVr0S2tCSm4DnB/0joeQyflqs8+AnyyDPUSMioAoPgGEXA1hc01Fwjt99M76YEo/Rvow==",
+      "dependencies": {
+        "chalk": "^4.1.1",
+        "chokidar": "^3.5.1",
+        "commander": "^8.3.0",
+        "node-elm-compiler": "^5.0.6"
+      },
+      "bin": {
+        "elm-codegen": "bin/elm-codegen"
+      }
+    },
+    "node_modules/elm-codegen/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/elm-codegen/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/elm-doc-preview": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/elm-doc-preview/-/elm-doc-preview-5.0.3.tgz",
@@ -1060,6 +1098,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-elm-dependencies": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.4.tgz",
+      "integrity": "sha512-x/4w4fVmlD2X4PD9oQ+yh9EyaQef6OtEULdMGBTuWx0Nkppvo2Z/bAiQioW2n+GdRYKypME2b9OmYTw5tw5qDg==",
+      "dependencies": {
+        "firstline": "^1.2.0",
+        "lodash": "^4.17.19"
+      },
+      "bin": {
+        "find-elm-dependencies": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1070,6 +1123,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/firstline": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.3.1.tgz",
+      "integrity": "sha512-ycwgqtoxujz1dm0kjkBFOPQMESxB9uKc/PlD951dQDIG+tBXRpYZC2UmJb0gDxopQ1ZX6oyRQN3goRczYu7Deg==",
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/folder-hash": {
@@ -1561,6 +1622,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -1712,6 +1778,73 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node_modules/node-elm-compiler": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.6.tgz",
+      "integrity": "sha512-DWTRQR8b54rvschcZRREdsz7K84lnS8A6YJu8du3QLQ8f204SJbyTaA6NzYYbfUG97OTRKRv/0KZl82cTfpLhA==",
+      "dependencies": {
+        "cross-spawn": "6.0.5",
+        "find-elm-dependencies": "^2.0.4",
+        "lodash": "^4.17.19",
+        "temp": "^0.9.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/node-elm-compiler/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/node-elm-compiler/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/node-elm-compiler/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-elm-compiler/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-elm-compiler/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -3289,6 +3422,33 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "elm-codegen": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/elm-codegen/-/elm-codegen-0.5.0.tgz",
+      "integrity": "sha512-n4l/LnUZzTjGtWBTjVtVr0S2tCSm4DnB/0joeQyflqs8+AnyyDPUSMioAoPgGEXA1hc01Fwjt99M76YEo/Rvow==",
+      "requires": {
+        "chalk": "^4.1.1",
+        "chokidar": "^3.5.1",
+        "commander": "^8.3.0",
+        "node-elm-compiler": "^5.0.6"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        }
+      }
+    },
     "elm-doc-preview": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/elm-doc-preview/-/elm-doc-preview-5.0.3.tgz",
@@ -3679,6 +3839,15 @@
         }
       }
     },
+    "find-elm-dependencies": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.4.tgz",
+      "integrity": "sha512-x/4w4fVmlD2X4PD9oQ+yh9EyaQef6OtEULdMGBTuWx0Nkppvo2Z/bAiQioW2n+GdRYKypME2b9OmYTw5tw5qDg==",
+      "requires": {
+        "firstline": "^1.2.0",
+        "lodash": "^4.17.19"
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3687,6 +3856,11 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "firstline": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.3.1.tgz",
+      "integrity": "sha512-ycwgqtoxujz1dm0kjkBFOPQMESxB9uKc/PlD951dQDIG+tBXRpYZC2UmJb0gDxopQ1ZX6oyRQN3goRczYu7Deg=="
     },
     "folder-hash": {
       "version": "3.3.3",
@@ -4058,6 +4232,11 @@
         "p-locate": "^4.1.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -4166,6 +4345,57 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node-elm-compiler": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.6.tgz",
+      "integrity": "sha512-DWTRQR8b54rvschcZRREdsz7K84lnS8A6YJu8du3QLQ8f204SJbyTaA6NzYYbfUG97OTRKRv/0KZl82cTfpLhA==",
+      "requires": {
+        "cross-spawn": "6.0.5",
+        "find-elm-dependencies": "^2.0.4",
+        "lodash": "^4.17.19",
+        "temp": "^0.9.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
       "name": "elm-review-simplify",
       "hasInstallScript": true,
       "dependencies": {
-        "elm-codegen": "^0.5.0",
         "elm-doc-preview": "^5.0.3",
         "elm-review": "^2.8.1",
         "elm-test": "^0.19.1-revision6",
@@ -554,43 +553,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "node_modules/elm-codegen": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/elm-codegen/-/elm-codegen-0.5.0.tgz",
-      "integrity": "sha512-n4l/LnUZzTjGtWBTjVtVr0S2tCSm4DnB/0joeQyflqs8+AnyyDPUSMioAoPgGEXA1hc01Fwjt99M76YEo/Rvow==",
-      "dependencies": {
-        "chalk": "^4.1.1",
-        "chokidar": "^3.5.1",
-        "commander": "^8.3.0",
-        "node-elm-compiler": "^5.0.6"
-      },
-      "bin": {
-        "elm-codegen": "bin/elm-codegen"
-      }
-    },
-    "node_modules/elm-codegen/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/elm-codegen/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/elm-doc-preview": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/elm-doc-preview/-/elm-doc-preview-5.0.3.tgz",
@@ -1098,21 +1060,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/find-elm-dependencies": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.4.tgz",
-      "integrity": "sha512-x/4w4fVmlD2X4PD9oQ+yh9EyaQef6OtEULdMGBTuWx0Nkppvo2Z/bAiQioW2n+GdRYKypME2b9OmYTw5tw5qDg==",
-      "dependencies": {
-        "firstline": "^1.2.0",
-        "lodash": "^4.17.19"
-      },
-      "bin": {
-        "find-elm-dependencies": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1123,14 +1070,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/firstline": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.3.1.tgz",
-      "integrity": "sha512-ycwgqtoxujz1dm0kjkBFOPQMESxB9uKc/PlD951dQDIG+tBXRpYZC2UmJb0gDxopQ1ZX6oyRQN3goRczYu7Deg==",
-      "engines": {
-        "node": ">=6.4.0"
       }
     },
     "node_modules/folder-hash": {
@@ -1622,11 +1561,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -1778,73 +1712,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "node_modules/node-elm-compiler": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.6.tgz",
-      "integrity": "sha512-DWTRQR8b54rvschcZRREdsz7K84lnS8A6YJu8du3QLQ8f204SJbyTaA6NzYYbfUG97OTRKRv/0KZl82cTfpLhA==",
-      "dependencies": {
-        "cross-spawn": "6.0.5",
-        "find-elm-dependencies": "^2.0.4",
-        "lodash": "^4.17.19",
-        "temp": "^0.9.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/node-elm-compiler/node_modules/cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dependencies": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "engines": {
-        "node": ">=4.8"
-      }
-    },
-    "node_modules/node-elm-compiler/node_modules/path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/node-elm-compiler/node_modules/shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-      "dependencies": {
-        "shebang-regex": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-elm-compiler/node_modules/shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/node-elm-compiler/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
-      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -3422,33 +3289,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "elm-codegen": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/elm-codegen/-/elm-codegen-0.5.0.tgz",
-      "integrity": "sha512-n4l/LnUZzTjGtWBTjVtVr0S2tCSm4DnB/0joeQyflqs8+AnyyDPUSMioAoPgGEXA1hc01Fwjt99M76YEo/Rvow==",
-      "requires": {
-        "chalk": "^4.1.1",
-        "chokidar": "^3.5.1",
-        "commander": "^8.3.0",
-        "node-elm-compiler": "^5.0.6"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "commander": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
-        }
-      }
-    },
     "elm-doc-preview": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/elm-doc-preview/-/elm-doc-preview-5.0.3.tgz",
@@ -3839,15 +3679,6 @@
         }
       }
     },
-    "find-elm-dependencies": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/find-elm-dependencies/-/find-elm-dependencies-2.0.4.tgz",
-      "integrity": "sha512-x/4w4fVmlD2X4PD9oQ+yh9EyaQef6OtEULdMGBTuWx0Nkppvo2Z/bAiQioW2n+GdRYKypME2b9OmYTw5tw5qDg==",
-      "requires": {
-        "firstline": "^1.2.0",
-        "lodash": "^4.17.19"
-      }
-    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3856,11 +3687,6 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
-    },
-    "firstline": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/firstline/-/firstline-1.3.1.tgz",
-      "integrity": "sha512-ycwgqtoxujz1dm0kjkBFOPQMESxB9uKc/PlD951dQDIG+tBXRpYZC2UmJb0gDxopQ1ZX6oyRQN3goRczYu7Deg=="
     },
     "folder-hash": {
       "version": "3.3.3",
@@ -4232,11 +4058,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -4345,57 +4166,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "node-elm-compiler": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/node-elm-compiler/-/node-elm-compiler-5.0.6.tgz",
-      "integrity": "sha512-DWTRQR8b54rvschcZRREdsz7K84lnS8A6YJu8du3QLQ8f204SJbyTaA6NzYYbfUG97OTRKRv/0KZl82cTfpLhA==",
-      "requires": {
-        "cross-spawn": "6.0.5",
-        "find-elm-dependencies": "^2.0.4",
-        "lodash": "^4.17.19",
-        "temp": "^0.9.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ=="
-        },
-        "which": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
-      }
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postinstall": "elm-tooling install"
   },
   "dependencies": {
+    "elm-codegen": "^0.5.0",
     "elm-doc-preview": "^5.0.3",
     "elm-review": "^2.8.1",
     "elm-test": "^0.19.1-revision6",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "test:review-run": "(cd review && elm-test)",
     "test:package": "node elm-review-package-tests/check-previews-compile.js",
     "preview-docs": "elm-doc-preview",
+    "codegen": "./codegen.sh",
     "elm-bump": "npm-run-all --print-name --silent --sequential test bump-version 'test:review -- --fix-all-without-prompt' update-examples",
     "bump-version": "(yes | elm bump)",
     "update-examples": "node maintenance/update-examples-from-preview.js",
     "postinstall": "elm-tooling install"
   },
   "dependencies": {
-    "elm-codegen": "^0.5.0",
     "elm-doc-preview": "^5.0.3",
     "elm-review": "^2.8.1",
     "elm-test": "^0.19.1-revision6",

--- a/review/src/ConvertQualifiedToFromFnModule.elm
+++ b/review/src/ConvertQualifiedToFromFnModule.elm
@@ -75,7 +75,11 @@ expressionVisitor expressionNode context =
 
                         replacementAsString : String
                         replacementAsString =
-                            moduleNameAsString ++ "." ++ (name |> stringFirstCharToLower)
+                            if name == stringFirstCharToLower name then
+                                moduleNameAsString ++ "." ++ name
+
+                            else
+                                moduleNameAsString ++ "." ++ stringFirstCharToLower name ++ "Variant"
 
                         importFix : List Fix
                         importFix =

--- a/review/tests/ConvertQualifiedToFromFnModuleTest.elm
+++ b/review/tests/ConvertQualifiedToFromFnModuleTest.elm
@@ -54,8 +54,8 @@ a =
                     |> Review.Test.run rule
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Manual qualified fn tuple can be replaced by Fn.Result.ok"
-                            , details = [ "You can replace this tuple by Fn.Result.ok." ]
+                            { message = "Manual qualified fn tuple can be replaced by Fn.Result.okVariant"
+                            , details = [ "You can replace this tuple by Fn.Result.okVariant." ]
                             , under = """( [ "Result" ], "Ok" )"""
                             }
                             |> Review.Test.whenFixed
@@ -64,7 +64,7 @@ import Fn.Result
 import Set
 
 a =
-    Fn.Result.ok
+    Fn.Result.okVariant
 """
                         ]
         ]

--- a/src/Fn/Basics.elm
+++ b/src/Fn/Basics.elm
@@ -183,26 +183,26 @@ xor =
     ( [ "Basics" ], "xor" )
 
 
-true : ( Elm.Syntax.ModuleName.ModuleName, String )
-true =
+trueVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+trueVariant =
     ( [ "Basics" ], "True" )
 
 
-false : ( Elm.Syntax.ModuleName.ModuleName, String )
-false =
+falseVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+falseVariant =
     ( [ "Basics" ], "False" )
 
 
-lT : ( Elm.Syntax.ModuleName.ModuleName, String )
-lT =
+lTVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+lTVariant =
     ( [ "Basics" ], "LT" )
 
 
-eQ : ( Elm.Syntax.ModuleName.ModuleName, String )
-eQ =
+eQVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+eQVariant =
     ( [ "Basics" ], "EQ" )
 
 
-gT : ( Elm.Syntax.ModuleName.ModuleName, String )
-gT =
+gTVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+gTVariant =
     ( [ "Basics" ], "GT" )

--- a/src/Fn/Json/Decode.elm
+++ b/src/Fn/Json/Decode.elm
@@ -178,6 +178,6 @@ oneOfVariant =
     ( [ "Json", "Decode" ], "OneOf" )
 
 
-failure : ( Elm.Syntax.ModuleName.ModuleName, String )
-failure =
+failureVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+failureVariant =
     ( [ "Json", "Decode" ], "Failure" )

--- a/src/Fn/Json/Decode.elm
+++ b/src/Fn/Json/Decode.elm
@@ -161,3 +161,23 @@ succeed =
 value : ( Elm.Syntax.ModuleName.ModuleName, String )
 value =
     ( [ "Json", "Decode" ], "value" )
+
+
+fieldVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+fieldVariant =
+    ( [ "Json", "Decode" ], "Field" )
+
+
+indexVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+indexVariant =
+    ( [ "Json", "Decode" ], "Index" )
+
+
+oneOfVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+oneOfVariant =
+    ( [ "Json", "Decode" ], "OneOf" )
+
+
+failure : ( Elm.Syntax.ModuleName.ModuleName, String )
+failure =
+    ( [ "Json", "Decode" ], "Failure" )

--- a/src/Fn/Maybe.elm
+++ b/src/Fn/Maybe.elm
@@ -38,11 +38,11 @@ withDefault =
     ( [ "Maybe" ], "withDefault" )
 
 
-just : ( Elm.Syntax.ModuleName.ModuleName, String )
-just =
+justVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+justVariant =
     ( [ "Maybe" ], "Just" )
 
 
-nothing : ( Elm.Syntax.ModuleName.ModuleName, String )
-nothing =
+nothingVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+nothingVariant =
     ( [ "Maybe" ], "Nothing" )

--- a/src/Fn/Parser.elm
+++ b/src/Fn/Parser.elm
@@ -181,3 +181,108 @@ variable =
 withIndent : ( Elm.Syntax.ModuleName.ModuleName, String )
 withIndent =
     ( [ "Parser" ], "withIndent" )
+
+
+notNestable : ( Elm.Syntax.ModuleName.ModuleName, String )
+notNestable =
+    ( [ "Parser" ], "NotNestable" )
+
+
+nestable : ( Elm.Syntax.ModuleName.ModuleName, String )
+nestable =
+    ( [ "Parser" ], "Nestable" )
+
+
+expecting : ( Elm.Syntax.ModuleName.ModuleName, String )
+expecting =
+    ( [ "Parser" ], "Expecting" )
+
+
+expectingInt : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingInt =
+    ( [ "Parser" ], "ExpectingInt" )
+
+
+expectingHex : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingHex =
+    ( [ "Parser" ], "ExpectingHex" )
+
+
+expectingOctal : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingOctal =
+    ( [ "Parser" ], "ExpectingOctal" )
+
+
+expectingBinary : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingBinary =
+    ( [ "Parser" ], "ExpectingBinary" )
+
+
+expectingFloat : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingFloat =
+    ( [ "Parser" ], "ExpectingFloat" )
+
+
+expectingNumber : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingNumber =
+    ( [ "Parser" ], "ExpectingNumber" )
+
+
+expectingVariable : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingVariable =
+    ( [ "Parser" ], "ExpectingVariable" )
+
+
+expectingSymbol : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingSymbol =
+    ( [ "Parser" ], "ExpectingSymbol" )
+
+
+expectingKeyword : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingKeyword =
+    ( [ "Parser" ], "ExpectingKeyword" )
+
+
+expectingEnd : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingEnd =
+    ( [ "Parser" ], "ExpectingEnd" )
+
+
+unexpectedChar : ( Elm.Syntax.ModuleName.ModuleName, String )
+unexpectedChar =
+    ( [ "Parser" ], "UnexpectedChar" )
+
+
+problemVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+problemVariant =
+    ( [ "Parser" ], "Problem" )
+
+
+badRepeat : ( Elm.Syntax.ModuleName.ModuleName, String )
+badRepeat =
+    ( [ "Parser" ], "BadRepeat" )
+
+
+loopVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+loopVariant =
+    ( [ "Parser" ], "Loop" )
+
+
+done : ( Elm.Syntax.ModuleName.ModuleName, String )
+done =
+    ( [ "Parser" ], "Done" )
+
+
+forbidden : ( Elm.Syntax.ModuleName.ModuleName, String )
+forbidden =
+    ( [ "Parser" ], "Forbidden" )
+
+
+optional : ( Elm.Syntax.ModuleName.ModuleName, String )
+optional =
+    ( [ "Parser" ], "Optional" )
+
+
+mandatory : ( Elm.Syntax.ModuleName.ModuleName, String )
+mandatory =
+    ( [ "Parser" ], "Mandatory" )

--- a/src/Fn/Parser.elm
+++ b/src/Fn/Parser.elm
@@ -183,73 +183,73 @@ withIndent =
     ( [ "Parser" ], "withIndent" )
 
 
-notNestable : ( Elm.Syntax.ModuleName.ModuleName, String )
-notNestable =
+notNestableVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+notNestableVariant =
     ( [ "Parser" ], "NotNestable" )
 
 
-nestable : ( Elm.Syntax.ModuleName.ModuleName, String )
-nestable =
+nestableVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+nestableVariant =
     ( [ "Parser" ], "Nestable" )
 
 
-expecting : ( Elm.Syntax.ModuleName.ModuleName, String )
-expecting =
+expectingVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingVariant =
     ( [ "Parser" ], "Expecting" )
 
 
-expectingInt : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingInt =
+expectingIntVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingIntVariant =
     ( [ "Parser" ], "ExpectingInt" )
 
 
-expectingHex : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingHex =
+expectingHexVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingHexVariant =
     ( [ "Parser" ], "ExpectingHex" )
 
 
-expectingOctal : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingOctal =
+expectingOctalVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingOctalVariant =
     ( [ "Parser" ], "ExpectingOctal" )
 
 
-expectingBinary : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingBinary =
+expectingBinaryVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingBinaryVariant =
     ( [ "Parser" ], "ExpectingBinary" )
 
 
-expectingFloat : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingFloat =
+expectingFloatVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingFloatVariant =
     ( [ "Parser" ], "ExpectingFloat" )
 
 
-expectingNumber : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingNumber =
+expectingNumberVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingNumberVariant =
     ( [ "Parser" ], "ExpectingNumber" )
 
 
-expectingVariable : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingVariable =
+expectingVariableVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingVariableVariant =
     ( [ "Parser" ], "ExpectingVariable" )
 
 
-expectingSymbol : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingSymbol =
+expectingSymbolVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingSymbolVariant =
     ( [ "Parser" ], "ExpectingSymbol" )
 
 
-expectingKeyword : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingKeyword =
+expectingKeywordVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingKeywordVariant =
     ( [ "Parser" ], "ExpectingKeyword" )
 
 
-expectingEnd : ( Elm.Syntax.ModuleName.ModuleName, String )
-expectingEnd =
+expectingEndVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+expectingEndVariant =
     ( [ "Parser" ], "ExpectingEnd" )
 
 
-unexpectedChar : ( Elm.Syntax.ModuleName.ModuleName, String )
-unexpectedChar =
+unexpectedCharVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+unexpectedCharVariant =
     ( [ "Parser" ], "UnexpectedChar" )
 
 
@@ -258,8 +258,8 @@ problemVariant =
     ( [ "Parser" ], "Problem" )
 
 
-badRepeat : ( Elm.Syntax.ModuleName.ModuleName, String )
-badRepeat =
+badRepeatVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+badRepeatVariant =
     ( [ "Parser" ], "BadRepeat" )
 
 
@@ -268,21 +268,21 @@ loopVariant =
     ( [ "Parser" ], "Loop" )
 
 
-done : ( Elm.Syntax.ModuleName.ModuleName, String )
-done =
+doneVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+doneVariant =
     ( [ "Parser" ], "Done" )
 
 
-forbidden : ( Elm.Syntax.ModuleName.ModuleName, String )
-forbidden =
+forbiddenVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+forbiddenVariant =
     ( [ "Parser" ], "Forbidden" )
 
 
-optional : ( Elm.Syntax.ModuleName.ModuleName, String )
-optional =
+optionalVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+optionalVariant =
     ( [ "Parser" ], "Optional" )
 
 
-mandatory : ( Elm.Syntax.ModuleName.ModuleName, String )
-mandatory =
+mandatoryVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+mandatoryVariant =
     ( [ "Parser" ], "Mandatory" )

--- a/src/Fn/Parser/Advanced.elm
+++ b/src/Fn/Parser/Advanced.elm
@@ -181,3 +181,43 @@ variable =
 withIndent : ( Elm.Syntax.ModuleName.ModuleName, String )
 withIndent =
     ( [ "Parser", "Advanced" ], "withIndent" )
+
+
+notNestable : ( Elm.Syntax.ModuleName.ModuleName, String )
+notNestable =
+    ( [ "Parser", "Advanced" ], "NotNestable" )
+
+
+nestable : ( Elm.Syntax.ModuleName.ModuleName, String )
+nestable =
+    ( [ "Parser", "Advanced" ], "Nestable" )
+
+
+loopVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+loopVariant =
+    ( [ "Parser", "Advanced" ], "Loop" )
+
+
+done : ( Elm.Syntax.ModuleName.ModuleName, String )
+done =
+    ( [ "Parser", "Advanced" ], "Done" )
+
+
+tokenVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+tokenVariant =
+    ( [ "Parser", "Advanced" ], "Token" )
+
+
+forbidden : ( Elm.Syntax.ModuleName.ModuleName, String )
+forbidden =
+    ( [ "Parser", "Advanced" ], "Forbidden" )
+
+
+optional : ( Elm.Syntax.ModuleName.ModuleName, String )
+optional =
+    ( [ "Parser", "Advanced" ], "Optional" )
+
+
+mandatory : ( Elm.Syntax.ModuleName.ModuleName, String )
+mandatory =
+    ( [ "Parser", "Advanced" ], "Mandatory" )

--- a/src/Fn/Parser/Advanced.elm
+++ b/src/Fn/Parser/Advanced.elm
@@ -183,13 +183,13 @@ withIndent =
     ( [ "Parser", "Advanced" ], "withIndent" )
 
 
-notNestable : ( Elm.Syntax.ModuleName.ModuleName, String )
-notNestable =
+notNestableVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+notNestableVariant =
     ( [ "Parser", "Advanced" ], "NotNestable" )
 
 
-nestable : ( Elm.Syntax.ModuleName.ModuleName, String )
-nestable =
+nestableVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+nestableVariant =
     ( [ "Parser", "Advanced" ], "Nestable" )
 
 
@@ -198,8 +198,8 @@ loopVariant =
     ( [ "Parser", "Advanced" ], "Loop" )
 
 
-done : ( Elm.Syntax.ModuleName.ModuleName, String )
-done =
+doneVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+doneVariant =
     ( [ "Parser", "Advanced" ], "Done" )
 
 
@@ -208,16 +208,16 @@ tokenVariant =
     ( [ "Parser", "Advanced" ], "Token" )
 
 
-forbidden : ( Elm.Syntax.ModuleName.ModuleName, String )
-forbidden =
+forbiddenVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+forbiddenVariant =
     ( [ "Parser", "Advanced" ], "Forbidden" )
 
 
-optional : ( Elm.Syntax.ModuleName.ModuleName, String )
-optional =
+optionalVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+optionalVariant =
     ( [ "Parser", "Advanced" ], "Optional" )
 
 
-mandatory : ( Elm.Syntax.ModuleName.ModuleName, String )
-mandatory =
+mandatoryVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+mandatoryVariant =
     ( [ "Parser", "Advanced" ], "Mandatory" )

--- a/src/Fn/Result.elm
+++ b/src/Fn/Result.elm
@@ -53,11 +53,11 @@ withDefault =
     ( [ "Result" ], "withDefault" )
 
 
-ok : ( Elm.Syntax.ModuleName.ModuleName, String )
-ok =
+okVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+okVariant =
     ( [ "Result" ], "Ok" )
 
 
-err : ( Elm.Syntax.ModuleName.ModuleName, String )
-err =
+errVariant : ( Elm.Syntax.ModuleName.ModuleName, String )
+errVariant =
     ( [ "Result" ], "Err" )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5162,7 +5162,7 @@ listHeadChecks =
                         checkInfo.fnRange
                         (replaceBySubExpressionFix (Node.range checkInfo.firstArg) listArgHead
                             ++ [ Fix.replaceRangeBy checkInfo.fnRange
-                                    (qualifiedToString (qualify Fn.Maybe.just checkInfo))
+                                    (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo))
                                ]
                         )
                 )
@@ -5197,7 +5197,7 @@ listTailExistsError replaceListArgByTailFix checkInfo =
         checkInfo.fnRange
         (replaceListArgByTailFix
             ++ [ Fix.replaceRangeBy checkInfo.fnRange
-                    (qualifiedToString (qualify Fn.Maybe.just checkInfo))
+                    (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo))
                ]
         )
 
@@ -5236,7 +5236,7 @@ listTailChecks =
                             checkInfo.fnRange
                             [ Fix.replaceRangeBy (Node.range checkInfo.firstArg) "[]"
                             , Fix.replaceRangeBy checkInfo.fnRange
-                                (qualifiedToString (qualify Fn.Maybe.just checkInfo))
+                                (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo))
                             ]
                         )
 
@@ -5496,7 +5496,7 @@ listMemberChecks : CheckInfo -> Maybe (Error {})
 listMemberChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck
-            { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.false res) }
+            { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
             listCollection
         , \checkInfo ->
             case secondArg checkInfo of
@@ -5532,7 +5532,7 @@ listMemberChecks =
                                     Just
                                         (resultsInConstantError
                                             (qualifiedToString checkInfo.fn ++ " on a list which contains the given element")
-                                            (\res -> qualifiedToString (qualify Fn.Basics.true res))
+                                            (\res -> qualifiedToString (qualify Fn.Basics.trueVariant res))
                                             checkInfo
                                         )
 
@@ -5872,7 +5872,7 @@ emptiableAllChecks : EmptiableProperties (TypeSubsetProperties empty) otherPrope
 emptiableAllChecks emptiable =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck
-            { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.true res) }
+            { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.trueVariant res) }
             emptiable
         , \checkInfo ->
             case Evaluate.isAlwaysBoolean checkInfo checkInfo.firstArg of
@@ -5880,7 +5880,7 @@ emptiableAllChecks emptiable =
                     Just
                         (alwaysResultsInUnparenthesizedConstantError
                             (qualifiedToString checkInfo.fn ++ " with a function that will always return True")
-                            { replacement = \res -> qualifiedToString (qualify Fn.Basics.true res) }
+                            { replacement = \res -> qualifiedToString (qualify Fn.Basics.trueVariant res) }
                             checkInfo
                         )
 
@@ -5921,7 +5921,7 @@ emptiableAnyChecks : EmptiableProperties (TypeSubsetProperties empty) otherPrope
 emptiableAnyChecks emptiable =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck
-            { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.false res) }
+            { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
             emptiable
         , \checkInfo ->
             case Evaluate.isAlwaysBoolean checkInfo checkInfo.firstArg of
@@ -5929,7 +5929,7 @@ emptiableAnyChecks emptiable =
                     Just
                         (alwaysResultsInUnparenthesizedConstantError
                             (qualifiedToString checkInfo.fn ++ " with a function that will always return False")
-                            { replacement = \res -> qualifiedToString (qualify Fn.Basics.false res) }
+                            { replacement = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
                             checkInfo
                         )
 
@@ -5951,7 +5951,7 @@ listFilterMapChecks =
                             Just list ->
                                 case
                                     traverse
-                                        (AstHelpers.getSpecificFnCall Fn.Maybe.just checkInfo.lookupTable)
+                                        (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant checkInfo.lookupTable)
                                         list
                                 of
                                     Just justCalls ->
@@ -5991,7 +5991,7 @@ emptiableWrapperFilterMapChecks : TypeProperties (WrapperProperties (EmptiablePr
 emptiableWrapperFilterMapChecks emptiableWrapper =
     firstThatConstructsJust
         [ \checkInfo ->
-            case constructs (sameInAllBranches (AstHelpers.getSpecificFnCall Fn.Maybe.just checkInfo.lookupTable)) checkInfo.lookupTable checkInfo.firstArg of
+            case constructs (sameInAllBranches (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant checkInfo.lookupTable)) checkInfo.lookupTable checkInfo.firstArg of
                 Determined justCalls ->
                     Just
                         (Rule.errorWithFix
@@ -6008,7 +6008,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
                 Undetermined ->
                     Nothing
         , \checkInfo ->
-            case AstHelpers.getSpecificValueOrFn Fn.Maybe.just checkInfo.lookupTable checkInfo.firstArg of
+            case AstHelpers.getSpecificValueOrFn Fn.Maybe.justVariant checkInfo.lookupTable checkInfo.firstArg of
                 Just _ ->
                     Just
                         (alwaysReturnsLastArgError
@@ -6020,7 +6020,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
                 Nothing ->
                     Nothing
         , \checkInfo ->
-            case constructs (sameInAllBranches (AstHelpers.getSpecificValueOrFn Fn.Maybe.nothing checkInfo.lookupTable)) checkInfo.lookupTable checkInfo.firstArg of
+            case constructs (sameInAllBranches (AstHelpers.getSpecificValueOrFn Fn.Maybe.nothingVariant checkInfo.lookupTable)) checkInfo.lookupTable checkInfo.firstArg of
                 Determined _ ->
                     Just
                         (alwaysResultsInUnparenthesizedConstantError
@@ -6378,7 +6378,7 @@ indexAccessChecks collection checkInfo n =
                                         checkInfo.fnRange
                                         (replaceBySubExpressionFix (Node.range arg) element
                                             ++ [ Fix.replaceRangeBy (Range.combine [ checkInfo.fnRange, Node.range checkInfo.firstArg ])
-                                                    (qualifiedToString (qualify Fn.Maybe.just checkInfo))
+                                                    (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo))
                                                ]
                                         )
                                     )
@@ -6386,11 +6386,11 @@ indexAccessChecks collection checkInfo n =
                             Nothing ->
                                 Just
                                     (Rule.errorWithFix
-                                        { message = qualifiedToString checkInfo.fn ++ " with an index out of bounds of the given " ++ collection.represents ++ " will always return " ++ qualifiedToString (qualify Fn.Maybe.nothing checkInfo)
+                                        { message = qualifiedToString checkInfo.fn ++ " with an index out of bounds of the given " ++ collection.represents ++ " will always return " ++ qualifiedToString (qualify Fn.Maybe.nothingVariant checkInfo)
                                         , details = [ "You can replace this call by Nothing." ]
                                         }
                                         checkInfo.fnRange
-                                        [ Fix.replaceRangeBy checkInfo.parentRange (qualifiedToString (qualify Fn.Maybe.nothing checkInfo)) ]
+                                        [ Fix.replaceRangeBy checkInfo.parentRange (qualifiedToString (qualify Fn.Maybe.nothingVariant checkInfo)) ]
                                     )
 
                     Nothing ->
@@ -7919,20 +7919,20 @@ maybeWithJustAsWrap =
         { description = Constant "Nothing"
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificValueOrFn Fn.Maybe.nothing lookupTable expr)
+                isJust (AstHelpers.getSpecificValueOrFn Fn.Maybe.nothingVariant lookupTable expr)
         , asString =
             \resources ->
-                qualifiedToString (qualify Fn.Maybe.nothing resources)
+                qualifiedToString (qualify Fn.Maybe.nothingVariant resources)
         }
     , wrap =
         { description = A "just maybe"
-        , fn = Fn.Maybe.just
+        , fn = Fn.Maybe.justVariant
         , getValue =
             \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Maybe.just lookupTable expr)
+                Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant lookupTable expr)
         , is =
             \lookupTable expr ->
-                isJust (AstHelpers.getSpecificFnCall Fn.Maybe.just lookupTable expr)
+                isJust (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant lookupTable expr)
         }
     , mapFn = Fn.Maybe.map
     }
@@ -7957,26 +7957,26 @@ resultWithOkAsWrap =
 resultOkayConstruct : ConstructWithOneArgProperties
 resultOkayConstruct =
     { description = An "okay result"
-    , fn = Fn.Result.ok
+    , fn = Fn.Result.okVariant
     , getValue =
         \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Result.ok lookupTable expr)
+            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Result.okVariant lookupTable expr)
     , is =
         \lookupTable expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Result.ok lookupTable expr)
+            isJust (AstHelpers.getSpecificFnCall Fn.Result.okVariant lookupTable expr)
     }
 
 
 resultErrorConstruct : ConstructWithOneArgProperties
 resultErrorConstruct =
     { description = An "error"
-    , fn = Fn.Result.err
+    , fn = Fn.Result.errVariant
     , getValue =
         \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Result.err lookupTable expr)
+            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Result.errVariant lookupTable expr)
     , is =
         \lookupTable expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Result.err lookupTable expr)
+            isJust (AstHelpers.getSpecificFnCall Fn.Result.errVariant lookupTable expr)
     }
 
 
@@ -8903,7 +8903,7 @@ unwrapToMaybeChecks emptiableWrapper =
     firstThatConstructsJust
         [ callOnWrapReturnsJustItsValue emptiableWrapper
         , callOnEmptyReturnsCheck
-            { resultAsString = \res -> qualifiedToString (qualify Fn.Maybe.nothing res) }
+            { resultAsString = \res -> qualifiedToString (qualify Fn.Maybe.nothingVariant res) }
             emptiableWrapper
         ]
 
@@ -8924,7 +8924,7 @@ resultToMaybeCompositionChecks =
                             compositionReplaceByFix
                                 (qualifiedToString (qualify Fn.Basics.always checkInfo)
                                     ++ " "
-                                    ++ qualifiedToString (qualify Fn.Maybe.nothing checkInfo)
+                                    ++ qualifiedToString (qualify Fn.Maybe.nothingVariant checkInfo)
                                 )
                                 checkInfo
                         }
@@ -8937,7 +8937,7 @@ resultToMaybeCompositionChecks =
 resultFromMaybeChecks : CheckInfo -> Maybe (Error {})
 resultFromMaybeChecks =
     fromMaybeChecks
-        { onNothingFn = Fn.Result.err, onJustFn = Fn.Result.ok }
+        { onNothingFn = Fn.Result.errVariant, onJustFn = Fn.Result.okVariant }
 
 
 fromMaybeChecks : { onNothingFn : ( ModuleName, String ), onJustFn : ( ModuleName, String ) } -> CheckInfo -> Maybe (Error {})
@@ -8946,7 +8946,7 @@ fromMaybeChecks config checkInfo =
         Just maybeArg ->
             firstThatConstructsJust
                 [ \() ->
-                    case sameInAllBranches (AstHelpers.getSpecificValueOrFn Fn.Maybe.nothing checkInfo.lookupTable) maybeArg of
+                    case sameInAllBranches (AstHelpers.getSpecificValueOrFn Fn.Maybe.nothingVariant checkInfo.lookupTable) maybeArg of
                         Determined _ ->
                             Just
                                 (Rule.errorWithFix
@@ -8966,7 +8966,7 @@ fromMaybeChecks config checkInfo =
                         Undetermined ->
                             Nothing
                 , \() ->
-                    case sameInAllBranches (AstHelpers.getSpecificFnCall Fn.Maybe.just checkInfo.lookupTable) maybeArg of
+                    case sameInAllBranches (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant checkInfo.lookupTable) maybeArg of
                         Determined justCalls ->
                             Just
                                 (Rule.errorWithFix
@@ -9480,7 +9480,7 @@ callOnWrapReturnsJustItsValue withWrap checkInfo =
                             (Fix.removeRange { start = (Node.range withWrapArg).end, end = checkInfo.parentRange.end }
                                 :: List.concatMap (\wrap -> replaceBySubExpressionFix wrap.nodeRange wrap.value) wraps
                                 ++ [ Fix.replaceRangeBy { start = checkInfo.parentRange.start, end = (Node.range withWrapArg).start }
-                                        (qualifiedToString (qualify Fn.Maybe.just checkInfo) ++ " ")
+                                        (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo) ++ " ")
                                    ]
                             )
                         )
@@ -9513,7 +9513,7 @@ onWrapAlwaysReturnsJustIncomingCompositionCheck wrapper checkInfo =
                 { message = qualifiedToString checkInfo.later.fn ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " will always result in Just the value inside"
                 , details = [ "You can replace this call by Just." ]
                 }
-            , fix = compositionReplaceByFnFix Fn.Maybe.just checkInfo
+            , fix = compositionReplaceByFnFix Fn.Maybe.justVariant checkInfo
             }
 
     else
@@ -9723,7 +9723,7 @@ collectionInsertChecks collection checkInfo =
 collectionMemberChecks : CollectionProperties (EmptiableProperties (TypeSubsetProperties empty) otherProperties) -> CheckInfo -> Maybe (Error {})
 collectionMemberChecks collection =
     callOnEmptyReturnsCheck
-        { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.false res) }
+        { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
         collection
 
 
@@ -9734,7 +9734,7 @@ collectionIsEmptyChecks collection checkInfo =
             Just
                 (resultsInConstantError
                     (qualifiedToString checkInfo.fn ++ " on " ++ descriptionForIndefinite collection.empty.description)
-                    (\res -> qualifiedToString (qualify Fn.Basics.true res))
+                    (\res -> qualifiedToString (qualify Fn.Basics.trueVariant res))
                     checkInfo
                 )
 
@@ -9742,7 +9742,7 @@ collectionIsEmptyChecks collection checkInfo =
             Just
                 (resultsInConstantError
                     (qualifiedToString checkInfo.fn ++ " on this " ++ collection.represents)
-                    (\res -> qualifiedToString (qualify Fn.Basics.false res))
+                    (\res -> qualifiedToString (qualify Fn.Basics.falseVariant res))
                     checkInfo
                 )
 


### PR DESCRIPTION
- Add the missing `elm-codegen` dependency
- Add script to run code generation automatically
- Fix generation issues due to type variants and function names conflicting. Now if the module exposing `problem` and `Problem`, then we'll respectively generate `problem` and `problemVariant`
- Re-generate the Fn modules to include the variants

Please try it out using `npm run codegen`