### PR TITLE
Add Dict.filter simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@
 - `Task.onError f << Task.fail` to `f`
 - `Dict.map f Dict.empty` to `Dict.empty`
 - `Dict.map (\_ value -> value) dict` to `dict`
+- `Dict.filter f Dict.empty` to `Dict.empty`
+- `Dict.filter (\_ _ -> True) dict` to `dict`
+- `Dict.filter (\_ _ -> False) dict` to `Dict.empty`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -917,11 +917,8 @@ Destructuring using case expressions
     List.foldl f x (Set.toList set)
     --> Set.foldl f x set
 
-    Set.filter f Set.empty
-    --> Set.empty
-
     Set.filter (\_ -> True) set
-    --> dict
+    --> set
 
     Set.filter (\_ -> False) set
     --> Set.empty

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -917,6 +917,15 @@ Destructuring using case expressions
     List.foldl f x (Set.toList set)
     --> Set.foldl f x set
 
+    Set.filter f Set.empty
+    --> Set.empty
+
+    Set.filter (\_ -> True) set
+    --> dict
+
+    Set.filter (\_ -> False) set
+    --> Set.empty
+
     Set.partition f Set.empty
     --> ( Set.empty, Set.empty )
 

--- a/src/Simplify/Evaluate.elm
+++ b/src/Simplify/Evaluate.elm
@@ -75,8 +75,14 @@ isAlwaysBoolean resources node =
                 _ ->
                     Undetermined
 
-        Expression.LambdaExpression { expression } ->
-            getBoolean resources expression
+        Expression.LambdaExpression lambda ->
+            case lambda.args of
+                -- exactly one irrelevant arg pattern
+                _ :: [] ->
+                    getBoolean resources lambda.expression
+
+                _ ->
+                    Undetermined
 
         _ ->
             Undetermined

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -22931,6 +22931,7 @@ a = False
                         ]
         ]
 
+
 dictFilterTests : Test
 dictFilterTests =
     describe "Dict.filter"
@@ -23107,6 +23108,7 @@ a = always Dict.empty
 """
                         ]
         ]
+
 
 dictPartitionTests : Test
 dictPartitionTests =

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -22383,6 +22383,7 @@ dictSimplificationTests =
         , dictToListTests
         , dictSizeTests
         , dictMemberTests
+        , dictFilterTests
         , dictPartitionTests
         , dictMapTests
         , dictUnionTests
@@ -22930,6 +22931,182 @@ a = False
                         ]
         ]
 
+dictFilterTests : Test
+dictFilterTests =
+    describe "Dict.filter"
+        [ test "should not report Dict.filter used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a0 = Dict.filter
+a1 = Dict.filter f
+a2 = Dict.filter f dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Dict.filter f Dict.empty by Dict.empty" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter f Dict.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter on Dict.empty will result in Dict.empty"
+                            , details = [ "You can replace this call by Dict.empty." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.empty
+"""
+                        ]
+        , test "should replace Dict.filter (always (always True)) dict by dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter (always (always True)) dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter with a function that will always return True will always return the same given dict"
+                            , details = [ "You can replace this call by the dict itself." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict
+"""
+                        ]
+        , test "should replace Dict.filter (always (\\_ -> True)) dict by dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter (always (\\_ -> True)) dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter with a function that will always return True will always return the same given dict"
+                            , details = [ "You can replace this call by the dict itself." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict
+"""
+                        ]
+        , test "should replace Dict.filter (\\_ -> (\\_ -> True)) dict by dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter (\\_ -> (\\_ -> True)) dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter with a function that will always return True will always return the same given dict"
+                            , details = [ "You can replace this call by the dict itself." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict
+"""
+                        ]
+        , test "should replace Dict.filter (\\_ -> (always True)) dict by dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter (\\_ -> (always True)) dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter with a function that will always return True will always return the same given dict"
+                            , details = [ "You can replace this call by the dict itself." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict
+"""
+                        ]
+        , test "should replace Dict.filter (\\_ _ -> True)) dict by dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter (\\_ _ -> True) dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter with a function that will always return True will always return the same given dict"
+                            , details = [ "You can replace this call by the dict itself." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict
+"""
+                        ]
+        , test "should replace Dict.filter (always (always True)) by identity" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter (always (always True))
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter with a function that will always return True will always return the same given dict"
+                            , details = [ "You can replace this call by identity." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = identity
+"""
+                        ]
+        , test "should replace Dict.filter (always (always False)) dict by Dict.empty" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter (always (always False)) dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter with a function that will always return False will always result in Dict.empty"
+                            , details = [ "You can replace this call by Dict.empty." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.empty
+"""
+                        ]
+        , test "should replace Dict.filter (always (always False)) dict by always Dict.empty" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.filter (always (always False))
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.filter with a function that will always return False will always result in Dict.empty"
+                            , details = [ "You can replace this call by always Dict.empty." ]
+                            , under = "Dict.filter"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = always Dict.empty
+"""
+                        ]
+        ]
 
 dictPartitionTests : Test
 dictPartitionTests =


### PR DESCRIPTION
As hinted at in #28 
```elm
Dict.filter f Dict.empty
--> Dict.empty

Dict.filter (\_ _ -> True) dict
--> dict

Dict.filter (\_ _ -> False) dict
--> Dict.empty
```
Bonus: Correct `Evaluate.isAlwaysBool` (terrible name and seems unnecessary anyway?), add `Set.filter` simplifications to summary.