### PR TITLE
operations on list containing absorbing element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - `List.product [ a, 1, b ]` to `List.product [ a, b ]`
 - `List.product [ a, 0, b ]` to `0` when [`expectNaN`] is not enabled
 - `List.product [ a, 0 / 0, b ]` to `0 / 0` when [`expectNaN`] is enabled
+- `List.sum [ a, 0 / 0, b ]` to `0 / 0` when [`expectNaN`] is enabled
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@
 - `Tuple.first (List.partition f list)` to `List.filter f list` (same for `Set.partition` and `Dict.partition`)
 - `List.sum [ a, 0, b ]` to `List.sum [ a, b ]`
 - `List.product [ a, 1, b ]` to `List.product [ a, b ]`
+- `List.product [ a, 0, b ]` to `0` when [`expectNaN`] is not enabled
+- `List.product [ a, 0 / 0, b ]` to `0 / 0` when [`expectNaN`] is enabled
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5727,10 +5727,10 @@ listSumChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck { resultAsString = \_ -> "0" } listCollection
         , callOnWrapReturnsItsValueCheck listCollection
-        , callOnListWithIrrelevantEmptyElement additiveNumberProperties
+        , callOnListWithIrrelevantEmptyElement numberForAddProperties
         , \checkInfo ->
             if checkInfo.expectNaN then
-                callOnListWithAbsorbingElement additiveNumberProperties checkInfo
+                callOnListWithAbsorbingElement numberForAddProperties checkInfo
 
             else
                 Nothing
@@ -8255,8 +8255,8 @@ emptyAsString qualifyResources emptiable =
     emptiable.empty.asString (extractQualifyResources qualifyResources)
 
 
-additiveNumberProperties : TypeProperties (EmptiableProperties ConstantProperties (AbsorbableProperties {}))
-additiveNumberProperties =
+numberForAddProperties : TypeProperties (EmptiableProperties ConstantProperties (AbsorbableProperties {}))
+numberForAddProperties =
     { represents = "number"
     , empty = number0Constant
     , absorbing = numberNaNConstant

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8268,7 +8268,7 @@ numberForAddProperties =
     0 * (0 / 0)
     --> 0 / 0 (NaN)
 
-In fact, NaN _is_ an absorbing element for `(*)`.
+In fact, NaN is an absorbing element for `(*)`.
 If `expectingNaN` is not enabled, use `numberNotExpectingNaNForMultiplyProperties`.
 
 -}

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -629,6 +629,10 @@ Destructuring using case expressions
     List.sum [ a, 0, b ]
     --> List.sum [ a, b ]
 
+    -- when `expectNaN` is enabled
+    List.sum [ a, 0 / 0, b ]
+    --> 0 / 0
+
     List.product []
     --> 1
 
@@ -5724,6 +5728,12 @@ listSumChecks =
         [ callOnEmptyReturnsCheck { resultAsString = \_ -> "0" } listCollection
         , callOnWrapReturnsItsValueCheck listCollection
         , callOnListWithIrrelevantEmptyElement additiveNumberProperties
+        , \checkInfo ->
+            if checkInfo.expectNaN then
+                callOnListWithAbsorbingElement additiveNumberProperties checkInfo
+
+            else
+                Nothing
         ]
 
 
@@ -8245,10 +8255,11 @@ emptyAsString qualifyResources emptiable =
     emptiable.empty.asString (extractQualifyResources qualifyResources)
 
 
-additiveNumberProperties : TypeProperties (EmptiableProperties ConstantProperties {})
+additiveNumberProperties : TypeProperties (EmptiableProperties ConstantProperties (AbsorbableProperties {}))
 additiveNumberProperties =
     { represents = "number"
     , empty = number0Constant
+    , absorbing = numberNaNConstant
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4098,8 +4098,8 @@ isNegatableOperator op =
 orChecks : OperatorCheckInfo -> Maybe (Error {})
 orChecks =
     firstThatConstructsJust
-        [ \checkInfo -> findMap (\side -> unnecessaryOperationWithEmptyBoolSideChecks boolForOrProperties side checkInfo) (operationSides checkInfo)
-        , \checkInfo -> findMap (\side -> operationWithAbsorbingBoolSideChecks boolForOrProperties side checkInfo) (operationSides checkInfo)
+        [ \checkInfo -> findMap (\side -> unnecessaryOperationWithEmptySideChecks boolForOrProperties side checkInfo) (operationSides checkInfo)
+        , \checkInfo -> findMap (\side -> operationWithAbsorbingSideChecks boolForOrProperties side checkInfo) (operationSides checkInfo)
         , findSimilarConditionsError
         ]
 
@@ -4107,14 +4107,14 @@ orChecks =
 andChecks : OperatorCheckInfo -> Maybe (Error {})
 andChecks =
     firstThatConstructsJust
-        [ \checkInfo -> findMap (\side -> unnecessaryOperationWithEmptyBoolSideChecks boolForAndProperties side checkInfo) (operationSides checkInfo)
-        , \checkInfo -> findMap (\side -> operationWithAbsorbingBoolSideChecks boolForAndProperties side checkInfo) (operationSides checkInfo)
+        [ \checkInfo -> findMap (\side -> unnecessaryOperationWithEmptySideChecks boolForAndProperties side checkInfo) (operationSides checkInfo)
+        , \checkInfo -> findMap (\side -> operationWithAbsorbingSideChecks boolForAndProperties side checkInfo) (operationSides checkInfo)
         , findSimilarConditionsError
         ]
 
 
-unnecessaryOperationWithEmptyBoolSideChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> { side | node : Node Expression, otherNode : Node Expression, otherDescription : String } -> OperatorCheckInfo -> Maybe (Error {})
-unnecessaryOperationWithEmptyBoolSideChecks forOperationProperties side checkInfo =
+unnecessaryOperationWithEmptySideChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> { side | node : Node Expression, otherNode : Node Expression, otherDescription : String } -> OperatorCheckInfo -> Maybe (Error {})
+unnecessaryOperationWithEmptySideChecks forOperationProperties side checkInfo =
     if forOperationProperties.empty.is (extractInferResources checkInfo) side.node then
         Just
             (Rule.errorWithFix
@@ -4129,8 +4129,8 @@ unnecessaryOperationWithEmptyBoolSideChecks forOperationProperties side checkInf
         Nothing
 
 
-operationWithAbsorbingBoolSideChecks : TypeProperties (AbsorbableProperties otherProperties) -> { side | node : Node Expression, otherNode : Node Expression, otherDescription : String } -> OperatorCheckInfo -> Maybe (Error {})
-operationWithAbsorbingBoolSideChecks forOperationProperties side checkInfo =
+operationWithAbsorbingSideChecks : TypeProperties (AbsorbableProperties otherProperties) -> { side | node : Node Expression, otherNode : Node Expression, otherDescription : String } -> OperatorCheckInfo -> Maybe (Error {})
+operationWithAbsorbingSideChecks forOperationProperties side checkInfo =
     if forOperationProperties.absorbing.is (extractInferResources checkInfo) side.node then
         Just
             (Rule.errorWithFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4118,7 +4118,7 @@ unnecessaryOperationWithEmptySideChecks forOperationProperties side checkInfo =
     if forOperationProperties.empty.is (extractInferResources checkInfo) side.node then
         Just
             (Rule.errorWithFix
-                { message = "Unnecessary check for " ++ checkInfo.operator ++ " " ++ descriptionForIndefinite forOperationProperties.empty.description
+                { message = "Unnecessary " ++ checkInfo.operator ++ " " ++ descriptionForIndefinite forOperationProperties.empty.description
                 , details = [ "You can replace this operation by the " ++ side.otherDescription ++ " " ++ forOperationProperties.represents ++ "." ]
                 }
                 (Range.combine [ checkInfo.operatorRange, Node.range side.node ])

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5747,10 +5747,10 @@ listProductChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck { resultAsString = \_ -> "1" } listCollection
         , callOnWrapReturnsItsValueCheck listCollection
-        , callOnListWithIrrelevantEmptyElement multiplicativeNumberProperties
+        , callOnListWithIrrelevantEmptyElement numberForMultiplyProperties
         , \checkInfo ->
             if checkInfo.expectNaN then
-                callOnListWithAbsorbingElement multiplicativeNumberProperties checkInfo
+                callOnListWithAbsorbingElement numberForMultiplyProperties checkInfo
 
             else
                 callOnListWithAbsorbingElement multiplicativeNumberNotExpectingNaNProperties checkInfo
@@ -8272,8 +8272,8 @@ In fact, NaN _is_ an absorbing element for `(*)`.
 If `expectingNaN` is not enabled, use `multiplicativeNumberNotExpectingNaNProperties`.
 
 -}
-multiplicativeNumberProperties : TypeProperties (EmptiableProperties ConstantProperties (AbsorbableProperties {}))
-multiplicativeNumberProperties =
+numberForMultiplyProperties : TypeProperties (EmptiableProperties ConstantProperties (AbsorbableProperties {}))
+numberForMultiplyProperties =
     { represents = "number"
     , empty = number1Constant
     , absorbing = numberNaNConstant
@@ -8285,7 +8285,7 @@ multiplicativeNumberProperties =
     0 * (0 / 0)
     --> 0 / 0 (NaN)
 
-If that's the case, use `multiplicativeNumberProperties`.
+If that's the case, use `numberForMultiplyProperties`.
 
 Not having `expectingNaN` enabled however, 0 _is_ absorbing, so we can now simplify e.g.
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8055,10 +8055,10 @@ all others, which means any application with one such element results in that el
 
 Even NaN falls into this category with +, \*, min, max:
 
-    10 10 * Basics.max 10 (0 / 0) + 10
+    10 * Basics.max 10 (0 / 0) + 10
     --> 0 / 0 (NaN)
 
-    10 + Basics.min 10 (0 / 0) * 10
+    10 - Basics.min 10 (0 / 0) * 10
     --> 0 / 0
 
 And some properties only hold when `expectNaN` is not enabled, e.g.
@@ -8073,7 +8073,7 @@ And some properties only hold when `expectNaN` is not enabled, e.g.
     --> 1 / 0 (Infinity)
 
     List.maximum [ a, 1 / 0, b ]
-    --> 1 / 0
+    --> Just (1 / 0)
 
 More info: <https://en.wikipedia.org/wiki/Absorbing_element>
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5753,7 +5753,7 @@ listProductChecks =
                 callOnListWithAbsorbingElement numberForMultiplyProperties checkInfo
 
             else
-                callOnListWithAbsorbingElement multiplicativeNumberNotExpectingNaNProperties checkInfo
+                callOnListWithAbsorbingElement numberNotExpectingNaNForMultiplyProperties checkInfo
         ]
 
 
@@ -8269,7 +8269,7 @@ numberForAddProperties =
     --> 0 / 0 (NaN)
 
 In fact, NaN _is_ an absorbing element for `(*)`.
-If `expectingNaN` is not enabled, use `multiplicativeNumberNotExpectingNaNProperties`.
+If `expectingNaN` is not enabled, use `numberNotExpectingNaNForMultiplyProperties`.
 
 -}
 numberForMultiplyProperties : TypeProperties (EmptiableProperties ConstantProperties (AbsorbableProperties {}))
@@ -8295,8 +8295,8 @@ Not having `expectingNaN` enabled however, 0 _is_ absorbing, so we can now simpl
 (see `callOnListWithAbsorbingElement`)
 
 -}
-multiplicativeNumberNotExpectingNaNProperties : TypeProperties (EmptiableProperties ConstantProperties (AbsorbableProperties {}))
-multiplicativeNumberNotExpectingNaNProperties =
+numberNotExpectingNaNForMultiplyProperties : TypeProperties (EmptiableProperties ConstantProperties (AbsorbableProperties {}))
+numberNotExpectingNaNForMultiplyProperties =
     { represents = "number"
     , empty = number1Constant
     , absorbing = number0Constant

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -2424,8 +2424,8 @@ a = n * 1
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary multiplying by 1"
-                            , details = [ "You can replace this operation by the left number you multiplied by 1." ]
+                            { message = "Unnecessary * 1"
+                            , details = [ "You can replace this operation by the left number." ]
                             , under = "* 1"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2440,8 +2440,8 @@ a = n * 1.0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary multiplying by 1"
-                            , details = [ "You can replace this operation by the left number you multiplied by 1." ]
+                            { message = "Unnecessary * 1"
+                            , details = [ "You can replace this operation by the left number." ]
                             , under = "* 1.0"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2456,8 +2456,8 @@ a = 1 * n
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary multiplying by 1"
-                            , details = [ "You can replace this operation by the right number you multiplied by 1." ]
+                            { message = "Unnecessary * 1"
+                            , details = [ "You can replace this operation by the right number." ]
                             , under = "1 *"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10924,6 +10924,22 @@ a = List.sum [ 0, b ]
 a = List.sum [ b ]
 """
                         ]
+        , test "should replace [ a, 0 / 0.0, b ] |> List.sum by (0 / 0.0) when expectNaN is enabled" <|
+            \() ->
+                """module A exposing (..)
+a = [ a, 0 / 0.0, b ] |> List.sum
+"""
+                    |> Review.Test.run (rule (defaults |> Simplify.expectNaN))
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.sum on a list with NaN will result in NaN"
+                            , details = [ "You can replace this call by (0 / 0)." ]
+                            , under = "List.sum"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (0 / 0.0)
+"""
+                        ]
         ]
 
 

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1114,7 +1114,7 @@ a = False || x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary check for || False"
+                            { message = "Unnecessary || False"
                             , details = [ "You can replace this operation by the right bool." ]
                             , under = "False ||"
                             }
@@ -1130,7 +1130,7 @@ a = x || False
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary check for || False"
+                            { message = "Unnecessary || False"
                             , details = [ "You can replace this operation by the left bool." ]
                             , under = "|| False"
                             }
@@ -1146,7 +1146,7 @@ a = x || (False)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary check for || False"
+                            { message = "Unnecessary || False"
                             , details = [ "You can replace this operation by the left bool." ]
                             , under = "|| (False)"
                             }
@@ -1342,7 +1342,7 @@ a = True && x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary check for && True"
+                            { message = "Unnecessary && True"
                             , details = [ "You can replace this operation by the right bool." ]
                             , under = "True &&"
                             }
@@ -1358,7 +1358,7 @@ a = x && True
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary check for && True"
+                            { message = "Unnecessary && True"
                             , details = [ "You can replace this operation by the left bool." ]
                             , under = "&& True"
                             }
@@ -4428,7 +4428,7 @@ a =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary check for && True"
+                            { message = "Unnecessary && True"
                             , details = [ "You can replace this operation by the right bool." ]
                             , under = "x &&"
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -11058,6 +11058,77 @@ a = List.product [ 1, b ]
 a = List.product [ b ]
 """
                         ]
+        , test "should replace List.product [ a, 0, b ] by 0" <|
+            \() ->
+                """module A exposing (..)
+a = List.product [ a, 0, b ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.product on a list with 0 will result in 0"
+                            , details = [ "You can replace this call by 0." ]
+                            , under = "List.product"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 0
+"""
+                        ]
+        , test "should replace List.product (a :: 0 :: bs) by 0" <|
+            \() ->
+                """module A exposing (..)
+a = List.product (a :: 0 :: bs)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.product on a list with 0 will result in 0"
+                            , details = [ "You can replace this call by 0." ]
+                            , under = "List.product"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 0
+"""
+                        ]
+        , test "should replace List.product [ a, 0.0, b ] by 0.0" <|
+            \() ->
+                """module A exposing (..)
+a = List.product [ a, 0.0, b ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.product on a list with 0 will result in 0"
+                            , details = [ "You can replace this call by 0." ]
+                            , under = "List.product"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 0.0
+"""
+                        ]
+        , test "should not report List.product [ a, 0.0, 0, b ] when expectNaN is enabled" <|
+            \() ->
+                """module A exposing (..)
+a = List.product [ a, 0.0, 0, b ]
+"""
+                    |> Review.Test.run (rule (defaults |> Simplify.expectNaN))
+                    |> Review.Test.expectNoErrors
+        , test "should replace [ a, 0 / 0.0, b ] |> List.product by (0 / 0.0) when expectNaN is enabled" <|
+            \() ->
+                """module A exposing (..)
+a = [ a, 0 / 0.0, b ] |> List.product
+"""
+                    |> Review.Test.run (rule (defaults |> Simplify.expectNaN))
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.product on a list with NaN will result in NaN"
+                            , details = [ "You can replace this call by (0 / 0)." ]
+                            , under = "List.product"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (0 / 0.0)
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
#### when `expectNaN` is not enabled
```elm
List.product [ a, 0, b ]
--> 0
```
which is a simplification from https://github.com/jfmengels/elm-review-simplify/issues/127
#### when `expectNaN` is enabled
```elm
List.sum [ a, 0 / 0, b ]
--> 0 / 0

List.product [ a, 0 / 0, b ]
--> 0 / 0
```