### PR TITLE
Add missing List.take .drop on [] to simplification list

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -783,6 +783,12 @@ Destructuring using case expressions
     List.drop 0 list
     --> list
 
+    List.take n []
+    --> []
+
+    List.drop n []
+    --> []
+
     List.reverse []
     --> []
 


### PR DESCRIPTION
This adds 

```
List.take n []
--> []
List.drop n []
--> []
```

to the documentation list.
I could not find them there, and I think they should be included (if i understand correctly).
But it is possible they are included by some general "on empty lists"-statement?

These are currently implemented, executed and in the test suite:
https://github.com/jfmengels/elm-review-simplify/blob/1180d1c1a795e645759b1d4abe12b565a4a686da/tests/SimplifyTest.elm#L15227

https://github.com/jfmengels/elm-review-simplify/blob/1180d1c1a795e645759b1d4abe12b565a4a686da/tests/SimplifyTest.elm#L15305
