### PR TITLE
Add Dict.foldlr simplifications and make existing Dict functions with extra arg generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@
 - `Dict.filter (\_ _ -> True) dict` to `dict`
 - `Dict.filter (\_ _ -> False) dict` to `Dict.empty`
 - `Dict.remove k Dict.empty` to `Dict.empty`
+- `Dict.fold f initial Dict.empty` to `initial`
+- `Dict.fold (\_ soFar -> soFar) initial dict` to `initial`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10162,7 +10162,7 @@ partitionOnEmptyChecks emptiable =
 
 partitionWithConstantFunctionResult : Node Expression -> TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> CheckInfo -> Maybe (Error {})
 partitionWithConstantFunctionResult constantFunctionResult collection checkInfo =
-    case Evaluate.isAlwaysBoolean checkInfo checkInfo.firstArg of
+    case Evaluate.getBoolean checkInfo constantFunctionResult of
         Determined True ->
             case secondArg checkInfo of
                 Just (Node listArgRange _) ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8721,7 +8721,7 @@ emptiableMapWithExtraArgChecks :
     -> Maybe (Error {})
 emptiableMapWithExtraArgChecks emptiable =
     firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck dictCollection
+        [ unnecessaryCallOnEmptyCheck emptiable
         , \checkInfo ->
             case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
                 Just alwaysResult ->
@@ -8729,7 +8729,7 @@ emptiableMapWithExtraArgChecks emptiable =
                         Just
                             (alwaysReturnsLastArgError
                                 (qualifiedToString checkInfo.fn ++ " with a function that maps to the unchanged value")
-                                dictCollection
+                                emptiable
                                 checkInfo
                             )
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -9961,10 +9961,10 @@ a = List.filter (always True) x
 a = x
 """
                         ]
-        , test "should replace List.filter (\\x -> True) x by x" <|
+        , test "should replace List.filter (\\_ -> True) x by x" <|
             \() ->
                 """module A exposing (..)
-a = List.filter (\\x -> True) x
+a = List.filter (\\_ -> True) x
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -10041,10 +10041,10 @@ a = List.filter (always False) x
 a = []
 """
                         ]
-        , test "should replace List.filter (\\x -> False) x by []" <|
+        , test "should replace List.filter (\\_ -> False) x by []" <|
             \() ->
                 """module A exposing (..)
-a = List.filter (\\x -> False) x
+a = List.filter (\\_ -> False) x
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -16487,11 +16487,11 @@ import Array
 a = array
 """
                         ]
-        , test "should replace Array.filter (\\x -> True) array by array" <|
+        , test "should replace Array.filter (\\_ -> True) array by array" <|
             \() ->
                 """module A exposing (..)
 import Array
-a = Array.filter (\\x -> True) array
+a = Array.filter (\\_ -> True) array
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -16577,11 +16577,11 @@ import Array
 a = Array.empty
 """
                         ]
-        , test "should replace Array.filter (\\x -> False) array by Array.empty" <|
+        , test "should replace Array.filter (\\_ -> False) array by Array.empty" <|
             \() ->
                 """module A exposing (..)
 import Array
-a = Array.filter (\\x -> False) array
+a = Array.filter (\\_ -> False) array
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -20676,11 +20676,11 @@ import Set
 a = set
 """
                         ]
-        , test "should replace Set.filter (\\x -> True) set by set" <|
+        , test "should replace Set.filter (\\_ -> True) set by set" <|
             \() ->
                 """module A exposing (..)
 import Set
-a = Set.filter (\\x -> True) set
+a = Set.filter (\\_ -> True) set
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
@@ -20766,11 +20766,11 @@ import Set
 a = Set.empty
 """
                         ]
-        , test "should replace Set.filter (\\x -> False) set by Set.empty" <|
+        , test "should replace Set.filter (\\_ -> False) set by Set.empty" <|
             \() ->
                 """module A exposing (..)
 import Set
-a = Set.filter (\\x -> False) set
+a = Set.filter (\\_ -> False) set
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors


### PR DESCRIPTION
`Dict` simplifications should now be on par with `Set` except for `insert`
```elm
-- same for foldr
Dict.foldl f initial Dict.empty
--> initial

Dict.foldl (\_ soFar -> soFar) initial dict
--> initial
```

Bonus: Convert existing manual Dict operation checks that exist because the function takes 2 args to more generic helpers.