### PR TITLE
Add List.all/any with not on list with (not absorbing) simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@
 - `List.sum [ a, 0 / 0, b ]` to `0 / 0` when [`expectNaN`] is enabled
 - `List.all identity [ a, False, b ]` to `False`
 - `List.any identity [ a, True, b ]` to `True`
+- `List.all not [ a, True, b ]` to `False`
+- `List.any not [ a, False, b ]` to `True`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5998,17 +5998,18 @@ So for example with `onIndexableWithAbsorbingChecks ( listCollection, boolForAnd
 
 -}
 onIndexableWithAbsorbingChecks :
-    ( TypeProperties (IndexableProperties otherProperties), AbsorbableProperties elementOtherProperties )
+    String
+    -> ( TypeProperties (IndexableProperties otherProperties), AbsorbableProperties elementOtherProperties )
     -> CheckInfo
     -> Maybe (Error {})
-onIndexableWithAbsorbingChecks ( indexable, elementAbsorbable ) checkInfo =
+onIndexableWithAbsorbingChecks situation ( indexable, elementAbsorbable ) checkInfo =
     case Maybe.andThen (indexable.literalElements checkInfo.lookupTable) (fullyAppliedLastArg checkInfo) of
         Just elements ->
             case findMap (getAbsorbingExpressionNode elementAbsorbable checkInfo) elements of
                 Just absorbingElement ->
                     Just
                         (Rule.errorWithFix
-                            { message = qualifiedToString checkInfo.fn ++ " on a " ++ indexable.represents ++ " with " ++ descriptionForIndefinite elementAbsorbable.absorbing.description ++ " will result in " ++ descriptionForIndefinite elementAbsorbable.absorbing.description
+                            { message = situation ++ " on a " ++ indexable.represents ++ " with " ++ descriptionForIndefinite elementAbsorbable.absorbing.description ++ " will result in " ++ descriptionForIndefinite elementAbsorbable.absorbing.description
                             , details =
                                 [ "You can replace this call by " ++ elementAbsorbable.absorbing.asString defaultQualifyResources ++ "." ]
                             }
@@ -6049,7 +6050,9 @@ indexableAllChecks indexable =
     firstThatConstructsJust
         [ \checkInfo ->
             if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
-                onIndexableWithAbsorbingChecks ( listCollection, boolForAndProperties ) checkInfo
+                onIndexableWithAbsorbingChecks (qualifiedToString checkInfo.fn ++ " with an identity function")
+                    ( listCollection, boolForAndProperties )
+                    checkInfo
 
             else
                 Nothing
@@ -6137,7 +6140,9 @@ indexableAnyChecks indexable =
     firstThatConstructsJust
         [ \checkInfo ->
             if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
-                onIndexableWithAbsorbingChecks ( indexable, boolForOrProperties ) checkInfo
+                onIndexableWithAbsorbingChecks (qualifiedToString checkInfo.fn ++ " with an identity function")
+                    ( indexable, boolForOrProperties )
+                    checkInfo
 
             else
                 Nothing

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13352,14 +13352,14 @@ a = List.all (always True)
 a = always True
 """
                         ]
-        , test "should not report List.all on list with False but non-identity function" <|
+        , test "should not report List.all on list with False but non-identity and non-not function" <|
             \() ->
                 """module A exposing (..)
 a = List.all f [ b, False, c ]
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should not report List.all on list with True and not False" <|
+        , test "should not report List.all identity on list with True and not False" <|
             \() ->
                 """module A exposing (..)
 a = List.all identity [ b, True, c ]
@@ -13375,6 +13375,29 @@ a = List.all identity [ b, False, c ]
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "List.all on a list with False will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.all"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = False
+"""
+                        ]
+        , test "should not report List.all not on list with False and no True" <|
+            \() ->
+                """module A exposing (..)
+a = List.all not [ b, False, c ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace List.all not [ a, True, b ] by False" <|
+            \() ->
+                """module A exposing (..)
+a = List.all not [ b, True, c ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.all with `not` on a list with True will result in False"
                             , details = [ "You can replace this call by False." ]
                             , under = "List.all"
                             }
@@ -13498,14 +13521,14 @@ a = List.any (\\z -> x == y)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should not report List.any on list with True but non-identity function" <|
+        , test "should not report List.any on list with True but non-identity and non-not function" <|
             \() ->
                 """module A exposing (..)
 a = List.any f [ b, True, c ]
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should not report List.any on list with False and not True" <|
+        , test "should not report List.any identity on list with False and not True" <|
             \() ->
                 """module A exposing (..)
 a = List.any identity [ b, False, c ]
@@ -13521,6 +13544,29 @@ a = List.any identity [ b, True, c ]
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "List.any on a list with True will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = True
+"""
+                        ]
+        , test "should not report List.any not on list with True and no False" <|
+            \() ->
+                """module A exposing (..)
+a = List.any not [ b, True, c ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace List.any not [ a, False, b ] by True" <|
+            \() ->
+                """module A exposing (..)
+a = List.any not [ b, False, c ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with `not` on a list with False will result in True"
                             , details = [ "You can replace this call by True." ]
                             , under = "List.any"
                             }

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13374,7 +13374,7 @@ a = List.all identity [ b, False, c ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.all on a list with False will result in False"
+                            { message = "List.all with an identity function on a list with False will result in False"
                             , details = [ "You can replace this call by False." ]
                             , under = "List.all"
                             }
@@ -13543,7 +13543,7 @@ a = List.any identity [ b, True, c ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.any on a list with True will result in True"
+                            { message = "List.any with an identity function on a list with True will result in True"
                             , details = [ "You can replace this call by True." ]
                             , under = "List.any"
                             }


### PR DESCRIPTION
as suggested in https://github.com/jfmengels/elm-review-simplify/pull/260#discussion_r1349517443
```elm
List.all not [ a, True, b ]
--> False

List.any not [ a, False, b ]
--> True
```
Bonus: Improved error for `any/ all identity [ .. absorbing .. ]`