### PR TITLE
Add simplifications for number conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,8 @@
 - `round 1` to `1`
 - `ceiling 1` to `1`
 - `floor 1` to `1`
-- `round (toFloat n)` to `n` (and same for ceiling, floor)
+- `truncate 1` to `1`
+- `round (toFloat n)` to `n` (and same for ceiling, floor, truncate)
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,8 @@
 - `List.all not [ a, False, b ]` to `List.all not [ a, b ]`
 - `toFloat 1` to `1`
 - `round 1` to `1`
-- `round (toFloat n)` to `n`
+- `ceiling 1` to `1`
+- `round (toFloat n)` to `n` (and same for ceiling)
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - `List.any not [ a, True, b ]` to `List.any not [ a, b ]`
 - `List.all identity [ a, True, b ]` to `List.all identity [ a, b ]`
 - `List.all not [ a, False, b ]` to `List.all not [ a, b ]`
+- `toFloat 1` to `1`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@
 - `List.all identity [ a, True, b ]` to `List.all identity [ a, b ]`
 - `List.all not [ a, False, b ]` to `List.all not [ a, b ]`
 - `toFloat 1` to `1`
+- `round 1` to `1`
+- `round (toFloat n)` to `n`
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,8 @@
 - `toFloat 1` to `1`
 - `round 1` to `1`
 - `ceiling 1` to `1`
-- `round (toFloat n)` to `n` (and same for ceiling)
+- `floor 1` to `1`
+- `round (toFloat n)` to `n` (and same for ceiling, floor)
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4158,13 +4158,13 @@ basicsToFloatChecks checkInfo =
 intToIntChecks : CheckInfo -> Maybe (Error {})
 intToIntChecks =
     firstThatConstructsJust
-        [ intToIntCheck
+        [ unnecessaryConversionToIntOnIntCheck
         , onCallToInverseReturnsItsArgumentCheck Fn.Basics.toFloat
         ]
 
 
-intToIntCheck : CheckInfo -> Maybe (Error {})
-intToIntCheck checkInfo =
+unnecessaryConversionToIntOnIntCheck : CheckInfo -> Maybe (Error {})
+unnecessaryConversionToIntOnIntCheck checkInfo =
     case Evaluate.getInt checkInfo checkInfo.firstArg of
         Just _ ->
             Just

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -197,6 +197,9 @@ Destructuring using case expressions
     f >> always x
     --> always x
 
+    toFloat 1
+    --> 1
+
 
 ### Lambdas
 
@@ -2719,6 +2722,7 @@ functionCallChecks =
         , ( Fn.Basics.always, ( 2, basicsAlwaysChecks ) )
         , ( Fn.Basics.not, ( 1, basicsNotChecks ) )
         , ( Fn.Basics.negate, ( 1, basicsNegateChecks ) )
+        , ( Fn.Basics.toFloat, ( 1, basicsToFloatChecks ) )
         , ( Fn.Tuple.first, ( 1, tupleFirstChecks ) )
         , ( Fn.Tuple.second, ( 1, tupleSecondChecks ) )
         , ( Fn.Tuple.pair, ( 2, tuplePairChecks ) )
@@ -4105,6 +4109,26 @@ isNegatableOperator op =
             Just "=="
 
         _ ->
+            Nothing
+
+
+basicsToFloatChecks : CheckInfo -> Maybe (Error {})
+basicsToFloatChecks checkInfo =
+    case Evaluate.getNumber checkInfo checkInfo.firstArg of
+        Just _ ->
+            Just
+                (Rule.errorWithFix
+                    { message = "Unnecessary " ++ qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on a literal number"
+                    , details =
+                        [ "A literal integers is considered as both an Int and a Float, there is therefore no need to explicitly convert it to a Float."
+                        , "You can replace this function call by the literal number."
+                        ]
+                    }
+                    checkInfo.fnRange
+                    (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg })
+                )
+
+        Nothing ->
             Nothing
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4137,7 +4137,7 @@ isNegatableOperator op =
 
 basicsToFloatChecks : CheckInfo -> Maybe (Error {})
 basicsToFloatChecks checkInfo =
-    case Evaluate.getNumber checkInfo checkInfo.firstArg of
+    case Evaluate.getInt checkInfo checkInfo.firstArg of
         Just _ ->
             Just
                 (Rule.errorWithFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4171,7 +4171,7 @@ intToIntCheck checkInfo =
                 (Rule.errorWithFix
                     { message = "Unnecessary integer conversion on a literal integer"
                     , details =
-                        [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                        [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                         , "You can replace this function call by the literal integer."
                         ]
                     }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -203,7 +203,10 @@ Destructuring using case expressions
     round 1
     --> 1
 
-    round (toFloat n)
+    ceiling 1
+    --> 1
+
+    round (toFloat n) -- same for ceiling
     --> n
 
 
@@ -2729,7 +2732,8 @@ functionCallChecks =
         , ( Fn.Basics.not, ( 1, basicsNotChecks ) )
         , ( Fn.Basics.negate, ( 1, basicsNegateChecks ) )
         , ( Fn.Basics.toFloat, ( 1, basicsToFloatChecks ) )
-        , ( Fn.Basics.round, ( 1, basicsRoundChecks ) )
+        , ( Fn.Basics.round, ( 1, intToIntChecks ) )
+        , ( Fn.Basics.ceiling, ( 1, intToIntChecks ) )
         , ( Fn.Tuple.first, ( 1, tupleFirstChecks ) )
         , ( Fn.Tuple.second, ( 1, tupleSecondChecks ) )
         , ( Fn.Tuple.pair, ( 2, tuplePairChecks ) )
@@ -3033,6 +3037,7 @@ compositionIntoChecks =
         [ ( Fn.Basics.always, ( 2, basicsAlwaysCompositionChecks ) )
         , ( Fn.Basics.not, ( 1, toggleCompositionChecks ) )
         , ( Fn.Basics.round, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
+        , ( Fn.Basics.ceiling, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
         , ( Fn.Basics.negate, ( 1, toggleCompositionChecks ) )
         , ( Fn.String.reverse, ( 1, stringReverseCompositionChecks ) )
         , ( Fn.String.fromList, ( 1, stringFromListCompositionChecks ) )
@@ -4140,8 +4145,8 @@ basicsToFloatChecks checkInfo =
             Nothing
 
 
-basicsRoundChecks : CheckInfo -> Maybe (Error {})
-basicsRoundChecks =
+intToIntChecks : CheckInfo -> Maybe (Error {})
+intToIntChecks =
     firstThatConstructsJust
         [ intToIntCheck
         , onCallToInverseReturnsItsArgumentCheck Fn.Basics.toFloat

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -209,7 +209,10 @@ Destructuring using case expressions
     floor 1
     --> 1
 
-    round (toFloat n) -- same for ceiling, floor
+    truncate 1
+    --> 1
+
+    round (toFloat n) -- same for ceiling, floor and truncate
     --> n
 
 
@@ -2738,6 +2741,7 @@ functionCallChecks =
         , ( Fn.Basics.round, ( 1, intToIntChecks ) )
         , ( Fn.Basics.ceiling, ( 1, intToIntChecks ) )
         , ( Fn.Basics.floor, ( 1, intToIntChecks ) )
+        , ( Fn.Basics.truncate, ( 1, intToIntChecks ) )
         , ( Fn.Tuple.first, ( 1, tupleFirstChecks ) )
         , ( Fn.Tuple.second, ( 1, tupleSecondChecks ) )
         , ( Fn.Tuple.pair, ( 2, tuplePairChecks ) )
@@ -3043,6 +3047,7 @@ compositionIntoChecks =
         , ( Fn.Basics.round, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
         , ( Fn.Basics.ceiling, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
         , ( Fn.Basics.floor, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
+        , ( Fn.Basics.truncate, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
         , ( Fn.Basics.negate, ( 1, toggleCompositionChecks ) )
         , ( Fn.String.reverse, ( 1, stringReverseCompositionChecks ) )
         , ( Fn.String.fromList, ( 1, stringFromListCompositionChecks ) )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4143,7 +4143,7 @@ basicsToFloatChecks checkInfo =
                 (Rule.errorWithFix
                     { message = "Unnecessary " ++ qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on a literal number"
                     , details =
-                        [ "A literal integers is considered as both an Int and a Float, there is therefore no need to explicitly convert it to a Float."
+                        [ "A literal integer is considered a number which means it can be used as both an Int and a Float and there is no need to explicitly convert it to a Float."
                         , "You can replace this function call by the literal number."
                         ]
                     }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -206,7 +206,10 @@ Destructuring using case expressions
     ceiling 1
     --> 1
 
-    round (toFloat n) -- same for ceiling
+    floor 1
+    --> 1
+
+    round (toFloat n) -- same for ceiling, floor
     --> n
 
 
@@ -2734,6 +2737,7 @@ functionCallChecks =
         , ( Fn.Basics.toFloat, ( 1, basicsToFloatChecks ) )
         , ( Fn.Basics.round, ( 1, intToIntChecks ) )
         , ( Fn.Basics.ceiling, ( 1, intToIntChecks ) )
+        , ( Fn.Basics.floor, ( 1, intToIntChecks ) )
         , ( Fn.Tuple.first, ( 1, tupleFirstChecks ) )
         , ( Fn.Tuple.second, ( 1, tupleSecondChecks ) )
         , ( Fn.Tuple.pair, ( 2, tuplePairChecks ) )
@@ -3038,6 +3042,7 @@ compositionIntoChecks =
         , ( Fn.Basics.not, ( 1, toggleCompositionChecks ) )
         , ( Fn.Basics.round, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
         , ( Fn.Basics.ceiling, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
+        , ( Fn.Basics.floor, ( 1, inversesCompositionCheck Fn.Basics.toFloat ) )
         , ( Fn.Basics.negate, ( 1, toggleCompositionChecks ) )
         , ( Fn.String.reverse, ( 1, stringReverseCompositionChecks ) )
         , ( Fn.String.fromList, ( 1, stringFromListCompositionChecks ) )

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -16,6 +16,7 @@ all =
         , alwaysTests
         , toFloatTests
         , roundTests
+        , ceilingTests
         , booleanTests
         , caseOfTests
         , booleanCaseOfTests
@@ -1206,6 +1207,109 @@ a = round << toFloat
                             { message = "Basics.toFloat, then Basics.round cancels each other out"
                             , details = [ "You can replace this composition by identity." ]
                             , under = "round"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
+        ]
+
+
+ceilingTests : Test
+ceilingTests =
+    describe "Basics.ceiling"
+        [ test "should not report okay function calls" <|
+            \() ->
+                """module A exposing (..)
+a = ceiling
+b = ceiling n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should simplify ceiling 1 to 1" <|
+            \() ->
+                """module A exposing (..)
+a = ceiling 1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "ceiling"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 1
+"""
+                        ]
+        , test "should simplify ceiling -1 to -1" <|
+            \() ->
+                """module A exposing (..)
+a = ceiling -1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "ceiling"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = -1
+"""
+                        ]
+        , test "should simplify ceiling 0x1 to 0x1" <|
+            \() ->
+                """module A exposing (..)
+a = ceiling 0x1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "ceiling"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 0x1
+"""
+                        ]
+        , test "should simplify ceiling <| toFloat <| n to n" <|
+            \() ->
+                """module A exposing (..)
+a = ceiling <| toFloat <| n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Basics.toFloat, then Basics.ceiling cancels each other out"
+                            , details = [ "You can replace this call by the argument given to Basics.toFloat." ]
+                            , under = "ceiling"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = n
+"""
+                        ]
+        , test "should simplify ceiling << toFloat to identity" <|
+            \() ->
+                """module A exposing (..)
+a = ceiling << toFloat
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Basics.toFloat, then Basics.ceiling cancels each other out"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "ceiling"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = identity

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -14,6 +14,7 @@ all =
         , lambdaReduceTests
         , identityTests
         , alwaysTests
+        , toFloatTests
         , booleanTests
         , caseOfTests
         , booleanCaseOfTests
@@ -1033,6 +1034,77 @@ a = always g << f
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = always g
+"""
+                        ]
+        ]
+
+
+toFloatTests : Test
+toFloatTests =
+    describe "Basics.toFloat"
+        [ test "should not report okay function calls" <|
+            \() ->
+                """module A exposing (..)
+a = toFloat
+b = toFloat n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should simplify toFloat 1 to 1" <|
+            \() ->
+                """module A exposing (..)
+a = toFloat 1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary toFloat on a literal number"
+                            , details =
+                                [ "A literal integers is considered as both an Int and a Float, there is therefore no need to explicitly convert it to a Float."
+                                , "You can replace this function call by the literal number."
+                                ]
+                            , under = "toFloat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 1
+"""
+                        ]
+        , test "should simplify toFloat -1 to -1" <|
+            \() ->
+                """module A exposing (..)
+a = toFloat -1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary toFloat on a literal number"
+                            , details =
+                                [ "A literal integers is considered as both an Int and a Float, there is therefore no need to explicitly convert it to a Float."
+                                , "You can replace this function call by the literal number."
+                                ]
+                            , under = "toFloat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = -1
+"""
+                        ]
+        , test "should simplify toFloat 0x1 to 0x1" <|
+            \() ->
+                """module A exposing (..)
+a = toFloat 0x1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary toFloat on a literal number"
+                            , details =
+                                [ "A literal integers is considered as both an Int and a Float, there is therefore no need to explicitly convert it to a Float."
+                                , "You can replace this function call by the literal number."
+                                ]
+                            , under = "toFloat"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 0x1
 """
                         ]
         ]

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -18,6 +18,7 @@ all =
         , roundTests
         , ceilingTests
         , floorTests
+        , truncateTests
         , booleanTests
         , caseOfTests
         , booleanCaseOfTests
@@ -1414,6 +1415,109 @@ a = floor << toFloat
                             { message = "Basics.toFloat, then Basics.floor cancels each other out"
                             , details = [ "You can replace this composition by identity." ]
                             , under = "floor"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
+        ]
+
+
+truncateTests : Test
+truncateTests =
+    describe "Basics.truncate"
+        [ test "should not report okay function calls" <|
+            \() ->
+                """module A exposing (..)
+a = truncate
+b = truncate n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should simplify truncate 1 to 1" <|
+            \() ->
+                """module A exposing (..)
+a = truncate 1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "truncate"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 1
+"""
+                        ]
+        , test "should simplify truncate -1 to -1" <|
+            \() ->
+                """module A exposing (..)
+a = truncate -1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "truncate"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = -1
+"""
+                        ]
+        , test "should simplify truncate 0x1 to 0x1" <|
+            \() ->
+                """module A exposing (..)
+a = truncate 0x1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "truncate"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 0x1
+"""
+                        ]
+        , test "should simplify truncate <| toFloat <| n to n" <|
+            \() ->
+                """module A exposing (..)
+a = truncate <| toFloat <| n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Basics.toFloat, then Basics.truncate cancels each other out"
+                            , details = [ "You can replace this call by the argument given to Basics.toFloat." ]
+                            , under = "truncate"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = n
+"""
+                        ]
+        , test "should simplify truncate << toFloat to identity" <|
+            \() ->
+                """module A exposing (..)
+a = truncate << toFloat
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Basics.toFloat, then Basics.truncate cancels each other out"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "truncate"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = identity

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1064,7 +1064,7 @@ a = toFloat 1
                         [ Review.Test.error
                             { message = "Unnecessary toFloat on a literal number"
                             , details =
-                                [ "A literal integers is considered as both an Int and a Float, there is therefore no need to explicitly convert it to a Float."
+                                [ "A literal integer is considered a number which means it can be used as both an Int and a Float and there is no need to explicitly convert it to a Float."
                                 , "You can replace this function call by the literal number."
                                 ]
                             , under = "toFloat"
@@ -1083,7 +1083,7 @@ a = toFloat -1
                         [ Review.Test.error
                             { message = "Unnecessary toFloat on a literal number"
                             , details =
-                                [ "A literal integers is considered as both an Int and a Float, there is therefore no need to explicitly convert it to a Float."
+                                [ "A literal integer is considered a number which means it can be used as both an Int and a Float and there is no need to explicitly convert it to a Float."
                                 , "You can replace this function call by the literal number."
                                 ]
                             , under = "toFloat"
@@ -1102,7 +1102,7 @@ a = toFloat 0x1
                         [ Review.Test.error
                             { message = "Unnecessary toFloat on a literal number"
                             , details =
-                                [ "A literal integers is considered as both an Int and a Float, there is therefore no need to explicitly convert it to a Float."
+                                [ "A literal integer is considered a number which means it can be used as both an Int and a Float and there is no need to explicitly convert it to a Float."
                                 , "You can replace this function call by the literal number."
                                 ]
                             , under = "toFloat"

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -17,6 +17,7 @@ all =
         , toFloatTests
         , roundTests
         , ceilingTests
+        , floorTests
         , booleanTests
         , caseOfTests
         , booleanCaseOfTests
@@ -1310,6 +1311,109 @@ a = ceiling << toFloat
                             { message = "Basics.toFloat, then Basics.ceiling cancels each other out"
                             , details = [ "You can replace this composition by identity." ]
                             , under = "ceiling"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
+        ]
+
+
+floorTests : Test
+floorTests =
+    describe "Basics.floor"
+        [ test "should not report okay function calls" <|
+            \() ->
+                """module A exposing (..)
+a = floor
+b = floor n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should simplify floor 1 to 1" <|
+            \() ->
+                """module A exposing (..)
+a = floor 1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "floor"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 1
+"""
+                        ]
+        , test "should simplify floor -1 to -1" <|
+            \() ->
+                """module A exposing (..)
+a = floor -1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "floor"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = -1
+"""
+                        ]
+        , test "should simplify floor 0x1 to 0x1" <|
+            \() ->
+                """module A exposing (..)
+a = floor 0x1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary integer conversion on a literal integer"
+                            , details =
+                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                , "You can replace this function call by the literal integer."
+                                ]
+                            , under = "floor"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 0x1
+"""
+                        ]
+        , test "should simplify floor <| toFloat <| n to n" <|
+            \() ->
+                """module A exposing (..)
+a = floor <| toFloat <| n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Basics.toFloat, then Basics.floor cancels each other out"
+                            , details = [ "You can replace this call by the argument given to Basics.toFloat." ]
+                            , under = "floor"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = n
+"""
+                        ]
+        , test "should simplify floor << toFloat to identity" <|
+            \() ->
+                """module A exposing (..)
+a = floor << toFloat
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Basics.toFloat, then Basics.floor cancels each other out"
+                            , details = [ "You can replace this composition by identity." ]
+                            , under = "floor"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = identity

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1142,7 +1142,7 @@ a = round 1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "round"
@@ -1161,7 +1161,7 @@ a = round -1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "round"
@@ -1180,7 +1180,7 @@ a = round 0x1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "round"
@@ -1245,7 +1245,7 @@ a = ceiling 1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "ceiling"
@@ -1264,7 +1264,7 @@ a = ceiling -1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "ceiling"
@@ -1283,7 +1283,7 @@ a = ceiling 0x1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "ceiling"
@@ -1348,7 +1348,7 @@ a = floor 1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "floor"
@@ -1367,7 +1367,7 @@ a = floor -1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "floor"
@@ -1386,7 +1386,7 @@ a = floor 0x1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "floor"
@@ -1451,7 +1451,7 @@ a = truncate 1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "truncate"
@@ -1470,7 +1470,7 @@ a = truncate -1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "truncate"
@@ -1489,7 +1489,7 @@ a = truncate 0x1
                         [ Review.Test.error
                             { message = "Unnecessary integer conversion on a literal integer"
                             , details =
-                                [ "Literal integers are already considered to be integers and it is therefore not necessary to convert them further."
+                                [ "A literal integer is already considered to be an Int which means converting it further is not necessary."
                                 , "You can replace this function call by the literal integer."
                                 ]
                             , under = "truncate"

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -1111,6 +1111,13 @@ a = toFloat 0x1
 a = 0x1
 """
                         ]
+        , test "should not report toFloat 1.2" <|
+            \() ->
+                """module A exposing (..)
+a = toFloat 1.2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
         ]
 
 


### PR DESCRIPTION
Fixes #259

- `toFloat 1` -> `1`
- `round 1` -> `1`
- `ceiling 1` -> `1`
- `floor 1` -> `1`
- `truncate 1` -> `1`

Compositions of these functions:
- `round << toFloat` -> `identity`
- `ceiling << toFloat` -> `identity`
- `floor << toFloat` -> `identity`
- `truncate << toFloat` -> `identity`