### PR TITLE
Rework Indexable, Collection, FromList properties

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9271,9 +9271,9 @@ dictDetermineSize resources =
                     case listGetElements resources fromListCall.firstArg of
                         Just listElements ->
                             if listElements.allKnown then
-                                case traverse getComparableExpressionInTupleFirst listElements.known of
-                                    Just comparableExpressions ->
-                                        comparableExpressions |> unique |> List.length |> Exactly |> Just
+                                case traverse (getTupleWithComparableFirst resources.lookupTable) listElements.known of
+                                    Just comparableKeyExpressions ->
+                                        comparableKeyExpressions |> uniqueBy .comparableFirst |> List.length |> Exactly |> Just
 
                                     Nothing ->
                                         case listElements.known of
@@ -12141,16 +12141,6 @@ sameInAllBranches getSpecific baseExpressionNode =
 
                 _ ->
                     Undetermined
-
-
-getComparableExpressionInTupleFirst : Node Expression -> Maybe (List Expression)
-getComparableExpressionInTupleFirst expressionNode =
-    case AstHelpers.getTuple2Literal expressionNode of
-        Just tuple ->
-            getComparableExpression tuple.first
-
-        Nothing ->
-            Nothing
 
 
 getComparableExpression : Node Expression -> Maybe (List Expression)

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5710,10 +5710,6 @@ knownMemberChecks collection checkInfo =
                             needleArg =
                                 checkInfo.firstArg
 
-                            needleRange : Range
-                            needleRange =
-                                Node.range needleArg
-
                             needleArgNormalized : Node Expression
                             needleArgNormalized =
                                 Normalize.normalize checkInfo needleArg

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8247,11 +8247,14 @@ type alias WrapperProperties otherProperties =
 -}
 type alias ConstructibleFromListProperties otherProperties =
     { otherProperties
-        | fromList :
-            { description : String
-            , getList : ModuleNameLookupTable -> Node Expression -> Maybe (Node Expression)
-            }
+        | fromList : ConstructionFromListProperties
         , unionLeftElementsStayOnTheLeft : Bool
+    }
+
+
+type alias ConstructionFromListProperties =
+    { description : String
+    , getList : ModuleNameLookupTable -> Node Expression -> Maybe (Node Expression)
     }
 
 
@@ -8817,11 +8820,15 @@ listCollection =
         }
     , wrap = listSingletonConstruct
     , mapFn = Fn.List.map
-    , fromList =
-        { description = "list literal"
-        , getList = \_ listExpr -> Just listExpr
-        }
+    , fromList = listFromListProperties
     , unionLeftElementsStayOnTheLeft = True
+    }
+
+
+listFromListProperties : ConstructionFromListProperties
+listFromListProperties =
+    { description = "list literal"
+    , getList = \_ listExpr -> Just listExpr
     }
 
 
@@ -8903,13 +8910,17 @@ stringCollection =
         , get = stringGetElements
         }
     , wrap = singleCharConstruct
-    , fromList =
-        { description = "String.fromList call"
-        , getList =
-            \lookupTable expr ->
-                AstHelpers.getSpecificFnCall Fn.String.fromList lookupTable expr |> Maybe.map .firstArg
-        }
+    , fromList = stringFromListProperties
     , unionLeftElementsStayOnTheLeft = True
+    }
+
+
+stringFromListProperties : ConstructionFromListProperties
+stringFromListProperties =
+    { description = "String.fromList call"
+    , getList =
+        \lookupTable expr ->
+            AstHelpers.getSpecificFnCall Fn.String.fromList lookupTable expr |> Maybe.map .firstArg
     }
 
 
@@ -9007,13 +9018,17 @@ arrayCollection =
         , determineCount = arrayDetermineLength
         , get = arrayGetElements
         }
-    , fromList =
-        { description = "Array.fromList call"
-        , getList =
-            \lookupTable expr ->
-                AstHelpers.getSpecificFnCall Fn.Array.fromList lookupTable expr |> Maybe.map .firstArg
-        }
+    , fromList = arrayFromListProperties
     , unionLeftElementsStayOnTheLeft = True
+    }
+
+
+arrayFromListProperties : ConstructionFromListProperties
+arrayFromListProperties =
+    { description = "Array.fromList call"
+    , getList =
+        \lookupTable expr ->
+            AstHelpers.getSpecificFnCall Fn.Array.fromList lookupTable expr |> Maybe.map .firstArg
     }
 
 
@@ -9099,13 +9114,17 @@ setCollection =
         , get = setGetElements
         }
     , wrap = setSingletonConstruct
-    , fromList =
-        { description = "Set.fromList call"
-        , getList =
-            \lookupTable expr ->
-                AstHelpers.getSpecificFnCall Fn.Set.fromList lookupTable expr |> Maybe.map .firstArg
-        }
+    , fromList = setFromListProperties
     , unionLeftElementsStayOnTheLeft = True
+    }
+
+
+setFromListProperties : ConstructionFromListProperties
+setFromListProperties =
+    { description = "Set.fromList call"
+    , getList =
+        \lookupTable expr ->
+            AstHelpers.getSpecificFnCall Fn.Set.fromList lookupTable expr |> Maybe.map .firstArg
     }
 
 
@@ -9233,13 +9252,17 @@ dictCollection =
         , determineCount = dictDetermineSize
         , get = dictGetValues
         }
-    , fromList =
-        { description = "Dict.fromList call"
-        , getList =
-            \lookupTable expr ->
-                AstHelpers.getSpecificFnCall Fn.Dict.fromList lookupTable expr |> Maybe.map .firstArg
-        }
+    , fromList = dictFromListProperties
     , unionLeftElementsStayOnTheLeft = False
+    }
+
+
+dictFromListProperties : ConstructionFromListProperties
+dictFromListProperties =
+    { description = "Dict.fromList call"
+    , getList =
+        \lookupTable expr ->
+            AstHelpers.getSpecificFnCall Fn.Dict.fromList lookupTable expr |> Maybe.map .firstArg
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8637,17 +8637,21 @@ maybeWithJustAsWrap =
             \resources ->
                 qualifiedToString (qualify Fn.Maybe.nothingVariant resources)
         }
-    , wrap =
-        { description = A "just maybe"
-        , fn = Fn.Maybe.justVariant
-        , getValue =
-            \lookupTable expr ->
-                Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant lookupTable expr)
-        , is =
-            \res expr ->
-                isJust (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant res.lookupTable expr)
-        }
+    , wrap = maybeJustConstructProperties
     , mapFn = Fn.Maybe.map
+    }
+
+
+maybeJustConstructProperties : ConstructWithOneArgProperties
+maybeJustConstructProperties =
+    { description = A "just maybe"
+    , fn = Fn.Maybe.justVariant
+    , getValue =
+        \lookupTable expr ->
+            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant lookupTable expr)
+    , is =
+        \res expr ->
+            isJust (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant res.lookupTable expr)
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9008,15 +9008,7 @@ stringGetElements resources =
 arrayCollection : TypeProperties (CollectionProperties (ConstructibleFromListProperties (EmptiableProperties ConstantProperties {})))
 arrayCollection =
     { represents = "array"
-    , empty =
-        { description = Constant (qualifiedToString Fn.Array.empty)
-        , is =
-            \res expr ->
-                isJust (AstHelpers.getSpecificValueOrFn Fn.Array.empty res.lookupTable expr)
-        , asString =
-            \resources ->
-                qualifiedToString (qualify Fn.Array.empty resources)
-        }
+    , empty = arrayEmptyConstantProperties
     , elements =
         { countDescription = "length"
         , determineCount = arrayDetermineLength
@@ -9024,6 +9016,18 @@ arrayCollection =
         }
     , fromList = arrayFromListProperties
     , unionLeftElementsStayOnTheLeft = True
+    }
+
+
+arrayEmptyConstantProperties : ConstantProperties
+arrayEmptyConstantProperties =
+    { description = Constant (qualifiedToString Fn.Array.empty)
+    , is =
+        \res expr ->
+            isJust (AstHelpers.getSpecificValueOrFn Fn.Array.empty res.lookupTable expr)
+    , asString =
+        \resources ->
+            qualifiedToString (qualify Fn.Array.empty resources)
     }
 
 
@@ -9103,15 +9107,7 @@ arrayDetermineLength resources =
 setCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (ConstructibleFromListProperties {}))))
 setCollection =
     { represents = "set"
-    , empty =
-        { description = Constant (qualifiedToString Fn.Set.empty)
-        , is =
-            \res expr ->
-                isJust (AstHelpers.getSpecificValueOrFn Fn.Set.empty res.lookupTable expr)
-        , asString =
-            \resources ->
-                qualifiedToString (qualify Fn.Set.empty resources)
-        }
+    , empty = setEmptyConstantProperties
     , elements =
         { countDescription = "size"
         , determineCount = setDetermineSize
@@ -9120,6 +9116,18 @@ setCollection =
     , wrap = setSingletonConstruct
     , fromList = setFromListProperties
     , unionLeftElementsStayOnTheLeft = True
+    }
+
+
+setEmptyConstantProperties : ConstantProperties
+setEmptyConstantProperties =
+    { description = Constant (qualifiedToString Fn.Set.empty)
+    , is =
+        \res expr ->
+            isJust (AstHelpers.getSpecificValueOrFn Fn.Set.empty res.lookupTable expr)
+    , asString =
+        \resources ->
+            qualifiedToString (qualify Fn.Set.empty resources)
     }
 
 
@@ -9242,15 +9250,7 @@ setDetermineSize resources =
 dictCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (ConstructibleFromListProperties {})))
 dictCollection =
     { represents = "dict"
-    , empty =
-        { description = Constant (qualifiedToString Fn.Dict.empty)
-        , is =
-            \res expr ->
-                isJust (AstHelpers.getSpecificValueOrFn Fn.Dict.empty res.lookupTable expr)
-        , asString =
-            \resources ->
-                qualifiedToString (qualify Fn.Dict.empty resources)
-        }
+    , empty = dictEmptyConstantProperties
     , elements =
         { countDescription = "size"
         , determineCount = dictDetermineSize
@@ -9258,6 +9258,18 @@ dictCollection =
         }
     , fromList = dictFromListProperties
     , unionLeftElementsStayOnTheLeft = False
+    }
+
+
+dictEmptyConstantProperties : ConstantProperties
+dictEmptyConstantProperties =
+    { description = Constant (qualifiedToString Fn.Dict.empty)
+    , is =
+        \res expr ->
+            isJust (AstHelpers.getSpecificValueOrFn Fn.Dict.empty res.lookupTable expr)
+    , asString =
+        \resources ->
+            qualifiedToString (qualify Fn.Dict.empty resources)
     }
 
 
@@ -9393,32 +9405,38 @@ getTupleWithComparableFirst lookupTable expressionNode =
 cmdCollection : TypeProperties (EmptiableProperties ConstantProperties {})
 cmdCollection =
     { represents = "command"
-    , empty =
-        { description =
-            Constant "Cmd.none"
-        , is =
-            \res expr ->
-                isJust (AstHelpers.getSpecificValueOrFn Fn.Platform.Cmd.none res.lookupTable expr)
-        , asString =
-            \resources ->
-                qualifiedToString (qualify Fn.Platform.Cmd.none resources)
-        }
+    , empty = cmdNoneConstantProperties
+    }
+
+
+cmdNoneConstantProperties : ConstantProperties
+cmdNoneConstantProperties =
+    { description = Constant "Cmd.none"
+    , is =
+        \res expr ->
+            isJust (AstHelpers.getSpecificValueOrFn Fn.Platform.Cmd.none res.lookupTable expr)
+    , asString =
+        \resources ->
+            qualifiedToString (qualify Fn.Platform.Cmd.none resources)
     }
 
 
 subCollection : TypeProperties (EmptiableProperties ConstantProperties {})
 subCollection =
     { represents = "subscription"
-    , empty =
-        { description =
-            Constant "Sub.none"
-        , is =
-            \res expr ->
-                isJust (AstHelpers.getSpecificValueOrFn Fn.Platform.Sub.none res.lookupTable expr)
-        , asString =
-            \resources ->
-                qualifiedToString (qualify Fn.Platform.Sub.none resources)
-        }
+    , empty = subNoneConstantProperties
+    }
+
+
+subNoneConstantProperties : ConstantProperties
+subNoneConstantProperties =
+    { description = Constant "Sub.none"
+    , is =
+        \res expr ->
+            isJust (AstHelpers.getSpecificValueOrFn Fn.Platform.Sub.none res.lookupTable expr)
+    , asString =
+        \resources ->
+            qualifiedToString (qualify Fn.Platform.Sub.none resources)
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5134,7 +5134,10 @@ listConcatCompositionChecks =
 
 callOnFromListWithIrrelevantEmptyElement :
     String
-    -> ( TypeProperties (FromListProperties otherProperties), EmptiableProperties (TypeSubsetProperties empty) elementOtherProperties )
+    ->
+        ( TypeProperties (ConstructibleFromListProperties otherProperties)
+        , EmptiableProperties (TypeSubsetProperties empty) elementOtherProperties
+        )
     -> CheckInfo
     -> Maybe (Error {})
 callOnFromListWithIrrelevantEmptyElement situation ( constructibleFromList, emptiableElement ) checkInfo =
@@ -6103,7 +6106,7 @@ emptiableAllChecks emptiable =
         ]
 
 
-collectionAllChecks : TypeProperties (CollectionProperties (FromListProperties otherProperties)) -> CheckInfo -> Maybe (Error {})
+collectionAllChecks : TypeProperties (CollectionProperties (ConstructibleFromListProperties otherProperties)) -> CheckInfo -> Maybe (Error {})
 collectionAllChecks collection =
     firstThatConstructsJust
         [ \checkInfo ->
@@ -6209,7 +6212,7 @@ emptiableAnyChecks emptiable =
         ]
 
 
-collectionAnyChecks : TypeProperties (CollectionProperties (FromListProperties otherProperties)) -> CheckInfo -> Maybe (Error {})
+collectionAnyChecks : TypeProperties (CollectionProperties (ConstructibleFromListProperties otherProperties)) -> CheckInfo -> Maybe (Error {})
 collectionAnyChecks collection =
     firstThatConstructsJust
         [ \checkInfo ->
@@ -8246,7 +8249,7 @@ type alias WrapperProperties otherProperties =
 
 {-| Properties of a type that can be constructed from a list, like String with String.fromList.
 -}
-type alias FromListProperties otherProperties =
+type alias ConstructibleFromListProperties otherProperties =
     { otherProperties
         | fromList :
             { description : String
@@ -8398,9 +8401,9 @@ getAbsorbingExpressionNode absorbable inferResources expressionNode =
         Nothing
 
 
-fromListGetLiteral : FromListProperties otherProperties -> ModuleNameLookupTable -> Node Expression -> Maybe { range : Range, elements : List (Node Expression) }
-fromListGetLiteral fromListProperties lookupTable expressionNode =
-    case fromListProperties.fromList.getList lookupTable expressionNode of
+fromListGetLiteral : ConstructibleFromListProperties otherProperties -> ModuleNameLookupTable -> Node Expression -> Maybe { range : Range, elements : List (Node Expression) }
+fromListGetLiteral constructibleFromList lookupTable expressionNode =
+    case constructibleFromList.fromList.getList lookupTable expressionNode of
         Just listExpressionNode ->
             case AstHelpers.removeParens listExpressionNode of
                 Node listLiteralRange (Expression.ListExpr listElements) ->
@@ -8807,7 +8810,7 @@ jsonDecoderFailingConstruct =
     }
 
 
-listCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (FromListProperties { mapFn : ( ModuleName, String ) }))))
+listCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (ConstructibleFromListProperties { mapFn : ( ModuleName, String ) }))))
 listCollection =
     { represents = "list"
     , empty = listEmptyConstant
@@ -8894,7 +8897,7 @@ listDetermineLength resources =
         ]
 
 
-stringCollection : TypeProperties (CollectionProperties (WrapperProperties (EmptiableProperties ConstantProperties (FromListProperties {}))))
+stringCollection : TypeProperties (CollectionProperties (WrapperProperties (EmptiableProperties ConstantProperties (ConstructibleFromListProperties {}))))
 stringCollection =
     { represents = "string"
     , empty = stringEmptyConstant
@@ -8991,7 +8994,7 @@ stringGetElements resources =
         ]
 
 
-arrayCollection : TypeProperties (CollectionProperties (FromListProperties (EmptiableProperties ConstantProperties {})))
+arrayCollection : TypeProperties (CollectionProperties (ConstructibleFromListProperties (EmptiableProperties ConstantProperties {})))
 arrayCollection =
     { represents = "array"
     , empty =
@@ -9082,7 +9085,7 @@ arrayDetermineLength resources =
         ]
 
 
-setCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (FromListProperties {}))))
+setCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (ConstructibleFromListProperties {}))))
 setCollection =
     { represents = "set"
     , empty =
@@ -9217,7 +9220,7 @@ setDetermineSize resources =
         ]
 
 
-dictCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (FromListProperties {})))
+dictCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (ConstructibleFromListProperties {})))
 dictCollection =
     { represents = "dict"
     , empty =
@@ -10636,7 +10639,7 @@ collectionDiffChecks collection =
         ]
 
 
-collectionUnionChecks : TypeProperties (CollectionProperties (FromListProperties (EmptiableProperties (TypeSubsetProperties empty) otherProperties))) -> CheckInfo -> Maybe (Error {})
+collectionUnionChecks : TypeProperties (CollectionProperties (ConstructibleFromListProperties (EmptiableProperties (TypeSubsetProperties empty) otherProperties))) -> CheckInfo -> Maybe (Error {})
 collectionUnionChecks collection =
     firstThatConstructsJust
         [ \checkInfo ->
@@ -10684,7 +10687,7 @@ collectionUnionWithLiteralsChecks :
     , operationRange : Range
     , operation : String
     }
-    -> CollectionProperties (FromListProperties otherProperties)
+    -> CollectionProperties (ConstructibleFromListProperties otherProperties)
     ->
         { checkInfo
             | lookupTable : ModuleNameLookupTable

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -5,7 +5,7 @@ module Simplify.AstHelpers exposing
     , isIdentity, getAlwaysResult, isSpecificUnappliedBinaryOperation
     , isTupleFirstAccess, isTupleSecondAccess
     , getOrder, getSpecificBool, getBool, getBoolPattern, getUncomputedNumberValue
-    , getCollapsedCons, getListLiteral, getListLiteralRange, getListSingleton
+    , getCollapsedCons, getListLiteral, getListSingleton
     , getTuple2, getTuple2Literal
     , boolToString, orderToString, emptyStringAsString
     , moduleNameFromString, qualifiedName, qualifiedModuleName, qualifiedToString
@@ -32,7 +32,7 @@ module Simplify.AstHelpers exposing
 @docs isIdentity, getAlwaysResult, isSpecificUnappliedBinaryOperation
 @docs isTupleFirstAccess, isTupleSecondAccess
 @docs getOrder, getSpecificBool, getBool, getBoolPattern, getUncomputedNumberValue
-@docs getCollapsedCons, getListLiteral, getListLiteralRange, getListSingleton
+@docs getCollapsedCons, getListLiteral, getListSingleton
 @docs getTuple2, getTuple2Literal
 
 
@@ -642,16 +642,6 @@ getListLiteral expressionNode =
     case removeParens expressionNode of
         Node _ (Expression.ListExpr list) ->
             Just list
-
-        _ ->
-            Nothing
-
-
-getListLiteralRange : Node Expression -> Maybe Range
-getListLiteralRange expressionNode =
-    case removeParens expressionNode of
-        Node range (Expression.ListExpr _) ->
-            Just range
 
         _ ->
             Nothing

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -13900,6 +13900,22 @@ a = List.all identity [ b, False, c ]
 a = False
 """
                         ]
+        , test "should replace List.all identity (a :: False :: bs) by False" <|
+            \() ->
+                """module A exposing (..)
+a = List.all identity (b :: False :: cs)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.all with an identity function on a list with False will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.all"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = False
+"""
+                        ]
         , test "should replace List.all not [ a, False, b ] by List.all not [ a, b ]" <|
             \() ->
                 """module A exposing (..)

--- a/tests/SimplifyTest.elm
+++ b/tests/SimplifyTest.elm
@@ -9582,8 +9582,8 @@ a = List.member c (List.singleton b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.member on an list with a single element is the same as directly checking for equality"
-                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            { message = "List.member on a singleton list is the same as directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the value inside the singleton list are equal." ]
                             , under = "List.member"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -9598,8 +9598,8 @@ a = List.member b (List.singleton b)
                     |> Review.Test.run ruleExpectingNaN
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.member on an list with a single element is the same as directly checking for equality"
-                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            { message = "List.member on a singleton list is the same as directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the value inside the singleton list are equal." ]
                             , under = "List.member"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -9630,8 +9630,8 @@ a = List.member c [ b ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.member on an list with a single element is the same as directly checking for equality"
-                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            { message = "List.member on a singleton list is the same as directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the value inside the singleton list are equal." ]
                             , under = "List.member"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -9646,8 +9646,8 @@ a = List.member c <| [ b ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.member on an list with a single element is the same as directly checking for equality"
-                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            { message = "List.member on a singleton list is the same as directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the value inside the singleton list are equal." ]
                             , under = "List.member"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -9662,8 +9662,8 @@ a = List.member c [ f b ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.member on an list with a single element is the same as directly checking for equality"
-                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            { message = "List.member on a singleton list is the same as directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the value inside the singleton list are equal." ]
                             , under = "List.member"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -9678,8 +9678,8 @@ a = [ b ] |> List.member c
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.member on an list with a single element is the same as directly checking for equality"
-                            , details = [ "You can replace this call by checking whether the member to find and the list element are equal." ]
+                            { message = "List.member on a singleton list is the same as directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the value inside the singleton list are equal." ]
                             , under = "List.member"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -18944,8 +18944,8 @@ a = Array.set 1 x (Array.fromList [ b, c, d ])
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.set will replace a known element in the Array.fromList call"
-                            , details = [ "You can move the replacement argument directly into the Array.fromList call." ]
+                            { message = "Array.set will replace a known element"
+                            , details = [ "You can directly replace the element at the given index in the array." ]
                             , under = "Array.set"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)


### PR DESCRIPTION
I'll apologize in advance for the first commit which one could say does multiple things at once. Sorry!
- Introduce property `elements.get` which can detect known elements, including information of whether some parts are unknown
  - allowed introducing generic checks for e.g. member
  - `onCollectionWithAbsorbingCheck` now also reports e.g. `List.all identity (a :: False :: bs)`, `callOnListWithAbsorbingElement` therefore became unnecessary
- `Indexable` was confusing. Does `literalElements` refer to the "fromList" construction method? I would expect no but some checks were relying on that behavior.
  - → remove in favor of `fromList.getList` and `elements.get`
- `FromListProperties` contained `unionLeftElementsStayOnTheLeft`. To me it does not seem like the right place. First, not every type that can be constructed from a list has a union function. Second, a type can have different union functions, e.g. `Array.append`, the pipe-friendly version `prependTo` and the pipe-friendly prepend function `appendTo`.
  - `leftElementsStayOnTheLeft` is now provided as an argument to the union checks
- Simplify `FromListProperties` to match any `fromList` call, not just on literals
- Refactor `-DetermineSize` functions
- Introduce separate declarations for the grouped properties of a type

(Unrelated note: I've added my personal todo list for simplify publically in https://github.com/lue-bird/elm-review-simplify/issues/1 which always contains all the refactorings I plan to do in the near future but have not yet formalized)