### PR TITLE
List.all/any on list with unnecessary element simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Bug fixes:
 - Fixed an issue where `List.intersperse << List.singleton` would be fixed to `List.singleton`
 - Fixed an issue where e.g. `List.sortBy f << g` would be fixed to `g`
 - Fixed an issue where `Dict.partition (always (always True/False)) dict` would not be reported
+- Fixed an issue where `List.filterMap f [ a, Nothing, b ]` would be fixed to `List.filterMap f [ a, b ]`
 
 ## [2.1.2] - 2023-09-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,10 @@
 - `List.any identity [ a, True, b ]` to `True`
 - `List.all not [ a, True, b ]` to `False`
 - `List.any not [ a, False, b ]` to `True`
+- `List.any identity [ a, False, b ]` to `List.any identity [ a, b ]`
+- `List.any not [ a, True, b ]` to `List.any not [ a, b ]`
+- `List.all identity [ a, True, b ]` to `List.all identity [ a, b ]`
+- `List.all not [ a, False, b ]` to `List.all not [ a, b ]`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13366,13 +13366,22 @@ a = List.all f [ b, False, c ]
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should not report List.all identity on list with True and not False" <|
+        , test "should replace List.all identity [ a, True, b ] by List.all identity [ a, b ]" <|
             \() ->
                 """module A exposing (..)
 a = List.all identity [ b, True, c ]
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectNoErrors
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.all with an identity function on a list containing an irrelevant True"
+                            , details = [ "Including True in the list does not change the result of this call. You can remove the True element." ]
+                            , under = "True"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.all identity [ b, c ]
+"""
+                        ]
         , test "should replace List.all identity [ a, False, b ] by False" <|
             \() ->
                 """module A exposing (..)
@@ -13389,13 +13398,22 @@ a = List.all identity [ b, False, c ]
 a = False
 """
                         ]
-        , test "should not report List.all not on list with False and no True" <|
+        , test "should replace List.all not [ a, False, b ] by List.all not [ a, b ]" <|
             \() ->
                 """module A exposing (..)
 a = List.all not [ b, False, c ]
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectNoErrors
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.all with `not` on a list containing an irrelevant False"
+                            , details = [ "Including False in the list does not change the result of this call. You can remove the False element." ]
+                            , under = "False"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.all not [ b, c ]
+"""
+                        ]
         , test "should replace List.all not [ a, True, b ] by False" <|
             \() ->
                 """module A exposing (..)
@@ -13535,13 +13553,22 @@ a = List.any f [ b, True, c ]
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should not report List.any identity on list with False and not True" <|
+        , test "should replace List.any identity [ a, False, b ] and by List.any identity [ a, b ]" <|
             \() ->
                 """module A exposing (..)
 a = List.any identity [ b, False, c ]
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectNoErrors
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with an identity function on a list containing an irrelevant False"
+                            , details = [ "Including False in the list does not change the result of this call. You can remove the False element." ]
+                            , under = "False"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.any identity [ b, c ]
+"""
+                        ]
         , test "should replace List.any identity [ a, True, b ] by True" <|
             \() ->
                 """module A exposing (..)
@@ -13558,13 +13585,22 @@ a = List.any identity [ b, True, c ]
 a = True
 """
                         ]
-        , test "should not report List.any not on list with True and no False" <|
+        , test "should replace List.any not [ a, True, b ] by List.any not [ a, b ]" <|
             \() ->
                 """module A exposing (..)
 a = List.any not [ b, True, c ]
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectNoErrors
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with `not` on a list containing an irrelevant True"
+                            , details = [ "Including True in the list does not change the result of this call. You can remove the True element." ]
+                            , under = "True"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.any not [ b, c ]
+"""
+                        ]
         , test "should replace List.any not [ a, False, b ] by True" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -10486,6 +10486,13 @@ a = List.map f >> List.filterMap identity
 a = List.filterMap f
 """
                         ]
+        , test "should not report List.filterMap f [ a, Nothing, b ] with f not being an identity function" <|
+            \() ->
+                """module A exposing (..)
+a = List.filterMap f [ a, Nothing, b ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
         , test "should replace List.filterMap identity [ a, Nothing, b ] by List.filterMap identity [ a, b ]" <|
             \() ->
                 """module A exposing (..)
@@ -10494,7 +10501,7 @@ a = List.filterMap identity [ a, Nothing, b ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.filterMap on a list containing an irrelevant Nothing"
+                            { message = "List.filterMap with an identity function on a list containing an irrelevant Nothing"
                             , details = [ "Including Nothing in the list does not change the result of this call. You can remove the Nothing element." ]
                             , under = "Nothing"
                             }


### PR DESCRIPTION
as hinted at in https://github.com/jfmengels/elm-review-simplify/pull/261#discussion_r1349564444
```elm
List.all identity [ a, True, b ]
--> List.all identity [ a, b ]

List.all not [ a, False, b ]
--> List.all not [ a, b ]


List.any identity [ a, False, b ]
--> List.any identity [ a, b ]

List.any not [ a, True, b ]
--> List.any not [ a, b ]
```

Bonus: Fixed a bug where `List.filterMap` with a non-identity function on a list with `Nothing` would remove the `Nothing` element.