### PR TITLE
More List.drop simplifications

### DIFF
--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -7190,6 +7190,54 @@ a = List.drop -1
 a = identity
 """
                         ]
+        , test "should replace [a, b, c] |> List.drop 2 by [c]" <|
+            \() ->
+                """module A exposing (..)
+a = [b, c, d] |> List.drop 2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.drop with a count less than the given list's length will remove these elements"
+                            , details = [ "You can remove the first 2 elements from the list literal." ]
+                            , under = "List.drop"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = [d]
+"""
+                        ]
+        , test "should replace List.singleton a |> List.drop 1 by []" <|
+            \() ->
+                """module A exposing (..)
+a = List.singleton b |> List.drop 1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.drop with a count greater than or equal to the given list's length will always result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.drop"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
+        , test "should replace [ a, b ] |> List.drop 2 by []" <|
+            \() ->
+                """module A exposing (..)
+a = [ b, c ] |> List.drop 2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.drop with a count greater than or equal to the given list's length will always result in []"
+                            , details = [ "You can replace this call by []." ]
+                            , under = "List.drop"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = []
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -7118,7 +7118,7 @@ a = List.drop 0 list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.drop 0 will always return the same given list"
+                            { message = "List.drop with count 0 will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.drop"
                             }
@@ -7134,7 +7134,7 @@ a = list |> List.drop 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.drop 0 will always return the same given list"
+                            { message = "List.drop with count 0 will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.drop"
                             }
@@ -7150,7 +7150,39 @@ a = List.drop 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.drop 0 will always return the same given list"
+                            { message = "List.drop with count 0 will always return the same given list"
+                            , details = [ "You can replace this call by identity." ]
+                            , under = "List.drop"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = identity
+"""
+                        ]
+        , test "should replace list |> List.drop -1 by list" <|
+            \() ->
+                """module A exposing (..)
+a = list |> List.drop -1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.drop with negative count will always return the same given list"
+                            , details = [ "You can replace this call by the list itself." ]
+                            , under = "List.drop"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = list
+"""
+                        ]
+        , test "should replace List.drop -1 by identity" <|
+            \() ->
+                """module A exposing (..)
+a = List.drop -1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.drop with negative count will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.drop"
                             }


### PR DESCRIPTION
Some simplifications from https://github.com/jfmengels/elm-review-simplify/issues/268 and more
```elm
List.drop -1 list
--> list

List.drop 3 [ a, b ] -- including List.singleton etc where we can determine the size
--> []

List.drop 2 [ a, b, c ]
--> [ c ]
```