### PR TITLE
Add Tuple.first after partition simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - `Dict.remove k Dict.empty` to `Dict.empty`
 - `Dict.foldl f initial Dict.empty` to `initial` (same for `Dict.foldr`)
 - `Dict.foldl (\_ soFar -> soFar) initial dict` to `initial` (same for `Dict.foldr`)
+- `Tuple.first (List.partition f list)` to `List.filter` (same for `Set.partition` and `Dict.partition`)
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 - `Dict.remove k Dict.empty` to `Dict.empty`
 - `Dict.foldl f initial Dict.empty` to `initial` (same for `Dict.foldr`)
 - `Dict.foldl (\_ soFar -> soFar) initial dict` to `initial` (same for `Dict.foldr`)
-- `Tuple.first (List.partition f list)` to `List.filter` (same for `Set.partition` and `Dict.partition`)
+- `Tuple.first (List.partition f list)` to `List.filter f list` (same for `Set.partition` and `Dict.partition`)
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -714,6 +714,9 @@ Destructuring using case expressions
     List.partition (always False) list
     --> ( [], list )
 
+    Tuple.first (List.partition f list)
+    --> List.filter f
+
     List.take 0 list
     --> []
 
@@ -941,6 +944,9 @@ Destructuring using case expressions
     Set.partition (always True) set
     --> ( set, Set.empty )
 
+    Tuple.first (Set.partition f set)
+    --> Set.filter f
+
     -- The following simplifications for Set.foldl also work for Set.foldr
     Set.foldl f initial Set.empty
     --> initial
@@ -1010,6 +1016,9 @@ Destructuring using case expressions
 
     Dict.partition (\_ _ -> False) dict
     --> ( Dict.empty, dict )
+
+    Tuple.first (Dict.partition f dict)
+    --> Dict.filter f
 
     List.map Tuple.first (Dict.toList dict)
     --> Dict.keys dict
@@ -4315,12 +4324,20 @@ tuplePairChecks checkInfo =
 
 tupleFirstChecks : CheckInfo -> Maybe (Error {})
 tupleFirstChecks =
-    tuplePartChecks
-        { part = TupleFirst
-        , description = "first"
-        , mapUnrelatedFn = Fn.Tuple.mapSecond
-        , mapFn = Fn.Tuple.mapFirst
-        }
+    firstThatConstructsJust
+        [ tuplePartChecks
+            { part = TupleFirst
+            , description = "first"
+            , mapUnrelatedFn = Fn.Tuple.mapSecond
+            , mapFn = Fn.Tuple.mapFirst
+            }
+        , callFromCanBeCombinedCheck
+            { fromFn = Fn.List.partition, combinedFn = Fn.List.filter }
+        , callFromCanBeCombinedCheck
+            { fromFn = Fn.Set.partition, combinedFn = Fn.Set.filter }
+        , callFromCanBeCombinedCheck
+            { fromFn = Fn.Dict.partition, combinedFn = Fn.Dict.filter }
+        ]
 
 
 tupleFirstCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
@@ -4350,6 +4367,12 @@ tupleFirstCompositionChecks =
 
                 _ ->
                     Nothing
+        , compositionFromCanBeCombinedCheck
+            { fromFn = Fn.List.partition, combinedFn = Fn.List.filter }
+        , compositionFromCanBeCombinedCheck
+            { fromFn = Fn.Set.partition, combinedFn = Fn.Set.filter }
+        , compositionFromCanBeCombinedCheck
+            { fromFn = Fn.Dict.partition, combinedFn = Fn.Dict.filter }
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -715,7 +715,7 @@ Destructuring using case expressions
     --> ( [], list )
 
     Tuple.first (List.partition f list)
-    --> List.filter f
+    --> List.filter f list
 
     List.take 0 list
     --> []
@@ -945,7 +945,7 @@ Destructuring using case expressions
     --> ( set, Set.empty )
 
     Tuple.first (Set.partition f set)
-    --> Set.filter f
+    --> Set.filter f set
 
     -- The following simplifications for Set.foldl also work for Set.foldr
     Set.foldl f initial Set.empty
@@ -1018,7 +1018,7 @@ Destructuring using case expressions
     --> ( Dict.empty, dict )
 
     Tuple.first (Dict.partition f dict)
-    --> Dict.filter f
+    --> Dict.filter f dict
 
     List.map Tuple.first (Dict.toList dict)
     --> Dict.keys dict

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -15464,6 +15464,110 @@ a = Tuple.first << Tuple.mapBoth changeFirst changeSecond
 a = Tuple.first << Tuple.mapFirst changeFirst
 """
                         ]
+        , test "should replace Tuple.first (List.partition f list) by (List.filter f list)" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.first (List.partition f list)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.partition, then Tuple.first can be combined into List.filter"
+                            , details = [ "You can replace this call by List.filter with the same arguments given to List.partition which is meant for this exact purpose." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.filter f list)
+"""
+                        ]
+        , test "should replace Tuple.first (Set.partition f set) by (Set.filter f set)" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Tuple.first (Set.partition f set)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.partition, then Tuple.first can be combined into Set.filter"
+                            , details = [ "You can replace this call by Set.filter with the same arguments given to Set.partition which is meant for this exact purpose." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = (Set.filter f set)
+"""
+                        ]
+        , test "should replace Tuple.first (Dict.partition f dict) by (Dict.filter f dict)" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Tuple.first (Dict.partition f dict)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.partition, then Tuple.first can be combined into Dict.filter"
+                            , details = [ "You can replace this call by Dict.filter with the same arguments given to Dict.partition which is meant for this exact purpose." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = (Dict.filter f dict)
+"""
+                        ]
+        , test "should replace Tuple.first << List.partition f by List.filter f" <|
+            \() ->
+                """module A exposing (..)
+a = Tuple.first << List.partition f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.partition, then Tuple.first can be combined into List.filter"
+                            , details = [ "You can replace this composition by List.filter with the same arguments given to List.partition which is meant for this exact purpose." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.filter f
+"""
+                        ]
+        , test "should replace Tuple.first << Set.partition f by Set.filter f" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Tuple.first << Set.partition f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.partition, then Tuple.first can be combined into Set.filter"
+                            , details = [ "You can replace this composition by Set.filter with the same arguments given to Set.partition which is meant for this exact purpose." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.filter f
+"""
+                        ]
+        , test "should replace Tuple.first << Dict.partition f by Dict.filter f" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Tuple.first << Dict.partition f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.partition, then Tuple.first can be combined into Dict.filter"
+                            , details = [ "You can replace this composition by Dict.filter with the same arguments given to Dict.partition which is meant for this exact purpose." ]
+                            , under = "Tuple.first"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.filter f
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
One simplification from https://github.com/jfmengels/elm-review-simplify/issues/2
```elm
-- same for Set and Dict
Tuple.first (List.partition f list)
--> List.filter f
```
including composition