### PR TITLE
WIP: cleanup (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@
 - `Array.toList Array.empty` to `[]`
 - `Array.toList (Array.repeat n a)` to `List.repeat n a`
 - `Array.toIndexedList Array.empty` to `[]`
+- `Array.slice n n array` to `Array.empty`
+- `Array.slice n 0 array` to `Array.empty`
+- `Array.slice a z Array.empty` to `Array.empty`
+- `Array.slice 2 1 array` to `Array.empty`
+- `Array.slice -1 -2 array` to `Array.empty`
 - `List.map Tuple.second (Array.toIndexedList array)` to `Array.toList array`
 - `Result.map f << Err` to `Err`
 - `Result.andThen f << Err` to `Err`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8358,20 +8358,8 @@ jsonDecodeAndThenCompositionChecks =
 
 
 oneOfChecks : CheckInfo -> Maybe (Error {})
-oneOfChecks checkInfo =
-    case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.firstArg of
-        Just listSingletonArg ->
-            Just
-                (Rule.errorWithFix
-                    { message = "Unnecessary oneOf"
-                    , details = [ "There is only a single element in the list of elements to try out." ]
-                    }
-                    checkInfo.fnRange
-                    (replaceBySubExpressionFix checkInfo.parentRange listSingletonArg.element)
-                )
-
-        Nothing ->
-            Nothing
+oneOfChecks =
+    callOnWrapReturnsItsValueCheck listCollection
 
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8819,7 +8819,7 @@ type alias ConstantProperties =
         { asString : QualifyResources {} -> String }
 
 
-{-| Create `ConstantProperties` for a value with a given full qualified name.
+{-| Create `ConstantProperties` for a value with a given fully qualified name.
 -}
 constantFnProperties : ( ModuleName, String ) -> ConstantProperties
 constantFnProperties fullyQualified =
@@ -8829,6 +8829,21 @@ constantFnProperties fullyQualified =
             isJust (AstHelpers.getSpecificValueOrFn fullyQualified res.lookupTable expr)
     , asString =
         \res -> qualifiedToString (qualify fullyQualified res)
+    }
+
+
+{-| Create `ConstructWithOneArgProperties` for a function call with a given fully qualified name with a given `Description`.
+-}
+fnCallConstructWithOneArgProperties : Description -> ( ModuleName, String ) -> ConstructWithOneArgProperties
+fnCallConstructWithOneArgProperties description fullyQualified =
+    { description = description
+    , fn = fullyQualified
+    , getValue =
+        \lookupTable expr ->
+            Maybe.map .firstArg (AstHelpers.getSpecificFnCall fullyQualified lookupTable expr)
+    , is =
+        \res expr ->
+            isJust (AstHelpers.getSpecificFnCall fullyQualified res.lookupTable expr)
     }
 
 
@@ -9086,15 +9101,7 @@ randomGeneratorWrapper =
 
 randomGeneratorConstantConstruct : ConstructWithOneArgProperties
 randomGeneratorConstantConstruct =
-    { description = A "constant generator"
-    , fn = Fn.Random.constant
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Random.constant lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Random.constant res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (A "constant generator") Fn.Random.constant
 
 
 maybeWithJustAsWrap : TypeProperties (EmptiableProperties ConstantProperties (WrapperProperties (MappableProperties {})))
@@ -9108,15 +9115,7 @@ maybeWithJustAsWrap =
 
 maybeJustConstructProperties : ConstructWithOneArgProperties
 maybeJustConstructProperties =
-    { description = A "just maybe"
-    , fn = Fn.Maybe.justVariant
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (A "just maybe") Fn.Maybe.justVariant
 
 
 resultWithOkAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
@@ -9130,28 +9129,12 @@ resultWithOkAsWrap =
 
 resultOkayConstruct : ConstructWithOneArgProperties
 resultOkayConstruct =
-    { description = An "okay result"
-    , fn = Fn.Result.okVariant
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Result.okVariant lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Result.okVariant res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (An "okay result") Fn.Result.okVariant
 
 
 resultErrorConstruct : ConstructWithOneArgProperties
 resultErrorConstruct =
-    { description = An "error"
-    , fn = Fn.Result.errVariant
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Result.errVariant lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Result.errVariant res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (An "error") Fn.Result.errVariant
 
 
 resultWithErrAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
@@ -9174,28 +9157,12 @@ taskWithSucceedAsWrap =
 
 taskSucceedingConstruct : ConstructWithOneArgProperties
 taskSucceedingConstruct =
-    { description = A "succeeding task"
-    , fn = Fn.Task.succeed
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Task.succeed lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Task.succeed res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (A "succeeding task") Fn.Task.succeed
 
 
 taskFailingConstruct : ConstructWithOneArgProperties
 taskFailingConstruct =
-    { description = A "failing task"
-    , fn = Fn.Task.fail
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Task.fail lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Task.fail res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (A "failing task") Fn.Task.fail
 
 
 taskWithFailAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
@@ -9218,28 +9185,12 @@ jsonDecoderWithSucceedAsWrap =
 
 jsonDecoderSucceedingConstruct : ConstructWithOneArgProperties
 jsonDecoderSucceedingConstruct =
-    { description = A "succeeding decoder"
-    , fn = Fn.Json.Decode.succeed
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Json.Decode.succeed lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Json.Decode.succeed res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (A "succeeding decoder") Fn.Json.Decode.succeed
 
 
 jsonDecoderFailingConstruct : ConstructWithOneArgProperties
 jsonDecoderFailingConstruct =
-    { description = A "failing decoder"
-    , fn = Fn.Json.Decode.fail
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Json.Decode.fail lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Json.Decode.fail res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (A "failing decoder") Fn.Json.Decode.fail
 
 
 listCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (ConstructibleFromListProperties (MappableProperties {})))))
@@ -9369,15 +9320,7 @@ stringEmptyConstant =
 
 singleCharConstruct : ConstructWithOneArgProperties
 singleCharConstruct =
-    { description = A "single-char string"
-    , fn = Fn.String.fromChar
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.String.fromChar lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.String.fromChar res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (A "single-char string") Fn.String.fromChar
 
 
 stringDetermineLength : Infer.Resources res -> Node Expression -> Maybe CollectionSize
@@ -9529,15 +9472,7 @@ setCollection =
 
 setSingletonConstruct : ConstructWithOneArgProperties
 setSingletonConstruct =
-    { description = A "singleton set"
-    , fn = Fn.Set.singleton
-    , getValue =
-        \lookupTable expr ->
-            Maybe.map .firstArg (AstHelpers.getSpecificFnCall Fn.Set.singleton lookupTable expr)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificFnCall Fn.Set.singleton res.lookupTable expr)
-    }
+    fnCallConstructWithOneArgProperties (A "singleton set") Fn.Set.singleton
 
 
 setGetElements : Infer.Resources a -> Node Expression -> Maybe { known : List (Node Expression), allKnown : Bool }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7153,24 +7153,18 @@ listSortWithChecks =
                         fixToIdentity : Error {}
                         fixToIdentity =
                             alwaysReturnsLastArgError
-                                (qualifiedToString checkInfo.fn ++ " (\\_ _ -> " ++ AstHelpers.orderToString order ++ ")")
+                                (qualifiedToString checkInfo.fn ++ " with a comparison that always returns " ++ AstHelpers.orderToString order)
                                 { represents = "list" }
                                 checkInfo
                     in
                     case order of
                         LT ->
                             Just
-                                (Rule.errorWithFix
-                                    { message = qualifiedToString checkInfo.fn ++ " (\\_ _ -> LT) is the same as " ++ qualifiedToString Fn.List.reverse
-                                    , details = [ "You can replace this call by " ++ qualifiedToString Fn.List.reverse ++ "." ]
+                                (operationWithFirstArgIsEquivalentToFnError
+                                    { firstArgDescription = "a comparison that always returns LT"
+                                    , replacementFn = Fn.List.reverse
                                     }
-                                    checkInfo.fnRange
-                                    [ Fix.replaceRangeBy
-                                        { start = checkInfo.fnRange.start
-                                        , end = (Node.range checkInfo.firstArg).end
-                                        }
-                                        (qualifiedToString (qualify Fn.List.reverse checkInfo))
-                                    ]
+                                    checkInfo
                                 )
 
                         EQ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2943,7 +2943,7 @@ functionCallChecks =
         , ( Fn.String.words, ( 1, stringWordsChecks ) )
         , ( Fn.String.lines, ( 1, stringLinesChecks ) )
         , ( Fn.String.reverse, ( 1, stringReverseChecks ) )
-        , ( Fn.String.slice, ( 3, stringSliceChecks ) )
+        , ( Fn.String.slice, ( 3, collectionSliceChecks stringCollection ) )
         , ( Fn.String.left, ( 2, stringLeftChecks ) )
         , ( Fn.String.right, ( 2, stringRightChecks ) )
         , ( Fn.String.append, ( 2, collectionUnionChecks { leftElementsStayOnTheLeft = True } stringCollection ) )
@@ -4794,10 +4794,10 @@ stringReverseCompositionChecks =
         ]
 
 
-stringSliceChecks : CheckInfo -> Maybe (Error {})
-stringSliceChecks =
+collectionSliceChecks : EmptiableProperties ConstantProperties otherProperties -> CheckInfo -> Maybe (Error {})
+collectionSliceChecks collection =
     firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck stringCollection
+        [ unnecessaryCallOnEmptyCheck collection
         , \checkInfo ->
             case secondArg checkInfo of
                 Just endArg ->
@@ -4805,8 +4805,8 @@ stringSliceChecks =
                         [ \() ->
                             if Normalize.areAllTheSame checkInfo checkInfo.firstArg [ endArg ] then
                                 Just
-                                    (alwaysResultsInUnparenthesizedConstantError "String.slice with equal start and end index"
-                                        { replacement = stringCollection.empty.asString }
+                                    (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with equal start and end index")
+                                        { replacement = collection.empty.asString }
                                         checkInfo
                                     )
 
@@ -4820,8 +4820,8 @@ stringSliceChecks =
                                             case endInt of
                                                 0 ->
                                                     Just
-                                                        (alwaysResultsInUnparenthesizedConstantError "String.slice with end index 0"
-                                                            { replacement = stringCollection.empty.asString }
+                                                        (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with end index 0")
+                                                            { replacement = collection.empty.asString }
                                                             checkInfo
                                                         )
 
@@ -4833,15 +4833,15 @@ stringSliceChecks =
                                                     if startInt > endInt then
                                                         if startInt >= 0 && endInt >= 0 then
                                                             Just
-                                                                (alwaysResultsInUnparenthesizedConstantError "String.slice with a start index greater than the end index"
-                                                                    { replacement = stringCollection.empty.asString }
+                                                                (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with a start index greater than the end index")
+                                                                    { replacement = collection.empty.asString }
                                                                     checkInfo
                                                                 )
 
                                                         else if startInt <= -1 && endInt <= -1 then
                                                             Just
-                                                                (alwaysResultsInUnparenthesizedConstantError "String.slice with a negative start index closer to the right than the negative end index"
-                                                                    { replacement = stringCollection.empty.asString }
+                                                                (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with a negative start index closer to the right than the negative end index")
+                                                                    { replacement = collection.empty.asString }
                                                                     checkInfo
                                                                 )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8110,19 +8110,19 @@ sequenceOnWrappedIsEquivalentToMapWrapOnValue :
     ( WrapperProperties wrapperOtherProperties, WrapperProperties { elementOtherProperties | mapFn : ( ModuleName, String ) } )
     -> CheckInfo
     -> Maybe (Error {})
-sequenceOnWrappedIsEquivalentToMapWrapOnValue ( collection, elementWrapper ) checkInfo =
-    case collection.wrap.getValue checkInfo.lookupTable checkInfo.firstArg of
+sequenceOnWrappedIsEquivalentToMapWrapOnValue ( wrapper, elementWrapper ) checkInfo =
+    case wrapper.wrap.getValue checkInfo.lookupTable checkInfo.firstArg of
         Just wrappedValue ->
             let
                 replacement : QualifyResources a -> String
                 replacement qualifyResources =
                     qualifiedToString (qualify elementWrapper.mapFn qualifyResources)
                         ++ " "
-                        ++ qualifiedToString (qualify Fn.List.singleton qualifyResources)
+                        ++ qualifiedToString (qualify wrapper.wrap.fn qualifyResources)
             in
             Just
                 (Rule.errorWithFix
-                    { message = qualifiedToString checkInfo.fn ++ " on " ++ descriptionForIndefinite elementWrapper.wrap.description ++ " is the same as " ++ replacement defaultQualifyResources ++ " on the value inside"
+                    { message = qualifiedToString checkInfo.fn ++ " on " ++ descriptionForIndefinite wrapper.wrap.description ++ " is the same as " ++ replacement defaultQualifyResources ++ " on the value inside"
                     , details = [ "You can replace this call by " ++ replacement defaultQualifyResources ++ " on the value inside the singleton list." ]
                     }
                     checkInfo.fnRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10034,6 +10034,10 @@ getValueWithNodeRange getValue expressionNode =
 
     mapFlat f (wrap a) --> f a
 
+    mapFlat wrap wrapper --> wrapper
+
+    mapFlat (\a -> wrap b) wrapper --> map (\a -> b) wrapper
+
 So for example
 
     List.concatMap f [ a ] --> f a

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10030,6 +10030,17 @@ getValueWithNodeRange getValue expressionNode =
         (getValue expressionNode)
 
 
+{-| `mapFlat f` on a wrapped value is equivalent to `f`
+
+    mapFlat f (wrap a) --> f a
+
+So for example
+
+    List.concatMap f [ a ] --> f a
+
+Use in together with `wrapperMapFlatCompositionChecks`.
+
+-}
 wrapperMapFlatChecks :
     TypeProperties (WrapperProperties (MappableProperties otherProperties))
     -> CheckInfo

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8872,6 +8872,13 @@ getAbsorbingExpressionNode absorbable inferResources expressionNode =
     else
         Nothing
 
+getValueWithNodeRange :
+    (Node Expression -> Maybe (Node Expression))
+    -> Node Expression
+    -> Maybe { value : Node Expression, nodeRange : Range }
+getValueWithNodeRange getValue expressionNode =
+    Maybe.map (\value -> { value = value, nodeRange = Node.range expressionNode })
+        (getValue expressionNode)
 
 fromListGetLiteral : ConstructibleFromListProperties otherProperties -> ModuleNameLookupTable -> Node Expression -> Maybe { range : Range, elements : List (Node Expression) }
 fromListGetLiteral constructibleFromList lookupTable expressionNode =
@@ -10021,13 +10028,7 @@ emptiableMapFlatChecks emptiable =
         ]
 
 
-getValueWithNodeRange :
-    (Node Expression -> Maybe (Node Expression))
-    -> Node Expression
-    -> Maybe { value : Node Expression, nodeRange : Range }
-getValueWithNodeRange getValue expressionNode =
-    Maybe.map (\value -> { value = value, nodeRange = Node.range expressionNode })
-        (getValue expressionNode)
+
 
 
 {-| `mapFlat f` on a wrapped value is equivalent to `f`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7934,35 +7934,53 @@ listSequenceOrFirstEmptyChecks :
 listSequenceOrFirstEmptyChecks emptiable =
     firstThatConstructsJust
         [ sequenceOnCollectionWithKnownEmptyElementCheck ( listCollection, emptiable )
-        , \checkInfo ->
-            case AstHelpers.getListLiteral checkInfo.firstArg of
-                Just list ->
-                    case findMapNeighboring (\el -> getEmpty checkInfo emptiable el) list of
-                        Just emptyAndNeighbors ->
-                            case emptyAndNeighbors.after of
-                                Just _ ->
-                                    Just
-                                        (Rule.errorWithFix
-                                            { message = qualifiedToString checkInfo.fn ++ " on a list containing " ++ descriptionForIndefinite emptiable.empty.description ++ " early will ignore later elements"
-                                            , details = [ "You can remove all list elements after " ++ descriptionForDefinite "the first" emptiable.empty.description ++ "." ]
-                                            }
-                                            checkInfo.fnRange
-                                            [ Fix.removeRange
-                                                { start = emptyAndNeighbors.found.range.end
-                                                , end = endWithoutBoundary (Node.range checkInfo.firstArg)
-                                                }
-                                            ]
-                                        )
+        , sequenceOnFromListWithEmptyIgnoresLaterElementsCheck ( listCollection, emptiable )
+        ]
 
-                                Nothing ->
-                                    Nothing
+
+{-| The sequence check
+
+    sequence (construction fromList [ a, empty, b ])
+    --> sequence (construction fromList [ a, empty ])
+
+So for example
+
+    Task.sequence [ aTask, Task.fail x, bTask ]
+    --> Task.sequence [ aTask, Task.fail x ]
+
+-}
+sequenceOnFromListWithEmptyIgnoresLaterElementsCheck :
+    ( TypeProperties (ConstructibleFromListProperties constructibleFromListOtherProperties), EmptiableProperties (TypeSubsetProperties empty) elementOtherProperties )
+    -> CheckInfo
+    -> Maybe (Error {})
+sequenceOnFromListWithEmptyIgnoresLaterElementsCheck ( constructibleFromList, elementEmptiable ) checkInfo =
+    case fromListGetLiteral constructibleFromList checkInfo.lookupTable checkInfo.firstArg of
+        Just listLiteral ->
+            case findMapNeighboring (\el -> getEmpty checkInfo elementEmptiable el) listLiteral.elements of
+                Just emptyAndNeighbors ->
+                    case emptyAndNeighbors.after of
+                        Just _ ->
+                            Just
+                                (Rule.errorWithFix
+                                    { message = qualifiedToString checkInfo.fn ++ " on a " ++ constructibleFromList.represents ++ " containing " ++ descriptionForIndefinite elementEmptiable.empty.description ++ " early will ignore later elements"
+                                    , details = [ "You can remove all " ++ constructibleFromList.represents ++ " elements after " ++ descriptionForDefinite "the first" elementEmptiable.empty.description ++ "." ]
+                                    }
+                                    checkInfo.fnRange
+                                    [ Fix.removeRange
+                                        { start = emptyAndNeighbors.found.range.end
+                                        , end = endWithoutBoundary listLiteral.range
+                                        }
+                                    ]
+                                )
 
                         Nothing ->
                             Nothing
 
                 Nothing ->
                     Nothing
-        ]
+
+        Nothing ->
+            Nothing
 
 
 {-| The sequence check

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6552,32 +6552,16 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
 
 mapToOperationWithIdentityCanBeCombinedToOperationChecks : MappableProperties otherProperties -> CheckInfo -> Maybe (Error {})
 mapToOperationWithIdentityCanBeCombinedToOperationChecks mappable checkInfo =
-    case secondArg checkInfo of
-        Just mappableArg ->
-            if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
-                case AstHelpers.getSpecificFnCall mappable.mapFn checkInfo.lookupTable mappableArg of
-                    Just mapCall ->
-                        Just
-                            (Rule.errorWithFix
-                                { message = qualifiedToString mappable.mapFn ++ " and " ++ qualifiedToString checkInfo.fn ++ " identity can be combined using " ++ qualifiedToString checkInfo.fn
-                                , details = [ qualifiedToString checkInfo.fn ++ " is meant for this exact purpose and will also be faster." ]
-                                }
-                                checkInfo.fnRange
-                                (replaceBySubExpressionFix checkInfo.parentRange mappableArg
-                                    ++ [ Fix.replaceRangeBy mapCall.fnRange
-                                            (qualifiedToString (qualify checkInfo.fn checkInfo))
-                                       ]
-                                )
-                            )
+    if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
+        onFnCallCanBeCombinedCheck
+            { laterOperationDescription = qualifiedToString checkInfo.fn ++ " with an identity function"
+            , earlierFn = mappable.mapFn
+            , combinedFn = checkInfo.fn
+            }
+            checkInfo
 
-                    Nothing ->
-                        Nothing
-
-            else
-                Nothing
-
-        Nothing ->
-            Nothing
+    else
+        Nothing
 
 
 mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks : MappableProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
@@ -6585,22 +6569,12 @@ mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks mappable che
     case checkInfo.later.args of
         elementToMaybeMappingArg :: [] ->
             if AstHelpers.isIdentity checkInfo.lookupTable elementToMaybeMappingArg then
-                case ( checkInfo.earlier.fn == mappable.mapFn, checkInfo.earlier.args ) of
-                    ( True, _ :: [] ) ->
-                        Just
-                            { info =
-                                { message = qualifiedToString mappable.mapFn ++ " and " ++ qualifiedToString checkInfo.later.fn ++ " identity can be combined using " ++ qualifiedToString checkInfo.later.fn
-                                , details = [ qualifiedToString checkInfo.later.fn ++ " is meant for this exact purpose and will also be faster." ]
-                                }
-                            , fix =
-                                [ Fix.replaceRangeBy checkInfo.earlier.fnRange
-                                    (qualifiedToString (qualify checkInfo.later.fn checkInfo))
-                                , Fix.removeRange checkInfo.later.removeRange
-                                ]
-                            }
-
-                    _ ->
-                        Nothing
+                compositionAfterFnCanBeCombinedCheck
+                    { laterOperationDescription = qualifiedToString checkInfo.later.fn ++ " with an identity function"
+                    , earlierFn = mappable.mapFn
+                    , combinedFn = checkInfo.later.fn
+                    }
+                    checkInfo
 
             else
                 Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2384,8 +2384,22 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                             _ ->
                                 Nothing
 
-                    _ ->
-                        Nothing
+                    otherApplied ->
+                        case AstHelpers.getRecordAccessFunction otherApplied of
+                            Just fieldName ->
+                                accessingRecordChecks
+                                    { parentRange = Range.combine [ Node.range applied, Node.range firstArg ]
+                                    , record = firstArg
+                                    , fieldRange = Node.range otherApplied
+                                    , fieldName = fieldName
+                                    , importRecordTypeAliases = context.importRecordTypeAliases
+                                    , moduleRecordTypeAliases = context.moduleRecordTypeAliases
+                                    , lookupTable = context.lookupTable
+                                    }
+                                    |> Maybe.map (\e -> Rule.errorWithFix e.info (Node.range otherApplied) e.fix)
+
+                            Nothing ->
+                                Nothing
                 )
 
         ----------
@@ -2451,6 +2465,9 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                             , nodeRange = expressionRange
                             , pipedInto = pipedIntoOther
                             , arg = lastArg
+                            , importRecordTypeAliases = context.importRecordTypeAliases
+                            , moduleRecordTypeAliases = context.moduleRecordTypeAliases
+                            , lookupTable = context.lookupTable
                             }
                         )
 
@@ -2517,6 +2534,9 @@ expressionVisitorHelp (Node expressionRange expression) config context =
                             , nodeRange = expressionRange
                             , pipedInto = pipedIntoOther
                             , arg = lastArg
+                            , importRecordTypeAliases = context.importRecordTypeAliases
+                            , moduleRecordTypeAliases = context.moduleRecordTypeAliases
+                            , lookupTable = context.lookupTable
                             }
                         )
 
@@ -2603,62 +2623,17 @@ expressionVisitorHelp (Node expressionRange expression) config context =
         -- RECORD ACCESS --
         -------------------
         Expression.RecordAccess record (Node fieldRange fieldName) ->
-            let
-                dotFieldRange : Range
-                dotFieldRange =
-                    { start = (Node.range record).end, end = fieldRange.end }
-
-                maybeErrorInfoAndFix : Maybe ErrorInfoAndFix
-                maybeErrorInfoAndFix =
-                    case Node.value (AstHelpers.removeParens record) of
-                        Expression.RecordExpr setters ->
-                            recordAccessChecks
-                                { nodeRange = expressionRange
-                                , maybeRecordNameRange = Nothing
-                                , fieldName = fieldName
-                                , setters = setters
-                                }
-
-                        Expression.RecordUpdateExpression (Node recordNameRange _) setters ->
-                            recordAccessChecks
-                                { nodeRange = expressionRange
-                                , maybeRecordNameRange = Just recordNameRange
-                                , fieldName = fieldName
-                                , setters = setters
-                                }
-
-                        Expression.LetExpression letIn ->
-                            Just (injectRecordAccessIntoLetExpression dotFieldRange letIn.expression fieldName)
-
-                        Expression.IfBlock _ thenBranch elseBranch ->
-                            distributeFieldAccess "an if/then/else" dotFieldRange [ thenBranch, elseBranch ] fieldName
-
-                        Expression.CaseExpression caseOf ->
-                            distributeFieldAccess "a case/of" dotFieldRange (List.map Tuple.second caseOf.cases) fieldName
-
-                        _ ->
-                            case getRecordTypeAliasConstructorCall record context of
-                                Just recordTypeAliasConstructorCall ->
-                                    if List.length recordTypeAliasConstructorCall.fieldNames == List.length recordTypeAliasConstructorCall.args then
-                                        recordAccessChecks
-                                            { nodeRange = expressionRange
-                                            , fieldName = fieldName
-                                            , maybeRecordNameRange = Nothing
-                                            , setters =
-                                                List.map2 (\name arg -> Node.empty ( Node.empty name, arg ))
-                                                    recordTypeAliasConstructorCall.fieldNames
-                                                    recordTypeAliasConstructorCall.args
-                                            }
-
-                                    else
-                                        Nothing
-
-                                Nothing ->
-                                    Nothing
-            in
             onlyMaybeError
-                (maybeErrorInfoAndFix
-                    |> Maybe.map (\e -> Rule.errorWithFix e.info dotFieldRange e.fix)
+                (accessingRecordChecks
+                    { parentRange = expressionRange
+                    , record = record
+                    , fieldRange = fieldRange
+                    , fieldName = fieldName
+                    , importRecordTypeAliases = context.importRecordTypeAliases
+                    , moduleRecordTypeAliases = context.moduleRecordTypeAliases
+                    , lookupTable = context.lookupTable
+                    }
+                    |> Maybe.map (\e -> Rule.errorWithFix e.info { start = (Node.range record).end, end = fieldRange.end } e.fix)
                 )
 
         --------
@@ -10265,12 +10240,31 @@ pipelineChecks :
     , pipedInto : Node Expression
     , arg : Node Expression
     , direction : LeftOrRightDirection
+    , importRecordTypeAliases : Dict ModuleName (Dict String (List String))
+    , moduleRecordTypeAliases : Dict String (List String)
+    , lookupTable : ModuleNameLookupTable
     }
     -> Maybe (Error {})
 pipelineChecks =
     firstThatConstructsJust
         [ \checkInfo -> pipingIntoCompositionChecks { commentRanges = checkInfo.commentRanges, extractSourceCode = checkInfo.extractSourceCode } checkInfo.direction checkInfo.pipedInto
         , \checkInfo -> fullyAppliedLambdaInPipelineChecks { nodeRange = checkInfo.nodeRange, function = checkInfo.pipedInto, firstArgument = checkInfo.arg }
+        , \checkInfo ->
+            case AstHelpers.getRecordAccessFunction checkInfo.pipedInto of
+                Just fieldName ->
+                    accessingRecordChecks
+                        { parentRange = checkInfo.nodeRange
+                        , record = checkInfo.arg
+                        , fieldRange = Node.range checkInfo.pipedInto
+                        , fieldName = fieldName
+                        , importRecordTypeAliases = checkInfo.importRecordTypeAliases
+                        , moduleRecordTypeAliases = checkInfo.moduleRecordTypeAliases
+                        , lookupTable = checkInfo.lookupTable
+                        }
+                        |> Maybe.map (\e -> Rule.errorWithFix e.info (Node.range checkInfo.pipedInto) e.fix)
+
+                Nothing ->
+                    Nothing
         ]
 
 
@@ -11328,15 +11322,20 @@ recordUpdateChecks recordUpdateRange recordVariable fields =
 
 getUnnecessaryRecordUpdateSetter : String -> Node ( Node String, Node Expression ) -> Maybe { valueAccessRange : Range, setterRange : Range }
 getUnnecessaryRecordUpdateSetter recordVariableName (Node setterRange ( Node _ field, valueNode )) =
-    case AstHelpers.removeParens valueNode of
-        Node valueAccessRange (Expression.RecordAccess (Node _ (Expression.FunctionOrValue [] valueHolder)) (Node _ fieldName)) ->
-            if field == fieldName && recordVariableName == valueHolder then
-                Just { setterRange = setterRange, valueAccessRange = valueAccessRange }
+    case AstHelpers.getAccessingRecord valueNode of
+        Just accessingRecord ->
+            case accessingRecord.record of
+                Node _ (Expression.FunctionOrValue [] recordVariable) ->
+                    if field == accessingRecord.field && recordVariableName == recordVariable then
+                        Just { setterRange = setterRange, valueAccessRange = accessingRecord.range }
 
-            else
-                Nothing
+                    else
+                        Nothing
 
-        _ ->
+                _ ->
+                    Nothing
+
+        Nothing ->
             Nothing
 
 
@@ -11811,14 +11810,80 @@ letKeyWordRange range =
 -- RECORD ACCESS
 
 
-recordAccessChecks :
+accessingRecordChecks :
+    { parentRange : Range
+    , fieldName : String
+    , fieldRange : Range
+    , record : Node Expression
+    , importRecordTypeAliases : Dict ModuleName (Dict String (List String))
+    , moduleRecordTypeAliases : Dict String (List String)
+    , lookupTable : ModuleNameLookupTable
+    }
+    -> Maybe ErrorInfoAndFix
+accessingRecordChecks checkInfo =
+    case Node.value (AstHelpers.removeParens checkInfo.record) of
+        Expression.RecordExpr fields ->
+            accessingRecordWithKnownFieldsChecks
+                { nodeRange = checkInfo.parentRange
+                , maybeRecordNameRange = Nothing
+                , fieldName = checkInfo.fieldName
+                , knownFields = fields
+                }
+
+        Expression.RecordUpdateExpression (Node recordNameRange _) setFields ->
+            accessingRecordWithKnownFieldsChecks
+                { nodeRange = checkInfo.parentRange
+                , maybeRecordNameRange = Just recordNameRange
+                , fieldName = checkInfo.fieldName
+                , knownFields = setFields
+                }
+
+        Expression.LetExpression letIn ->
+            Just
+                { info =
+                    { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                    , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
+                    }
+                , fix =
+                    keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.record }
+                        ++ replaceSubExpressionByRecordAccessFix checkInfo.fieldName letIn.expression
+                }
+
+        Expression.IfBlock _ thenBranch elseBranch ->
+            distributeFieldAccess "an if...then...else" [ thenBranch, elseBranch ] checkInfo
+
+        Expression.CaseExpression caseOf ->
+            distributeFieldAccess "a case...of" (List.map Tuple.second caseOf.cases) checkInfo
+
+        _ ->
+            case getRecordTypeAliasConstructorCall checkInfo.record checkInfo of
+                Just recordTypeAliasConstructorCall ->
+                    if List.length recordTypeAliasConstructorCall.fieldNames == List.length recordTypeAliasConstructorCall.args then
+                        accessingRecordWithKnownFieldsChecks
+                            { nodeRange = checkInfo.parentRange
+                            , fieldName = checkInfo.fieldName
+                            , maybeRecordNameRange = Nothing
+                            , knownFields =
+                                List.map2 (\name arg -> Node.empty ( Node.empty name, arg ))
+                                    recordTypeAliasConstructorCall.fieldNames
+                                    recordTypeAliasConstructorCall.args
+                            }
+
+                    else
+                        Nothing
+
+                Nothing ->
+                    Nothing
+
+
+accessingRecordWithKnownFieldsChecks :
     { nodeRange : Range
     , maybeRecordNameRange : Maybe Range
     , fieldName : String
-    , setters : List (Node Expression.RecordSetter)
+    , knownFields : List (Node Expression.RecordSetter)
     }
     -> Maybe ErrorInfoAndFix
-recordAccessChecks checkInfo =
+accessingRecordWithKnownFieldsChecks checkInfo =
     let
         maybeMatchingSetterValue : Maybe (Node Expression)
         maybeMatchingSetterValue =
@@ -11830,14 +11895,14 @@ recordAccessChecks checkInfo =
                     else
                         Nothing
                 )
-                checkInfo.setters
+                checkInfo.knownFields
     in
     case maybeMatchingSetterValue of
         Just setter ->
             Just
                 { info =
-                    { message = "Field access can be simplified"
-                    , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                    { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                    , details = [ "You can replace accessing this record by just that field's value." ]
                     }
                 , fix = replaceBySubExpressionFix checkInfo.nodeRange setter
                 }
@@ -11847,11 +11912,11 @@ recordAccessChecks checkInfo =
                 Just recordNameRange ->
                     Just
                         { info =
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of an unrelated record update can be simplified to just the original field's value." ]
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
                             }
                         , fix =
-                            [ Fix.replaceRangeBy { start = checkInfo.nodeRange.start, end = recordNameRange.start } ""
+                            [ Fix.removeRange { start = checkInfo.nodeRange.start, end = recordNameRange.start }
                             , Fix.replaceRangeBy { start = recordNameRange.end, end = checkInfo.nodeRange.end } ("." ++ checkInfo.fieldName)
                             ]
                         }
@@ -11860,34 +11925,22 @@ recordAccessChecks checkInfo =
                     Nothing
 
 
-distributeFieldAccess : String -> Range -> List (Node Expression) -> String -> Maybe ErrorInfoAndFix
-distributeFieldAccess kind dotFieldRange branches fieldName =
+distributeFieldAccess : String -> List (Node Expression) -> { checkInfo | parentRange : Range, record : Node Expression, fieldName : String } -> Maybe ErrorInfoAndFix
+distributeFieldAccess kind branches checkInfo =
     case returnsRecordInAllBranches branches of
         Just records ->
             Just
                 { info =
-                    { message = "Field access can be simplified"
-                    , details = [ "Accessing the field outside " ++ kind ++ " expression can be simplified to access the field inside it." ]
+                    { message = "Accessing a field outside " ++ kind ++ " will result in accessing it in each branch"
+                    , details = [ "You can replace accessing this record outside " ++ kind ++ " by accessing the record inside each branch." ]
                     }
                 , fix =
-                    Fix.removeRange dotFieldRange
-                        :: List.concatMap (\leaf -> replaceSubExpressionByRecordAccessFix fieldName leaf) records
+                    keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.record }
+                        ++ List.concatMap (\leaf -> replaceSubExpressionByRecordAccessFix checkInfo.fieldName leaf) records
                 }
 
         Nothing ->
             Nothing
-
-
-injectRecordAccessIntoLetExpression : Range -> Node Expression -> String -> ErrorInfoAndFix
-injectRecordAccessIntoLetExpression dotFieldRange letBody fieldName =
-    { info =
-        { message = "Field access can be simplified"
-        , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it." ]
-        }
-    , fix =
-        Fix.removeRange dotFieldRange
-            :: replaceSubExpressionByRecordAccessFix fieldName letBody
-    }
 
 
 returnsRecordInAllBranches : List (Node Expression) -> Maybe (List (Node Expression))

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4978,46 +4978,6 @@ stringJoinChecks =
         ]
 
 
-{-| Check for a function that given an empty separator is equivalent to a given replacement operation.
-
-    intersperseFlat empty something
-    --> replacementOperation something
-
-So for example
-
-    List.Extra.intercalate : List a -> List (List a) -> List a
-    List.Extra.intercalate [] list --> List.concat list
-
-    DList.intersperse : DList a -> List (DList a) -> DList a
-    DList.intersperse DList.empty dList --> DList.concat dList
-
-Note that this really only applies to "flat-intersperse-like" functions, not for example
-
-    concatMap identity type --> concat type
-    -- where identity would be the "empty function"
-
-for that specific example, there is `operationWithIdentityIsEquivalentToFnCheck`
-
--}
-intersperseFlatWithEmptySeparatorIsEquivalentToFnCheck : EmptiableProperties (TypeSubsetProperties empty) otherProperties -> ( ModuleName, String ) -> CheckInfo -> Maybe (Error {})
-intersperseFlatWithEmptySeparatorIsEquivalentToFnCheck elementProperties replacementFn checkInfo =
-    if elementProperties.empty.is (extractInferResources checkInfo) checkInfo.firstArg then
-        Just
-            (Rule.errorWithFix
-                { message = qualifiedToString checkInfo.fn ++ " with separator " ++ descriptionWithoutArticle elementProperties.empty.description ++ " is the same as " ++ qualifiedToString replacementFn
-                , details = [ "You can replace this call by " ++ qualifiedToString replacementFn ++ "." ]
-                }
-                checkInfo.fnRange
-                [ Fix.replaceRangeBy
-                    (Range.combine [ checkInfo.fnRange, Node.range checkInfo.firstArg ])
-                    (qualifiedToString (qualify replacementFn checkInfo))
-                ]
-            )
-
-    else
-        Nothing
-
-
 stringRepeatChecks : CheckInfo -> Maybe (Error {})
 stringRepeatChecks =
     emptiableRepeatFlatChecks stringCollection
@@ -5389,6 +5349,46 @@ operationWithIdentityIsEquivalentToFnCheck replacementFn checkInfo =
                 checkInfo.fnRange
                 [ Fix.replaceRangeBy
                     { start = checkInfo.fnRange.start, end = (Node.range checkInfo.firstArg).end }
+                    (qualifiedToString (qualify replacementFn checkInfo))
+                ]
+            )
+
+    else
+        Nothing
+
+
+{-| Check for a function that given an empty separator is equivalent to a given replacement operation.
+
+    intersperseFlat empty something
+    --> replacementOperation something
+
+So for example
+
+    List.Extra.intercalate : List a -> List (List a) -> List a
+    List.Extra.intercalate [] list --> List.concat list
+
+    DList.intersperse : DList a -> List (DList a) -> DList a
+    DList.intersperse DList.empty dList --> DList.concat dList
+
+Note that this really only applies to "flat-intersperse-like" functions, not for example
+
+    concatMap identity type --> concat type
+    -- where identity would be the "empty function"
+
+for that specific example, there is `operationWithIdentityIsEquivalentToFnCheck`
+
+-}
+intersperseFlatWithEmptySeparatorIsEquivalentToFnCheck : EmptiableProperties (TypeSubsetProperties empty) otherProperties -> ( ModuleName, String ) -> CheckInfo -> Maybe (Error {})
+intersperseFlatWithEmptySeparatorIsEquivalentToFnCheck elementProperties replacementFn checkInfo =
+    if elementProperties.empty.is (extractInferResources checkInfo) checkInfo.firstArg then
+        Just
+            (Rule.errorWithFix
+                { message = qualifiedToString checkInfo.fn ++ " with separator " ++ descriptionWithoutArticle elementProperties.empty.description ++ " is the same as " ++ qualifiedToString replacementFn
+                , details = [ "You can replace this call by " ++ qualifiedToString replacementFn ++ "." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy
+                    (Range.combine [ checkInfo.fnRange, Node.range checkInfo.firstArg ])
                     (qualifiedToString (qualify replacementFn checkInfo))
                 ]
             )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7918,21 +7918,13 @@ taskSequenceChecks : CheckInfo -> Maybe (Error {})
 taskSequenceChecks =
     firstThatConstructsJust
         [ listOfWrapperSequenceChecks taskWithSucceedAsWrap
-        , listSequenceOrFirstEmptyChecks taskWithSucceedAsWrap
+        , sequenceOrFirstEmptyChecks ( listCollection, taskWithSucceedAsWrap )
         ]
 
 
 taskSequenceCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 taskSequenceCompositionChecks =
     wrapperOfMappableCompositionCheck ( listCollection, taskWithSucceedAsWrap )
-
-
-listSequenceOrFirstEmptyChecks :
-    WrapperProperties (EmptiableProperties (TypeSubsetProperties empty) otherProperties)
-    -> CheckInfo
-    -> Maybe (Error {})
-listSequenceOrFirstEmptyChecks emptiable =
-    sequenceOrFirstEmptyChecks ( listCollection, emptiable )
 
 
 {-| The sequence checks `sequenceOnCollectionWithKnownEmptyElementCheck` and `sequenceOnFromListWithEmptyIgnoresLaterElementsCheck`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -9837,7 +9837,7 @@ subNoneConstantProperties =
 
 
 
--- GENERIC CHECKS
+-- CHECKS FOR GENERIC TYPES
 
 
 oneOfChecks : CheckInfo -> Maybe (Error {})
@@ -10516,6 +10516,10 @@ pipingIntoCompositionChecks context compositionDirection expressionNode =
                     error.opToReplaceRange
                     error.fixes
                 )
+
+
+
+-- GENERIC CHECKS
 
 
 {-| Condense applying the same function with equal arguments (except the last one) twice in sequence into one.

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4996,7 +4996,7 @@ Note that this really only applies to "flat-intersperse-like" functions, not for
     concatMap identity type --> concat type
     -- where identity would be the "empty function"
 
-for that specific example, there is operationWithIdentityCanBeReplacedChecks
+for that specific example, there is `operationWithIdentityIsEquivalentToFnCheck`
 
 -}
 intersperseFlatWithEmptySeparatorIsEquivalentToFnCheck : EmptiableProperties (TypeSubsetProperties empty) otherProperties -> ( ModuleName, String ) -> CheckInfo -> Maybe (Error {})
@@ -5363,7 +5363,7 @@ findConsecutiveListLiterals firstListElement restOfListElements =
 listConcatMapChecks : CheckInfo -> Maybe (Error {})
 listConcatMapChecks =
     firstThatConstructsJust
-        [ operationWithIdentityCanBeReplacedChecks { replacementFn = Fn.List.concat }
+        [ operationWithIdentityIsEquivalentToFnCheck Fn.List.concat
         , emptiableAndThenChecks listCollection
         , wrapperAndThenChecks listCollection
         ]
@@ -5378,18 +5378,18 @@ Can be used to for example
   - turn `List.Extra.minimumBy identity` into `List.minimum`
 
 -}
-operationWithIdentityCanBeReplacedChecks : { replacementFn : ( ModuleName, String ) } -> CheckInfo -> Maybe (Error {})
-operationWithIdentityCanBeReplacedChecks config checkInfo =
+operationWithIdentityIsEquivalentToFnCheck : ( ModuleName, String ) -> CheckInfo -> Maybe (Error {})
+operationWithIdentityIsEquivalentToFnCheck replacementFn checkInfo =
     if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
         Just
             (Rule.errorWithFix
-                { message = qualifiedToString checkInfo.fn ++ " with an identity function is the same as " ++ qualifiedToString config.replacementFn
-                , details = [ "You can replace this call by " ++ qualifiedToString config.replacementFn ++ "." ]
+                { message = qualifiedToString checkInfo.fn ++ " with an identity function is the same as " ++ qualifiedToString replacementFn
+                , details = [ "You can replace this call by " ++ qualifiedToString replacementFn ++ "." ]
                 }
                 checkInfo.fnRange
                 [ Fix.replaceRangeBy
                     { start = checkInfo.fnRange.start, end = (Node.range checkInfo.firstArg).end }
-                    (qualifiedToString (qualify config.replacementFn checkInfo))
+                    (qualifiedToString (qualify replacementFn checkInfo))
                 ]
             )
 
@@ -7119,7 +7119,7 @@ listSortByChecks =
 
                 Nothing ->
                     Nothing
-        , operationWithIdentityCanBeReplacedChecks { replacementFn = Fn.List.sort }
+        , operationWithIdentityIsEquivalentToFnCheck Fn.List.sort
         , operationDoesNotChangeResultOfOperationCheck
         ]
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7324,7 +7324,7 @@ For example given `resultWithOkAsWrap`:
     Result.map2 f (Ok first) (Ok second)
     --> Ok (f first second)
 
-This is pretty similar to `wrapperSequenceChecks` where we look at arguments instead of list elements.
+This is pretty similar to `listOfWrapperSequenceChecks` where we look at arguments instead of list elements.
 
 -}
 wrapperMapNChecks : TypeProperties (WrapperProperties otherProperties) -> CheckInfo -> Maybe (Error {})
@@ -7917,7 +7917,7 @@ taskOnErrorCompositionChecks =
 taskSequenceChecks : CheckInfo -> Maybe (Error {})
 taskSequenceChecks =
     firstThatConstructsJust
-        [ wrapperSequenceChecks taskWithSucceedAsWrap
+        [ listOfWrapperSequenceChecks taskWithSucceedAsWrap
         , sequenceOrFirstEmptyChecks taskWithSucceedAsWrap
         ]
 
@@ -7983,8 +7983,8 @@ sequenceOrFirstEmptyChecks emptiable checkInfo =
             Nothing
 
 
-wrapperSequenceChecks : WrapperProperties { otherProperties | mapFn : ( ModuleName, String ) } -> CheckInfo -> Maybe (Error {})
-wrapperSequenceChecks wrapper =
+listOfWrapperSequenceChecks : WrapperProperties { otherProperties | mapFn : ( ModuleName, String ) } -> CheckInfo -> Maybe (Error {})
+listOfWrapperSequenceChecks wrapper =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck
             { resultAsString =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6610,6 +6610,7 @@ mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks mappable che
 
 
 {-| Simplify this operation after a given call to `fromFn` into a given `combinedFn`.
+If the `fromFn` call isn't the first argument, use `onFnCallCanBeCombinedCheck`
 
 Examples:
 
@@ -6627,12 +6628,34 @@ callFromCanBeCombinedCheck :
     -> CheckInfo
     -> Maybe (Error {})
 callFromCanBeCombinedCheck config checkInfo =
-    case AstHelpers.getSpecificFnCall config.fromFn checkInfo.lookupTable checkInfo.firstArg of
+    onFnCallCanBeCombinedCheck
+        { laterOperationDescription = qualifiedToString checkInfo.fn
+        , earlierFn = config.fromFn
+        , combinedFn = config.combinedFn
+        }
+        checkInfo
+
+
+{-| Simplify this operation after a given call to `earlierFn` into a given `combinedFn`.
+
+Examples:
+
+  - `List.filterMap identity (List.map f list) --> List.filterMap f list`
+  - `traverse identity (map f a) --> traverse f a`
+  - those listed in `callFromCanBeCombinedCheck`
+
+-}
+onFnCallCanBeCombinedCheck :
+    { laterOperationDescription : String, earlierFn : ( ModuleName, String ), combinedFn : ( ModuleName, String ) }
+    -> CheckInfo
+    -> Maybe (Error {})
+onFnCallCanBeCombinedCheck config checkInfo =
+    case Maybe.andThen (AstHelpers.getSpecificFnCall config.earlierFn checkInfo.lookupTable) (fullyAppliedLastArg checkInfo) of
         Just fromFnCall ->
             Just
                 (Rule.errorWithFix
-                    { message = qualifiedToString config.fromFn ++ ", then " ++ qualifiedToString checkInfo.fn ++ " can be combined into " ++ qualifiedToString config.combinedFn
-                    , details = [ "You can replace this call by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.fromFn ++ " which is meant for this exact purpose." ]
+                    { message = qualifiedToString config.earlierFn ++ ", then " ++ config.laterOperationDescription ++ " can be combined into " ++ qualifiedToString config.combinedFn
+                    , details = [ "You can replace this call by " ++ qualifiedToString config.combinedFn ++ " with the same arguments given to " ++ qualifiedToString config.earlierFn ++ " which is meant for this exact purpose." ]
                     }
                     checkInfo.fnRange
                     (Fix.replaceRangeBy

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4974,27 +4974,48 @@ stringJoinChecks : CheckInfo -> Maybe (Error {})
 stringJoinChecks =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection
-        , \checkInfo ->
-            if stringCollection.empty.is (extractInferResources checkInfo) checkInfo.firstArg then
-                let
-                    replacementFn : ( ModuleName, String )
-                    replacementFn =
-                        Fn.String.concat
-                in
-                Just
-                    (Rule.errorWithFix
-                        { message = qualifiedToString checkInfo.fn ++ " with separator \"\" is the same as " ++ qualifiedToString replacementFn
-                        , details = [ "You can replace this call by " ++ qualifiedToString replacementFn ++ "." ]
-                        }
-                        checkInfo.fnRange
-                        [ Fix.replaceRangeBy { start = checkInfo.fnRange.start, end = (Node.range checkInfo.firstArg).end }
-                            (qualifiedToString (qualify replacementFn checkInfo))
-                        ]
-                    )
-
-            else
-                Nothing
+        , intersperseFlatWithEmptySeparatorIsEquivalentToFnCheck stringCollection Fn.String.concat
         ]
+
+
+{-| Check for a function that given an empty separator is equivalent to a given replacement operation.
+
+    intersperseFlat empty something
+    --> replacementOperation something
+
+So for example
+
+    List.Extra.intercalate : List a -> List (List a) -> List a
+    List.Extra.intercalate [] list --> List.concat list
+
+    DList.intersperse : DList a -> List (DList a) -> DList a
+    DList.intersperse DList.empty dList --> DList.concat dList
+
+Note that this really only applies to "flat-intersperse-like" functions, not for example
+
+    concatMap identity type --> concat type
+    -- where identity would be the "empty function"
+
+for that specific example, there is operationWithIdentityCanBeReplacedChecks
+
+-}
+intersperseFlatWithEmptySeparatorIsEquivalentToFnCheck : EmptiableProperties (TypeSubsetProperties empty) otherProperties -> ( ModuleName, String ) -> CheckInfo -> Maybe (Error {})
+intersperseFlatWithEmptySeparatorIsEquivalentToFnCheck elementProperties replacementFn checkInfo =
+    if elementProperties.empty.is (extractInferResources checkInfo) checkInfo.firstArg then
+        Just
+            (Rule.errorWithFix
+                { message = qualifiedToString checkInfo.fn ++ " with separator " ++ descriptionWithoutArticle elementProperties.empty.description ++ " is the same as " ++ qualifiedToString replacementFn
+                , details = [ "You can replace this call by " ++ qualifiedToString replacementFn ++ "." ]
+                }
+                checkInfo.fnRange
+                [ Fix.replaceRangeBy
+                    (Range.combine [ checkInfo.fnRange, Node.range checkInfo.firstArg ])
+                    (qualifiedToString (qualify replacementFn checkInfo))
+                ]
+            )
+
+    else
+        Nothing
 
 
 stringRepeatChecks : CheckInfo -> Maybe (Error {})

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7965,6 +7965,17 @@ listSequenceOrFirstEmptyChecks emptiable =
         ]
 
 
+{-| The sequence check
+
+    sequence (collection containing some wrapped elements, then empty, then other elements)
+    --> empty
+
+So for example
+
+    Task.sequence [ Task.succeed a, Task.fail x, task ]
+    --> Task.fail x
+
+-}
 sequenceOnCollectionWithKnownEmptyElementCheck :
     ( TypeProperties (CollectionProperties collectionOtherProperties), EmptiableProperties (TypeSubsetProperties empty) (WrapperProperties elementOtherProperties) )
     -> CheckInfo

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5565,7 +5565,7 @@ listTailChecks =
                 Just _ ->
                     Just
                         (Rule.errorWithFix
-                            { message = qualifiedToString checkInfo.fn ++ " on a list with a single element will result in Just []"
+                            { message = qualifiedToString checkInfo.fn ++ " on a singleton list will result in Just []"
                             , details = [ "You can replace this call by Just []." ]
                             }
                             checkInfo.fnRange

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7117,7 +7117,7 @@ listSortByChecks =
                 Just _ ->
                     Just
                         (alwaysReturnsLastArgError
-                            (qualifiedToString checkInfo.fn ++ " (always a)")
+                            (qualifiedToString checkInfo.fn ++ " with a function that always returns the same constant")
                             listCollection
                             checkInfo
                         )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7932,9 +7932,21 @@ listSequenceOrFirstEmptyChecks :
     -> CheckInfo
     -> Maybe (Error {})
 listSequenceOrFirstEmptyChecks emptiable =
+    sequenceOrFirstEmptyChecks ( listCollection, emptiable )
+
+
+{-| The sequence checks `sequenceOnCollectionWithKnownEmptyElementCheck` and `sequenceOnFromListWithEmptyIgnoresLaterElementsCheck`
+-}
+sequenceOrFirstEmptyChecks :
+    ( TypeProperties (CollectionProperties (ConstructibleFromListProperties collectionOtherProperties))
+    , EmptiableProperties (TypeSubsetProperties empty) (WrapperProperties elementOtherProperties)
+    )
+    -> CheckInfo
+    -> Maybe (Error {})
+sequenceOrFirstEmptyChecks ( collection, elementEmptiable ) =
     firstThatConstructsJust
-        [ sequenceOnCollectionWithKnownEmptyElementCheck ( listCollection, emptiable )
-        , sequenceOnFromListWithEmptyIgnoresLaterElementsCheck ( listCollection, emptiable )
+        [ sequenceOnCollectionWithKnownEmptyElementCheck ( collection, elementEmptiable )
+        , sequenceOnFromListWithEmptyIgnoresLaterElementsCheck ( collection, elementEmptiable )
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7924,7 +7924,7 @@ taskSequenceChecks =
 
 taskSequenceCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 taskSequenceCompositionChecks =
-    mappableSequenceCompositionChecks taskWithSucceedAsWrap
+    listOfMappableSequenceCompositionChecks taskWithSucceedAsWrap
 
 
 listSequenceOrFirstEmptyChecks :
@@ -8047,8 +8047,8 @@ listOfWrapperSequenceChecks wrapper =
         ]
 
 
-mappableSequenceCompositionChecks : TypeProperties { otherProperties | mapFn : ( ModuleName, String ) } -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-mappableSequenceCompositionChecks mappable checkInfo =
+listOfMappableSequenceCompositionChecks : TypeProperties { otherProperties | mapFn : ( ModuleName, String ) } -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+listOfMappableSequenceCompositionChecks mappable checkInfo =
     case checkInfo.earlier.fn of
         ( [ "List" ], "singleton" ) ->
             let

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8354,15 +8354,6 @@ jsonDecodeAndThenCompositionChecks =
 
 
 
--- PARSER
-
-
-oneOfChecks : CheckInfo -> Maybe (Error {})
-oneOfChecks =
-    callOnWrapReturnsItsValueCheck listCollection
-
-
-
 -- RANDOM
 
 
@@ -8582,7 +8573,7 @@ nonEmptiableWrapperAndThenAlwaysChecks wrapper checkInfo =
 
 
 
---
+-- TYPE PROPERTIES
 
 
 type alias TypeProperties properties =
@@ -9782,6 +9773,15 @@ subNoneConstantProperties =
         \resources ->
             qualifiedToString (qualify Fn.Platform.Sub.none resources)
     }
+
+
+
+-- GENERIC CHECKS
+
+
+oneOfChecks : CheckInfo -> Maybe (Error {})
+oneOfChecks =
+    callOnWrapReturnsItsValueCheck listCollection
 
 
 {-| The map checks

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4643,7 +4643,7 @@ tuplePartChecks partConfig =
                             )
                         )
                 )
-                (AstHelpers.getTuple2 checkInfo.firstArg checkInfo.lookupTable)
+                (AstHelpers.getTuple2 checkInfo.lookupTable checkInfo.firstArg)
         , \checkInfo ->
             case AstHelpers.getSpecificFnCall partConfig.mapUnrelatedFn checkInfo.lookupTable checkInfo.firstArg of
                 Just mapSecondCall ->
@@ -9726,7 +9726,7 @@ dictGetValues resources =
 
 getTupleWithComparableFirst : ModuleNameLookupTable -> Node Expression -> Maybe { comparableFirst : List Expression, second : Node Expression }
 getTupleWithComparableFirst lookupTable expressionNode =
-    case AstHelpers.getTuple2 expressionNode lookupTable of
+    case AstHelpers.getTuple2 lookupTable expressionNode of
         Just tuple ->
             case getComparableExpression tuple.first of
                 Just comparableFirst ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8819,6 +8819,19 @@ type alias ConstantProperties =
         { asString : QualifyResources {} -> String }
 
 
+{-| Create `ConstantProperties` for a value with a given full qualified name.
+-}
+constantFnProperties : ( ModuleName, String ) -> ConstantProperties
+constantFnProperties fullyQualified =
+    { description = Constant (qualifiedToString (qualify fullyQualified defaultQualifyResources))
+    , is =
+        \res expr ->
+            isJust (AstHelpers.getSpecificValueOrFn fullyQualified res.lookupTable expr)
+    , asString =
+        \res -> qualifiedToString (qualify fullyQualified res)
+    }
+
+
 getEmpty :
     Infer.Resources a
     -> EmptiableProperties (TypeSubsetProperties empty) otherProperties
@@ -9087,15 +9100,7 @@ randomGeneratorConstantConstruct =
 maybeWithJustAsWrap : TypeProperties (EmptiableProperties ConstantProperties (WrapperProperties (MappableProperties {})))
 maybeWithJustAsWrap =
     { represents = "maybe"
-    , empty =
-        { description = Constant "Nothing"
-        , is =
-            \res expr ->
-                isJust (AstHelpers.getSpecificValueOrFn Fn.Maybe.nothingVariant res.lookupTable expr)
-        , asString =
-            \resources ->
-                qualifiedToString (qualify Fn.Maybe.nothingVariant resources)
-        }
+    , empty = constantFnProperties Fn.Maybe.nothingVariant
     , wrap = maybeJustConstructProperties
     , mapFn = Fn.Maybe.map
     }
@@ -9434,25 +9439,13 @@ stringGetElements resources =
 arrayCollection : TypeProperties (CollectionProperties (ConstructibleFromListProperties (EmptiableProperties ConstantProperties {})))
 arrayCollection =
     { represents = "array"
-    , empty = arrayEmptyConstantProperties
+    , empty = constantFnProperties Fn.Array.empty
     , elements =
         { countDescription = "length"
         , determineCount = arrayDetermineLength
         , get = arrayGetElements
         }
     , fromList = ConstructionFromListCall Fn.Array.fromList
-    }
-
-
-arrayEmptyConstantProperties : ConstantProperties
-arrayEmptyConstantProperties =
-    { description = Constant (qualifiedToString Fn.Array.empty)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificValueOrFn Fn.Array.empty res.lookupTable expr)
-    , asString =
-        \resources ->
-            qualifiedToString (qualify Fn.Array.empty resources)
     }
 
 
@@ -9523,7 +9516,7 @@ arrayDetermineLength resources =
 setCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (ConstructibleFromListProperties {}))))
 setCollection =
     { represents = "set"
-    , empty = setEmptyConstantProperties
+    , empty = constantFnProperties Fn.Set.empty
     , elements =
         { countDescription = "size"
         , determineCount = setDetermineSize
@@ -9531,18 +9524,6 @@ setCollection =
         }
     , wrap = setSingletonConstruct
     , fromList = ConstructionFromListCall Fn.Set.fromList
-    }
-
-
-setEmptyConstantProperties : ConstantProperties
-setEmptyConstantProperties =
-    { description = Constant (qualifiedToString Fn.Set.empty)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificValueOrFn Fn.Set.empty res.lookupTable expr)
-    , asString =
-        \resources ->
-            qualifiedToString (qualify Fn.Set.empty resources)
     }
 
 
@@ -9656,25 +9637,13 @@ setDetermineSize resources =
 dictCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (ConstructibleFromListProperties {})))
 dictCollection =
     { represents = "dict"
-    , empty = dictEmptyConstantProperties
+    , empty = constantFnProperties Fn.Dict.empty
     , elements =
         { countDescription = "size"
         , determineCount = dictDetermineSize
         , get = dictGetValues
         }
     , fromList = ConstructionFromListCall Fn.Dict.fromList
-    }
-
-
-dictEmptyConstantProperties : ConstantProperties
-dictEmptyConstantProperties =
-    { description = Constant (qualifiedToString Fn.Dict.empty)
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificValueOrFn Fn.Dict.empty res.lookupTable expr)
-    , asString =
-        \resources ->
-            qualifiedToString (qualify Fn.Dict.empty resources)
     }
 
 
@@ -9801,38 +9770,14 @@ getTupleWithComparableFirst lookupTable expressionNode =
 cmdCollection : TypeProperties (EmptiableProperties ConstantProperties {})
 cmdCollection =
     { represents = "command"
-    , empty = cmdNoneConstantProperties
-    }
-
-
-cmdNoneConstantProperties : ConstantProperties
-cmdNoneConstantProperties =
-    { description = Constant "Cmd.none"
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificValueOrFn Fn.Platform.Cmd.none res.lookupTable expr)
-    , asString =
-        \resources ->
-            qualifiedToString (qualify Fn.Platform.Cmd.none resources)
+    , empty = constantFnProperties Fn.Platform.Cmd.none
     }
 
 
 subCollection : TypeProperties (EmptiableProperties ConstantProperties {})
 subCollection =
     { represents = "subscription"
-    , empty = subNoneConstantProperties
-    }
-
-
-subNoneConstantProperties : ConstantProperties
-subNoneConstantProperties =
-    { description = Constant "Sub.none"
-    , is =
-        \res expr ->
-            isJust (AstHelpers.getSpecificValueOrFn Fn.Platform.Sub.none res.lookupTable expr)
-    , asString =
-        \resources ->
-            qualifiedToString (qualify Fn.Platform.Sub.none resources)
+    , empty = constantFnProperties Fn.Platform.Sub.none
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5931,7 +5931,7 @@ listSumChecks =
                 checkInfo
         , \checkInfo ->
             if checkInfo.expectNaN then
-                onCollectionWithAbsorbingChecks (qualifiedToString checkInfo.fn)
+                callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
                     ( listCollection, numberForAddProperties )
                     checkInfo
 
@@ -5956,12 +5956,12 @@ listProductChecks =
                 checkInfo
         , \checkInfo ->
             if checkInfo.expectNaN then
-                onCollectionWithAbsorbingChecks (qualifiedToString checkInfo.fn)
+                callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
                     ( listCollection, numberForMultiplyProperties )
                     checkInfo
 
             else
-                onCollectionWithAbsorbingChecks (qualifiedToString checkInfo.fn)
+                callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
                     ( listCollection, numberNotExpectingNaNForMultiplyProperties )
                     checkInfo
         ]
@@ -6235,12 +6235,12 @@ with `( listCollection, numberNotExpectingNaNForMultiplyProperties )` and a chec
     --> False
 
 -}
-onCollectionWithAbsorbingChecks :
+callOnCollectionWithAbsorbingElementChecks :
     String
     -> ( TypeProperties (CollectionProperties otherProperties), AbsorbableProperties elementOtherProperties )
     -> CheckInfo
     -> Maybe (Error {})
-onCollectionWithAbsorbingChecks situation ( collection, elementAbsorbable ) checkInfo =
+callOnCollectionWithAbsorbingElementChecks situation ( collection, elementAbsorbable ) checkInfo =
     case Maybe.andThen (collection.elements.get (extractInferResources checkInfo)) (fullyAppliedLastArg checkInfo) of
         Just elements ->
             case findMap (getAbsorbingExpressionNode elementAbsorbable checkInfo) elements.known of
@@ -6290,7 +6290,7 @@ collectionAllChecks collection =
             if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
                 firstThatConstructsJust
                     [ \() ->
-                        onCollectionWithAbsorbingChecks (qualifiedToString checkInfo.fn ++ " with an identity function")
+                        callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn ++ " with an identity function")
                             ( collection, boolForAndProperties )
                             checkInfo
                     , \() ->
@@ -6396,7 +6396,7 @@ collectionAnyChecks collection =
             if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
                 firstThatConstructsJust
                     [ \() ->
-                        onCollectionWithAbsorbingChecks (qualifiedToString checkInfo.fn ++ " with an identity function")
+                        callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn ++ " with an identity function")
                             ( collection, boolForOrProperties )
                             checkInfo
                     , \() ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8036,36 +8036,54 @@ listOfWrapperSequenceChecks wrapper =
             }
             listCollection
         , sequenceOnWrappedIsEquivalentToMapWrapOnValue ( listCollection, wrapper )
-        , \checkInfo ->
-            case listCollection.elements.get (extractInferResources checkInfo) checkInfo.firstArg of
-                Just elements ->
-                    if elements.allKnown then
-                        case traverse (getValueWithNodeRange (wrapper.wrap.getValue checkInfo.lookupTable)) elements.known of
-                            Just wraps ->
-                                Just
-                                    (Rule.errorWithFix
-                                        { message = qualifiedToString checkInfo.fn ++ " on a list where each element is " ++ descriptionForIndefinite wrapper.wrap.description ++ " will result in " ++ qualifiedToString wrapper.wrap.fn ++ " on the values inside"
-                                        , details = [ "You can replace this call by " ++ qualifiedToString wrapper.wrap.fn ++ " on a list where each element is replaced by its value inside " ++ descriptionForDefinite "the" wrapper.wrap.description ++ "." ]
-                                        }
-                                        checkInfo.fnRange
-                                        (Fix.replaceRangeBy
-                                            checkInfo.fnRange
-                                            (qualifiedToString (qualify wrapper.wrap.fn checkInfo))
-                                            :: List.concatMap
-                                                (\wrap -> keepOnlyFix { parentRange = wrap.nodeRange, keep = Node.range wrap.value })
-                                                wraps
-                                        )
-                                    )
+        , sequenceOnCollectionWithAllElementsWrapped ( listCollection, wrapper )
+        ]
 
-                            Nothing ->
-                                Nothing
 
-                    else
+{-| The sequence check
+
+    sequence (collection with each element being wrapped)
+    --> wrap (collection with each value)
+
+so for example
+
+    Task.sequence [ Task.succeed a, Task.succeed b ]
+    --> Task.succeed [ a, b ]
+
+-}
+sequenceOnCollectionWithAllElementsWrapped :
+    ( TypeProperties (CollectionProperties otherCollectionProperties), WrapperProperties elementOtherProperties )
+    -> CheckInfo
+    -> Maybe (Error {})
+sequenceOnCollectionWithAllElementsWrapped ( collection, elementWrapper ) checkInfo =
+    case collection.elements.get (extractInferResources checkInfo) checkInfo.firstArg of
+        Just elements ->
+            if elements.allKnown then
+                case traverse (getValueWithNodeRange (elementWrapper.wrap.getValue checkInfo.lookupTable)) elements.known of
+                    Just wrappeds ->
+                        Just
+                            (Rule.errorWithFix
+                                { message = qualifiedToString checkInfo.fn ++ " on a " ++ collection.represents ++ " where each element is " ++ descriptionForIndefinite elementWrapper.wrap.description ++ " will result in " ++ qualifiedToString elementWrapper.wrap.fn ++ " on the values inside"
+                                , details = [ "You can replace this call by " ++ qualifiedToString elementWrapper.wrap.fn ++ " on a list where each element is replaced by its value inside " ++ descriptionForDefinite "the" elementWrapper.wrap.description ++ "." ]
+                                }
+                                checkInfo.fnRange
+                                (Fix.replaceRangeBy
+                                    checkInfo.fnRange
+                                    (qualifiedToString (qualify elementWrapper.wrap.fn checkInfo))
+                                    :: List.concatMap
+                                        (\wrapped -> keepOnlyFix { parentRange = wrapped.nodeRange, keep = Node.range wrapped.value })
+                                        wrappeds
+                                )
+                            )
+
+                    Nothing ->
                         Nothing
 
-                Nothing ->
-                    Nothing
-        ]
+            else
+                Nothing
+
+        Nothing ->
+            Nothing
 
 
 {-| The sequence composition check

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6501,7 +6501,7 @@ listFilterMapCompositionChecks =
     mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks { mapFn = Fn.List.map }
 
 
-emptiableWrapperFilterMapChecks : TypeProperties (WrapperProperties (EmptiableProperties ConstantProperties { otherProperties | mapFn : ( ModuleName, String ) })) -> CheckInfo -> Maybe (Error {})
+emptiableWrapperFilterMapChecks : TypeProperties (WrapperProperties (EmptiableProperties ConstantProperties (MappableProperties otherProperties))) -> CheckInfo -> Maybe (Error {})
 emptiableWrapperFilterMapChecks emptiableWrapper =
     firstThatConstructsJust
         [ \checkInfo ->
@@ -8027,7 +8027,7 @@ sequenceOnCollectionWithKnownEmptyElementCheck ( collection, elementEmptiable ) 
             Nothing
 
 
-listOfWrapperSequenceChecks : WrapperProperties { otherProperties | mapFn : ( ModuleName, String ) } -> CheckInfo -> Maybe (Error {})
+listOfWrapperSequenceChecks : WrapperProperties (MappableProperties otherProperties) -> CheckInfo -> Maybe (Error {})
 listOfWrapperSequenceChecks wrapper =
     firstThatConstructsJust
         [ callOnEmptyReturnsCheck
@@ -8107,7 +8107,7 @@ Use together with `wrapperOfMappableCompositionCheck`.
 
 -}
 sequenceOnWrappedIsEquivalentToMapWrapOnValue :
-    ( WrapperProperties wrapperOtherProperties, WrapperProperties { elementOtherProperties | mapFn : ( ModuleName, String ) } )
+    ( WrapperProperties wrapperOtherProperties, WrapperProperties (MappableProperties elementOtherProperties) )
     -> CheckInfo
     -> Maybe (Error {})
 sequenceOnWrappedIsEquivalentToMapWrapOnValue ( wrapper, elementWrapper ) checkInfo =
@@ -8157,7 +8157,7 @@ Use together with `sequenceOnWrappedIsEquivalentToMapWrapOnValue`.
 
 -}
 wrapperOfMappableCompositionCheck :
-    ( WrapperProperties wrapperOtherProperties, { valueOtherProperties | mapFn : ( ModuleName, String ) } )
+    ( WrapperProperties wrapperOtherProperties, MappableProperties valueOtherProperties )
     -> CompositionIntoCheckInfo
     -> Maybe ErrorInfoAndFix
 wrapperOfMappableCompositionCheck ( wrapper, valueMappable ) checkInfo =
@@ -8716,6 +8716,19 @@ type alias AbsorbableProperties otherProperties =
     }
 
 
+{-| Properties of a type that has a function that can change each current value given a function.
+Examples are `Result.mapError`, `List.map` or `Random.map`.
+
+Types with a `map` function typically have associated `WrapperProperties`.
+For now, this has to be explicitly specified!
+
+-}
+type alias MappableProperties otherProperties =
+    { otherProperties
+        | mapFn : ( ModuleName, String )
+    }
+
+
 {-| Common properties of a specific set of values for a type.
 
 Examples:
@@ -8990,7 +9003,7 @@ numberNaNConstant =
     }
 
 
-randomGeneratorWrapper : TypeProperties (NonEmptiableProperties (WrapperProperties { mapFn : ( ModuleName, String ) }))
+randomGeneratorWrapper : TypeProperties (NonEmptiableProperties (WrapperProperties (MappableProperties {})))
 randomGeneratorWrapper =
     { represents = "random generator"
     , wrap = randomGeneratorConstantConstruct
@@ -9012,12 +9025,7 @@ randomGeneratorConstantConstruct =
     }
 
 
-maybeWithJustAsWrap :
-    TypeProperties
-        (EmptiableProperties
-            ConstantProperties
-            (WrapperProperties { mapFn : ( ModuleName, String ) })
-        )
+maybeWithJustAsWrap : TypeProperties (EmptiableProperties ConstantProperties (WrapperProperties (MappableProperties {})))
 maybeWithJustAsWrap =
     { represents = "maybe"
     , empty =
@@ -9047,14 +9055,7 @@ maybeJustConstructProperties =
     }
 
 
-resultWithOkAsWrap :
-    TypeProperties
-        (WrapperProperties
-            (EmptiableProperties
-                ConstructWithOneArgProperties
-                { mapFn : ( ModuleName, String ) }
-            )
-        )
+resultWithOkAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
 resultWithOkAsWrap =
     { represents = "result"
     , wrap = resultOkayConstruct
@@ -9089,14 +9090,7 @@ resultErrorConstruct =
     }
 
 
-resultWithErrAsWrap :
-    TypeProperties
-        (WrapperProperties
-            (EmptiableProperties
-                ConstructWithOneArgProperties
-                { mapFn : ( ModuleName, String ) }
-            )
-        )
+resultWithErrAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
 resultWithErrAsWrap =
     { represents = "result"
     , wrap = resultErrorConstruct
@@ -9105,14 +9099,7 @@ resultWithErrAsWrap =
     }
 
 
-taskWithSucceedAsWrap :
-    TypeProperties
-        (WrapperProperties
-            (EmptiableProperties
-                ConstructWithOneArgProperties
-                { mapFn : ( ModuleName, String ) }
-            )
-        )
+taskWithSucceedAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
 taskWithSucceedAsWrap =
     { represents = "task"
     , wrap = taskSucceedingConstruct
@@ -9147,14 +9134,7 @@ taskFailingConstruct =
     }
 
 
-taskWithFailAsWrap :
-    TypeProperties
-        (WrapperProperties
-            (EmptiableProperties
-                ConstructWithOneArgProperties
-                { mapFn : ( ModuleName, String ) }
-            )
-        )
+taskWithFailAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
 taskWithFailAsWrap =
     { represents = "task"
     , wrap = taskFailingConstruct
@@ -9163,14 +9143,7 @@ taskWithFailAsWrap =
     }
 
 
-jsonDecoderWithSucceedAsWrap :
-    TypeProperties
-        (WrapperProperties
-            (EmptiableProperties
-                ConstructWithOneArgProperties
-                { mapFn : ( ModuleName, String ) }
-            )
-        )
+jsonDecoderWithSucceedAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
 jsonDecoderWithSucceedAsWrap =
     { represents = "json decoder"
     , wrap = jsonDecoderSucceedingConstruct
@@ -9205,7 +9178,7 @@ jsonDecoderFailingConstruct =
     }
 
 
-listCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (ConstructibleFromListProperties { mapFn : ( ModuleName, String ) }))))
+listCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (ConstructibleFromListProperties (MappableProperties {})))))
 listCollection =
     { represents = "list"
     , empty = listEmptyConstant
@@ -10119,7 +10092,7 @@ getValueWithNodeRange getValue expressionNode =
 
 
 wrapperAndThenChecks :
-    TypeProperties (WrapperProperties { otherProperties | mapFn : ( ModuleName, String ) })
+    TypeProperties (WrapperProperties (MappableProperties otherProperties))
     -> CheckInfo
     -> Maybe (Error {})
 wrapperAndThenChecks wrapper =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7924,7 +7924,7 @@ taskSequenceChecks =
 
 taskSequenceCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 taskSequenceCompositionChecks =
-    listOfMappableSequenceCompositionChecks taskWithSucceedAsWrap
+    wrapperOfMappableCompositionCheck ( listCollection, taskWithSucceedAsWrap )
 
 
 listSequenceOrFirstEmptyChecks :
@@ -8045,11 +8045,6 @@ listOfWrapperSequenceChecks wrapper =
                 Nothing ->
                     Nothing
         ]
-
-
-listOfMappableSequenceCompositionChecks : { otherProperties | mapFn : ( ModuleName, String ) } -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listOfMappableSequenceCompositionChecks mappable =
-    wrapperOfMappableCompositionCheck ( listCollection, mappable )
 
 
 {-| The sequence composition check

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4999,18 +4999,42 @@ stringJoinChecks =
 
 stringRepeatChecks : CheckInfo -> Maybe (Error {})
 stringRepeatChecks =
+    emptiableRepeatFlatChecks stringCollection
+
+
+{-| Checks for a repeat function that flattens the resulting list into the same type
+
+    repeatFlat -1 emptiable --> empty
+
+    repeatFlat n empty --> empty
+
+    repeatFlat 1 emptiable --> emptiable
+
+Examples of such functions:
+
+    String.Graphemes.repeat : Int -> String -> String
+    Animation.repeat : Int -> Animation.Step msg -> Animation.Step msg
+    applyTimes : Int -> (a -> a) -> a -> a
+
+-}
+emptiableRepeatFlatChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> CheckInfo -> Maybe (Error {})
+emptiableRepeatFlatChecks emptiable =
     firstThatConstructsJust
         [ \checkInfo ->
             case secondArg checkInfo of
-                Just stringArg ->
-                    if stringCollection.empty.is (extractInferResources checkInfo) stringArg then
+                Just emptiableArg ->
+                    if emptiable.empty.is (extractInferResources checkInfo) emptiableArg then
                         Just
                             (Rule.errorWithFix
-                                { message = "String.repeat with " ++ emptyStringAsString ++ " will result in " ++ emptyStringAsString
-                                , details = [ "You can replace this call by " ++ emptyStringAsString ++ "." ]
+                                { message = qualifiedToString checkInfo.fn ++ " with " ++ descriptionForIndefinite emptiable.empty.description ++ " will result in " ++ descriptionForDefinite "the given" emptiable.empty.description
+                                , details = [ "You can replace this call by " ++ descriptionForDefinite "the given" emptiable.empty.description ++ "." ]
                                 }
                                 checkInfo.fnRange
-                                [ Fix.replaceRangeBy checkInfo.parentRange emptyStringAsString ]
+                                (keepOnlyFix
+                                    { parentRange = checkInfo.parentRange
+                                    , keep = Node.range emptiableArg
+                                    }
+                                )
                             )
 
                     else
@@ -5026,8 +5050,8 @@ stringRepeatChecks =
                             case intValue of
                                 1 ->
                                     Just
-                                        (alwaysReturnsLastArgError "String.repeat 1"
-                                            { represents = "string to repeat" }
+                                        (alwaysReturnsLastArgError (qualifiedToString checkInfo.fn ++ " 1")
+                                            { represents = emptiable.represents ++ " to repeat" }
                                             checkInfo
                                         )
 
@@ -5037,7 +5061,7 @@ stringRepeatChecks =
                             callWithNonPositiveIntCanBeReplacedByCheck
                                 { int = intValue
                                 , intDescription = "length"
-                                , replacement = stringCollection.empty.asString
+                                , replacement = emptiable.empty.asString
                                 }
                                 checkInfo
                         ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5132,14 +5132,14 @@ maybeMapNChecks =
 maybeAndThenChecks : CheckInfo -> Maybe (Error {})
 maybeAndThenChecks =
     firstThatConstructsJust
-        [ wrapperAndThenChecks maybeWithJustAsWrap
-        , emptiableAndThenChecks maybeWithJustAsWrap
+        [ wrapperMapFlatChecks maybeWithJustAsWrap
+        , emptiableMapFlatChecks maybeWithJustAsWrap
         ]
 
 
 maybeAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 maybeAndThenCompositionChecks checkInfo =
-    wrapperAndThenCompositionChecks maybeWithJustAsWrap checkInfo
+    wrapperMapFlatCompositionChecks maybeWithJustAsWrap checkInfo
 
 
 
@@ -5205,7 +5205,7 @@ resultAndThenChecks : CheckInfo -> Maybe (Error {})
 resultAndThenChecks =
     firstThatConstructsJust
         [ unnecessaryCallOnEmptyCheck resultWithOkAsWrap
-        , wrapperAndThenChecks resultWithOkAsWrap
+        , wrapperMapFlatChecks resultWithOkAsWrap
         ]
 
 
@@ -5213,7 +5213,7 @@ resultAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndF
 resultAndThenCompositionChecks =
     firstThatConstructsJust
         [ unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
-        , wrapperAndThenCompositionChecks resultWithOkAsWrap
+        , wrapperMapFlatCompositionChecks resultWithOkAsWrap
         ]
 
 
@@ -5376,8 +5376,8 @@ listConcatMapChecks : CheckInfo -> Maybe (Error {})
 listConcatMapChecks =
     firstThatConstructsJust
         [ operationWithIdentityIsEquivalentToFnCheck Fn.List.concat
-        , emptiableAndThenChecks listCollection
-        , wrapperAndThenChecks listCollection
+        , emptiableMapFlatChecks listCollection
+        , wrapperMapFlatChecks listCollection
         ]
 
 
@@ -5876,7 +5876,7 @@ arrayToIndexedListMapCompositionCheck checkInfo =
 
 listConcatMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 listConcatMapCompositionChecks =
-    wrapperAndThenCompositionChecks listCollection
+    wrapperMapFlatCompositionChecks listCollection
 
 
 listMemberChecks : CheckInfo -> Maybe (Error {})
@@ -7941,7 +7941,7 @@ taskAndThenChecks : CheckInfo -> Maybe (Error {})
 taskAndThenChecks =
     firstThatConstructsJust
         [ unnecessaryCallOnEmptyCheck taskWithSucceedAsWrap
-        , wrapperAndThenChecks taskWithSucceedAsWrap
+        , wrapperMapFlatChecks taskWithSucceedAsWrap
         ]
 
 
@@ -7949,7 +7949,7 @@ taskAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 taskAndThenCompositionChecks =
     firstThatConstructsJust
         [ unnecessaryCompositionAfterEmptyCheck taskWithSucceedAsWrap
-        , wrapperAndThenCompositionChecks taskWithSucceedAsWrap
+        , wrapperMapFlatCompositionChecks taskWithSucceedAsWrap
         ]
 
 
@@ -7973,7 +7973,7 @@ taskOnErrorChecks : CheckInfo -> Maybe (Error {})
 taskOnErrorChecks =
     firstThatConstructsJust
         [ unnecessaryCallOnEmptyCheck taskWithFailAsWrap
-        , wrapperAndThenChecks taskWithFailAsWrap
+        , wrapperMapFlatChecks taskWithFailAsWrap
         ]
 
 
@@ -7981,7 +7981,7 @@ taskOnErrorCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 taskOnErrorCompositionChecks =
     firstThatConstructsJust
         [ unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap
-        , wrapperAndThenCompositionChecks taskWithFailAsWrap
+        , wrapperMapFlatCompositionChecks taskWithFailAsWrap
         ]
 
 
@@ -8393,7 +8393,7 @@ jsonDecodeAndThenChecks : CheckInfo -> Maybe (Error {})
 jsonDecodeAndThenChecks =
     firstThatConstructsJust
         [ unnecessaryCallOnEmptyCheck jsonDecoderWithSucceedAsWrap
-        , wrapperAndThenChecks jsonDecoderWithSucceedAsWrap
+        , wrapperMapFlatChecks jsonDecoderWithSucceedAsWrap
         ]
 
 
@@ -8401,7 +8401,7 @@ jsonDecodeAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfo
 jsonDecodeAndThenCompositionChecks =
     firstThatConstructsJust
         [ unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap
-        , wrapperAndThenCompositionChecks jsonDecoderWithSucceedAsWrap
+        , wrapperMapFlatCompositionChecks jsonDecoderWithSucceedAsWrap
         ]
 
 
@@ -8580,21 +8580,21 @@ randomMapCompositionChecks =
 randomAndThenChecks : CheckInfo -> Maybe (Error {})
 randomAndThenChecks =
     firstThatConstructsJust
-        [ wrapperAndThenChecks randomGeneratorWrapper
-        , nonEmptiableWrapperAndThenAlwaysChecks randomGeneratorWrapper
+        [ wrapperMapFlatChecks randomGeneratorWrapper
+        , nonEmptiableWrapperMapFlatAlwaysChecks randomGeneratorWrapper
         ]
 
 
 randomAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 randomAndThenCompositionChecks =
-    wrapperAndThenCompositionChecks randomGeneratorWrapper
+    wrapperMapFlatCompositionChecks randomGeneratorWrapper
 
 
-nonEmptiableWrapperAndThenAlwaysChecks :
+nonEmptiableWrapperMapFlatAlwaysChecks :
     TypeProperties (NonEmptiableProperties (WrapperProperties otherProperties))
     -> CheckInfo
     -> Maybe (Error {})
-nonEmptiableWrapperAndThenAlwaysChecks wrapper checkInfo =
+nonEmptiableWrapperMapFlatAlwaysChecks wrapper checkInfo =
     case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
         Just alwaysResult ->
             Just
@@ -8644,7 +8644,7 @@ type alias EmptiableProperties empty otherProperties =
 
 {-| Properties of a structure type that will always have data inside, for example a non-empty list, a `Test`, a `Benchmark` or a tree (but not a forest).
 
-This can be really valuable, for example when you want to know whether the function of a map or andThen will always be called.
+This can be really valuable, for example when you want to know whether the function of a map or mapFlat will always be called.
 
 The way this type is defined,
 it is impossible to have one type that has both `EmptiableProperties` and `NonEmptiableProperties`
@@ -9999,11 +9999,11 @@ mapAlwaysCompositionChecks wrapper checkInfo =
             Nothing
 
 
-emptiableAndThenChecks :
+emptiableMapFlatChecks :
     EmptiableProperties ConstantProperties otherProperties
     -> CheckInfo
     -> Maybe (Error {})
-emptiableAndThenChecks emptiable =
+emptiableMapFlatChecks emptiable =
     firstThatConstructsJust
         [ unnecessaryCallOnEmptyCheck emptiable
         , \checkInfo ->
@@ -10030,11 +10030,11 @@ getValueWithNodeRange getValue expressionNode =
         (getValue expressionNode)
 
 
-wrapperAndThenChecks :
+wrapperMapFlatChecks :
     TypeProperties (WrapperProperties (MappableProperties otherProperties))
     -> CheckInfo
     -> Maybe (Error {})
-wrapperAndThenChecks wrapper =
+wrapperMapFlatChecks wrapper =
     firstThatConstructsJust
         [ \checkInfo ->
             case secondArg checkInfo of
@@ -10094,19 +10094,19 @@ wrapperAndThenChecks wrapper =
         ]
 
 
-{-| `andThen f` on a wrapped value is equivalent to `f`
+{-| `mapFlat f` on a wrapped value is equivalent to `f`
 
-    andThen f << wrap --> f
+    mapFlat f << wrap --> f
 
 So for example
 
-    List.concat f << List.singleton --> f
+    List.concatMap f << List.singleton --> f
 
-Use in together with `wrapperAndThenChecks`
+Use in together with `wrapperMapFlatChecks`
 
 -}
-wrapperAndThenCompositionChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-wrapperAndThenCompositionChecks wrapper checkInfo =
+wrapperMapFlatCompositionChecks : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+wrapperMapFlatCompositionChecks wrapper checkInfo =
     case ( wrapper.wrap.fn == checkInfo.earlier.fn, checkInfo.later.args ) of
         ( True, (Node functionRange _) :: [] ) ->
             Just

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8016,27 +8016,31 @@ wrapperSequenceChecks wrapper =
                 Nothing ->
                     Nothing
         , \checkInfo ->
-            case AstHelpers.getListLiteral checkInfo.firstArg of
-                Just list ->
-                    case traverse (getValueWithNodeRange (wrapper.wrap.getValue checkInfo.lookupTable)) list of
-                        Just wraps ->
-                            Just
-                                (Rule.errorWithFix
-                                    { message = qualifiedToString checkInfo.fn ++ " on a list where each element is " ++ descriptionForIndefinite wrapper.wrap.description ++ " will result in " ++ qualifiedToString wrapper.wrap.fn ++ " on the values inside"
-                                    , details = [ "You can replace this call by " ++ qualifiedToString wrapper.wrap.fn ++ " on a list where each element is replaced by its value inside " ++ descriptionForDefinite "the" wrapper.wrap.description ++ "." ]
-                                    }
-                                    checkInfo.fnRange
-                                    (Fix.replaceRangeBy
+            case listCollection.elements.get (extractInferResources checkInfo) checkInfo.firstArg of
+                Just elements ->
+                    if elements.allKnown then
+                        case traverse (getValueWithNodeRange (wrapper.wrap.getValue checkInfo.lookupTable)) elements.known of
+                            Just wraps ->
+                                Just
+                                    (Rule.errorWithFix
+                                        { message = qualifiedToString checkInfo.fn ++ " on a list where each element is " ++ descriptionForIndefinite wrapper.wrap.description ++ " will result in " ++ qualifiedToString wrapper.wrap.fn ++ " on the values inside"
+                                        , details = [ "You can replace this call by " ++ qualifiedToString wrapper.wrap.fn ++ " on a list where each element is replaced by its value inside " ++ descriptionForDefinite "the" wrapper.wrap.description ++ "." ]
+                                        }
                                         checkInfo.fnRange
-                                        (qualifiedToString (qualify wrapper.wrap.fn checkInfo))
-                                        :: List.concatMap
-                                            (\wrap -> keepOnlyFix { parentRange = wrap.nodeRange, keep = Node.range wrap.value })
-                                            wraps
+                                        (Fix.replaceRangeBy
+                                            checkInfo.fnRange
+                                            (qualifiedToString (qualify wrapper.wrap.fn checkInfo))
+                                            :: List.concatMap
+                                                (\wrap -> keepOnlyFix { parentRange = wrap.nodeRange, keep = Node.range wrap.value })
+                                                wraps
+                                        )
                                     )
-                                )
 
-                        Nothing ->
-                            Nothing
+                            Nothing ->
+                                Nothing
+
+                    else
+                        Nothing
 
                 Nothing ->
                     Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -900,6 +900,21 @@ Destructuring using case expressions
     Array.append (Array.fromList [ a, b ]) (Array.fromList [ c, d ])
     --> Array.fromList [ a, b, c, d ]
 
+    Array.slice n n array
+    --> Array.empty
+
+    Array.slice n 0 array
+    --> Array.empty
+
+    Array.slice a z Array.empty
+    --> Array.empty
+
+    Array.slice 2 1 array
+    --> Array.empty
+
+    Array.slice -1 -2 array
+    --> Array.empty
+
     Array.get n Array.empty
     --> Nothing
 
@@ -2901,6 +2916,7 @@ functionCallChecks =
         , ( Fn.Array.append, ( 2, collectionUnionChecks { leftElementsStayOnTheLeft = True } arrayCollection ) )
         , ( Fn.Array.get, ( 2, getChecks arrayCollection ) )
         , ( Fn.Array.set, ( 3, setChecks arrayCollection ) )
+        , ( Fn.Array.slice, ( 3, collectionSliceChecks arrayCollection ) )
         , ( Fn.Array.foldl, ( 3, arrayFoldlChecks ) )
         , ( Fn.Array.foldr, ( 3, arrayFoldrChecks ) )
         , ( Fn.Set.map, ( 2, emptiableMapChecks setCollection ) )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4831,7 +4831,7 @@ stringSliceChecks =
                             if Normalize.areAllTheSame checkInfo checkInfo.firstArg [ endArg ] then
                                 Just
                                     (alwaysResultsInUnparenthesizedConstantError "String.slice with equal start and end index"
-                                        { replacement = \_ -> emptyStringAsString }
+                                        { replacement = stringCollection.empty.asString }
                                         checkInfo
                                     )
 
@@ -4846,7 +4846,7 @@ stringSliceChecks =
                                                 0 ->
                                                     Just
                                                         (alwaysResultsInUnparenthesizedConstantError "String.slice with end index 0"
-                                                            { replacement = \_ -> emptyStringAsString }
+                                                            { replacement = stringCollection.empty.asString }
                                                             checkInfo
                                                         )
 
@@ -4859,14 +4859,14 @@ stringSliceChecks =
                                                         if startInt >= 0 && endInt >= 0 then
                                                             Just
                                                                 (alwaysResultsInUnparenthesizedConstantError "String.slice with a start index greater than the end index"
-                                                                    { replacement = \_ -> emptyStringAsString }
+                                                                    { replacement = stringCollection.empty.asString }
                                                                     checkInfo
                                                                 )
 
                                                         else if startInt <= -1 && endInt <= -1 then
                                                             Just
                                                                 (alwaysResultsInUnparenthesizedConstantError "String.slice with a negative start index closer to the right than the negative end index"
-                                                                    { replacement = \_ -> emptyStringAsString }
+                                                                    { replacement = stringCollection.empty.asString }
                                                                     checkInfo
                                                                 )
 
@@ -4901,7 +4901,7 @@ stringLeftChecks =
                     callWithNonPositiveIntCanBeReplacedByCheck
                         { int = length
                         , intDescription = "length"
-                        , replacement = \_ -> emptyStringAsString
+                        , replacement = stringCollection.empty.asString
                         }
                         checkInfo
 
@@ -4961,7 +4961,7 @@ stringRightChecks =
                     callWithNonPositiveIntCanBeReplacedByCheck
                         { int = length
                         , intDescription = "length"
-                        , replacement = \_ -> emptyStringAsString
+                        , replacement = stringCollection.empty.asString
                         }
                         checkInfo
 
@@ -5037,7 +5037,7 @@ stringRepeatChecks =
                             callWithNonPositiveIntCanBeReplacedByCheck
                                 { int = intValue
                                 , intDescription = "length"
-                                , replacement = \_ -> emptyStringAsString
+                                , replacement = stringCollection.empty.asString
                                 }
                                 checkInfo
                         ]
@@ -6635,7 +6635,7 @@ listRangeChecks checkInfo =
                         Just
                             (resultsInConstantError
                                 (qualifiedToString checkInfo.fn ++ " with a start index greater than the end index")
-                                (\_ -> "[]")
+                                listCollection.empty.asString
                                 checkInfo
                             )
 
@@ -7143,7 +7143,7 @@ listTakeChecks =
                     callWithNonPositiveIntCanBeReplacedByCheck
                         { int = length
                         , intDescription = "length"
-                        , replacement = \_ -> "[]"
+                        , replacement = listCollection.empty.asString
                         }
                         checkInfo
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5348,7 +5348,7 @@ operationWithIdentityIsEquivalentToFnCheck replacementFn checkInfo =
                 }
                 checkInfo.fnRange
                 [ Fix.replaceRangeBy
-                    { start = checkInfo.fnRange.start, end = (Node.range checkInfo.firstArg).end }
+                    (Range.combine [ checkInfo.fnRange, Node.range checkInfo.firstArg ])
                     (qualifiedToString (qualify replacementFn checkInfo))
                 ]
             )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5089,7 +5089,7 @@ stringReplaceChecks =
                                     Just
                                         (alwaysReturnsLastArgError
                                             (qualifiedToString checkInfo.fn ++ " where the pattern to replace and the replacement are equal")
-                                            { represents = "string" }
+                                            stringCollection
                                             checkInfo
                                         )
 
@@ -7118,7 +7118,7 @@ listSortByChecks =
                     Just
                         (alwaysReturnsLastArgError
                             (qualifiedToString checkInfo.fn ++ " (always a)")
-                            { represents = "list" }
+                            listCollection
                             checkInfo
                         )
 
@@ -7154,7 +7154,7 @@ listSortWithChecks =
                         fixToIdentity =
                             alwaysReturnsLastArgError
                                 (qualifiedToString checkInfo.fn ++ " with a comparison that always returns " ++ AstHelpers.orderToString order)
-                                { represents = "list" }
+                                listCollection
                                 checkInfo
                     in
                     case order of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7400,7 +7400,7 @@ wrapperMapNChecks wrapper checkInfo =
         Result.map3 f errorOrOkWeDoNotKnow (Err x) thirdResult
         --> Result.map2 f errorOrOkWeDoNotKnow (Err x)
 
-This is pretty similar to `sequenceOrFirstEmptyChecks` where we look at arguments instead of list elements.
+This is pretty similar to `listSequenceOrFirstEmptyChecks` where we look at arguments instead of list elements.
 
 -}
 mapNOrFirstEmptyConstructionChecks :
@@ -7918,7 +7918,7 @@ taskSequenceChecks : CheckInfo -> Maybe (Error {})
 taskSequenceChecks =
     firstThatConstructsJust
         [ listOfWrapperSequenceChecks taskWithSucceedAsWrap
-        , sequenceOrFirstEmptyChecks taskWithSucceedAsWrap
+        , listSequenceOrFirstEmptyChecks taskWithSucceedAsWrap
         ]
 
 
@@ -7927,11 +7927,11 @@ taskSequenceCompositionChecks =
     mappableSequenceCompositionChecks taskWithSucceedAsWrap
 
 
-sequenceOrFirstEmptyChecks :
+listSequenceOrFirstEmptyChecks :
     WrapperProperties (EmptiableProperties (TypeSubsetProperties empty) otherProperties)
     -> CheckInfo
     -> Maybe (Error {})
-sequenceOrFirstEmptyChecks emptiable checkInfo =
+listSequenceOrFirstEmptyChecks emptiable checkInfo =
     case AstHelpers.getListLiteral checkInfo.firstArg of
         Just list ->
             firstThatConstructsJust

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5138,6 +5138,19 @@ maybeMapNChecks =
         ]
 
 
+maybeAndThenChecks : CheckInfo -> Maybe (Error {})
+maybeAndThenChecks =
+    firstThatConstructsJust
+        [ wrapperAndThenChecks maybeWithJustAsWrap
+        , emptiableAndThenChecks maybeWithJustAsWrap
+        ]
+
+
+maybeAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+maybeAndThenCompositionChecks checkInfo =
+    wrapperAndThenCompositionChecks maybeWithJustAsWrap checkInfo
+
+
 
 -- RESULT FUNCTIONS
 
@@ -5195,6 +5208,54 @@ resultMapErrorCompositionChecks =
         [ wrapToMapCompositionChecks resultWithErrAsWrap
         , unnecessaryCompositionAfterEmptyCheck resultWithErrAsWrap
         ]
+
+
+resultAndThenChecks : CheckInfo -> Maybe (Error {})
+resultAndThenChecks =
+    firstThatConstructsJust
+        [ unnecessaryCallOnEmptyCheck resultWithOkAsWrap
+        , wrapperAndThenChecks resultWithOkAsWrap
+        ]
+
+
+resultAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+resultAndThenCompositionChecks =
+    firstThatConstructsJust
+        [ unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
+        , wrapperAndThenCompositionChecks resultWithOkAsWrap
+        ]
+
+
+resultToMaybeCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
+resultToMaybeCompositionChecks =
+    firstThatConstructsJust
+        [ onWrapAlwaysReturnsJustIncomingCompositionCheck resultWithOkAsWrap
+        , \checkInfo ->
+            case checkInfo.earlier.fn of
+                ( [ "Result" ], "Err" ) ->
+                    Just
+                        { info =
+                            { message = qualifiedToString Fn.Result.toMaybe ++ " on an error will result in Nothing"
+                            , details = [ "You can replace this call by always Nothing." ]
+                            }
+                        , fix =
+                            compositionReplaceByFix
+                                (qualifiedToString (qualify Fn.Basics.always checkInfo)
+                                    ++ " "
+                                    ++ qualifiedToString (qualify Fn.Maybe.nothingVariant checkInfo)
+                                )
+                                checkInfo
+                        }
+
+                _ ->
+                    Nothing
+        ]
+
+
+resultFromMaybeChecks : CheckInfo -> Maybe (Error {})
+resultFromMaybeChecks =
+    fromMaybeChecks
+        { onNothingFn = Fn.Result.errVariant, onJustFn = Fn.Result.okVariant }
 
 
 
@@ -10191,35 +10252,6 @@ wrapperAndThenCompositionChecks wrapper checkInfo =
             Nothing
 
 
-maybeAndThenChecks : CheckInfo -> Maybe (Error {})
-maybeAndThenChecks =
-    firstThatConstructsJust
-        [ wrapperAndThenChecks maybeWithJustAsWrap
-        , emptiableAndThenChecks maybeWithJustAsWrap
-        ]
-
-
-maybeAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-maybeAndThenCompositionChecks checkInfo =
-    wrapperAndThenCompositionChecks maybeWithJustAsWrap checkInfo
-
-
-resultAndThenChecks : CheckInfo -> Maybe (Error {})
-resultAndThenChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck resultWithOkAsWrap
-        , wrapperAndThenChecks resultWithOkAsWrap
-        ]
-
-
-resultAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-resultAndThenCompositionChecks =
-    firstThatConstructsJust
-        [ unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
-        , wrapperAndThenCompositionChecks resultWithOkAsWrap
-        ]
-
-
 withDefaultChecks :
     WrapperProperties (EmptiableProperties (TypeSubsetProperties empty) otherProperties)
     -> CheckInfo
@@ -10272,38 +10304,6 @@ unwrapToMaybeChecks emptiableWrapper =
             { resultAsString = \res -> qualifiedToString (qualify Fn.Maybe.nothingVariant res) }
             emptiableWrapper
         ]
-
-
-resultToMaybeCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-resultToMaybeCompositionChecks =
-    firstThatConstructsJust
-        [ onWrapAlwaysReturnsJustIncomingCompositionCheck resultWithOkAsWrap
-        , \checkInfo ->
-            case checkInfo.earlier.fn of
-                ( [ "Result" ], "Err" ) ->
-                    Just
-                        { info =
-                            { message = qualifiedToString Fn.Result.toMaybe ++ " on an error will result in Nothing"
-                            , details = [ "You can replace this call by always Nothing." ]
-                            }
-                        , fix =
-                            compositionReplaceByFix
-                                (qualifiedToString (qualify Fn.Basics.always checkInfo)
-                                    ++ " "
-                                    ++ qualifiedToString (qualify Fn.Maybe.nothingVariant checkInfo)
-                                )
-                                checkInfo
-                        }
-
-                _ ->
-                    Nothing
-        ]
-
-
-resultFromMaybeChecks : CheckInfo -> Maybe (Error {})
-resultFromMaybeChecks =
-    fromMaybeChecks
-        { onNothingFn = Fn.Result.errVariant, onJustFn = Fn.Result.okVariant }
 
 
 fromMaybeChecks : { onNothingFn : ( ModuleName, String ), onJustFn : ( ModuleName, String ) } -> CheckInfo -> Maybe (Error {})

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -697,8 +697,8 @@ getTuple2Literal expressionNode =
             Nothing
 
 
-getTuple2 : Node Expression -> ModuleNameLookupTable -> Maybe { first : Node Expression, second : Node Expression }
-getTuple2 expressionNode lookupTable =
+getTuple2 : ModuleNameLookupTable -> Node Expression -> Maybe { first : Node Expression, second : Node Expression }
+getTuple2 lookupTable expressionNode =
     case removeParens expressionNode of
         Node _ (Expression.TupledExpression (first :: second :: [])) ->
             Just { first = first, second = second }

--- a/tests/Simplify/ArrayTest.elm
+++ b/tests/Simplify/ArrayTest.elm
@@ -21,6 +21,7 @@ all =
         , arrayAppendTests
         , arrayGetTests
         , arraySetTests
+        , arraySliceTests
         , arrayFoldlTests
         , arrayFoldrTests
         ]
@@ -2409,6 +2410,173 @@ import Array
 a = (Array.fromList [ b, c, d ])
 """
                         ]
+        ]
+
+
+arraySliceTests : Test
+arraySliceTests =
+    describe "Array.slice"
+        [ test "should not report Array.slice that contains variables or expressions" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice b c
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should not report Array.slice 0 n" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice 0
+b = Array.slice 0 n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Array.slice b 0 by always Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice b 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.slice with end index 0 will always result in Array.empty"
+                            , details = [ "You can replace this call by always Array.empty." ]
+                            , under = "Array.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always Array.empty
+"""
+                        ]
+        , test "should replace Array.slice b 0 str by Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice b 0 str
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.slice with end index 0 will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.empty
+"""
+                        ]
+        , test "should replace Array.slice n n by always Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice n n
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.slice with equal start and end index will always result in Array.empty"
+                            , details = [ "You can replace this call by always Array.empty." ]
+                            , under = "Array.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always Array.empty
+"""
+                        ]
+        , test "should replace Array.slice n n str by Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice n n str
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.slice with equal start and end index will always result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.empty
+"""
+                        ]
+        , test "should replace Array.slice a z Array.empty by Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice a z Array.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.slice on Array.empty will result in Array.empty"
+                            , details = [ "You can replace this call by Array.empty." ]
+                            , under = "Array.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = Array.empty
+"""
+                        ]
+        , test "should replace Array.slice with natural start >= natural end by always Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice 2 1
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.slice with a start index greater than the end index will always result in Array.empty"
+                            , details = [ "You can replace this call by always Array.empty." ]
+                            , under = "Array.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always Array.empty
+"""
+                        ]
+        , test "should replace Array.slice with negative start >= negative end by always Array.empty" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice -1 -2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.slice with a negative start index closer to the right than the negative end index will always result in Array.empty"
+                            , details = [ "You can replace this call by always Array.empty." ]
+                            , under = "Array.slice"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = always Array.empty
+"""
+                        ]
+        , test "should not report Array.slice with negative start, natural end" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice -1 2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        []
+        , test "should not report Array.slice with natural start, negative end" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.slice 1 -2
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        []
         ]
 
 

--- a/tests/Simplify/DuplicatedIfsTest.elm
+++ b/tests/Simplify/DuplicatedIfsTest.elm
@@ -5,12 +5,6 @@ import Test exposing (Test, describe, test)
 import TestHelpers exposing (ruleWithDefaults)
 
 
-sameThingOnBothSidesDetails : String -> List String
-sameThingOnBothSidesDetails value =
-    [ "Based on the values and/or the context, we can determine the result. You can replace this operation by " ++ value ++ "."
-    ]
-
-
 all : Test
 all =
     describe "Duplicated if conditions"
@@ -392,7 +386,7 @@ a =
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "x == 1"
                             }
                             |> Review.Test.atExactly { start = { row = 4, column = 8 }, end = { row = 4, column = 14 } }
@@ -423,7 +417,7 @@ a =
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "x == \"b\""
                             }
                             |> Review.Test.atExactly { start = { row = 4, column = 8 }, end = { row = 4, column = 16 } }
@@ -454,7 +448,7 @@ a =
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "item.name == \"Sulfuras, Hand of Ragnaros\""
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -484,7 +478,7 @@ a =
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "x == 2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -582,7 +576,7 @@ a =
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(/=) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "x /= 1"
                             }
                             |> Review.Test.atExactly { start = { row = 5, column = 11 }, end = { row = 5, column = 17 } }
@@ -611,7 +605,7 @@ a =
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "x == 1"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -719,7 +713,7 @@ a =
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "x == 1"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -5,12 +5,6 @@ import Test exposing (Test, describe, test)
 import TestHelpers exposing (ruleExpectingNaN, ruleWithDefaults)
 
 
-sameThingOnBothSidesDetails : String -> List String
-sameThingOnBothSidesDetails value =
-    [ "Based on the values and/or the context, we can determine the result. You can replace this operation by " ++ value ++ "."
-    ]
-
-
 all : Test
 all =
     describe "(==)"
@@ -170,7 +164,7 @@ a = x == x
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "x == x"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -193,7 +187,7 @@ a = x == (x)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "x == (x)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -209,7 +203,7 @@ a = x /= x
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(/=) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "x /= x"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -225,7 +219,7 @@ a = List.map (\\a -> a.value) things == List.map (\\a -> a.value) things
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "List.map (\\a -> a.value) things == List.map (\\a -> a.value) things"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -241,7 +235,7 @@ a = (f b) == (f <| b)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(f b) == (f <| b)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -257,7 +251,7 @@ a = (f b c) == (f b <| c)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(f b c) == (f b <| c)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -273,7 +267,7 @@ a = (f b) == (b |> f)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(f b) == (b |> f)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -289,7 +283,7 @@ a = (f b c) == (c |> f b)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(f b c) == (c |> f b)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -305,7 +299,7 @@ a = (f b c) == (c |> (b |> f))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(f b c) == (c |> (b |> f))"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -321,7 +315,7 @@ a = (let x = 1 in f b c) == (c |> (let x = 1 in f b))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(let x = 1 in f b c) == (c |> (let x = 1 in f b))"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -337,7 +331,7 @@ a = (if cond then f b c else g d c) == (c |> (if cond then f b else g d))
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(if cond then f b c else g d c) == (c |> (if cond then f b else g d))"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -361,7 +355,7 @@ a = (case x of
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = """(case x of
         X -> f b c
         Y -> g d c
@@ -385,7 +379,7 @@ a = (b.c) == (.c b)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(b.c) == (.c b)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -401,7 +395,7 @@ a = (b.c) == (.c <| b)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(b.c) == (.c <| b)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -417,7 +411,7 @@ a = "a" == "b"
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "\"a\" == \"b\""
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -433,7 +427,7 @@ a = 'a' == 'b'
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "'a' == 'b'"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -449,7 +443,7 @@ a = "a" /= "b"
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(/=) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "\"a\" /= \"b\""
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -465,7 +459,7 @@ a = 1 == 2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "1 == 2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -481,7 +475,7 @@ a = 1 == 2.0
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "1 == 2.0"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -497,7 +491,7 @@ a = 1.0 == 2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "1.0 == 2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -513,7 +507,7 @@ a = 0x10 == 2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "0x10 == 2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -529,7 +523,7 @@ a = 1 + 3 == 2 + 5
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "1 + 3 == 2 + 5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -545,7 +539,7 @@ a = 1 - 3 == 2 - 5
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "1 - 3 == 2 - 5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -561,7 +555,7 @@ a = 2 * 3 == 2 * 5
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "2 * 3 == 2 * 5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -577,7 +571,7 @@ a = 1 / 3 == 2 / 5
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "1 / 3 == 2 / 5"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -593,7 +587,7 @@ a = () == x
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "() == x"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -609,7 +603,7 @@ a = x == ()
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "x == ()"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -625,7 +619,7 @@ a = [ 1 ] == [ 1, 1 ]
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "[ 1 ] == [ 1, 1 ]"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -641,7 +635,7 @@ a = [ 1, 2 ] == [ 1, 1 ]
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "[ 1, 2 ] == [ 1, 1 ]"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -657,7 +651,7 @@ a = [ 1, 2 - 1 ] == [ 1, 1 ]
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "[ 1, 2 - 1 ] == [ 1, 1 ]"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -673,7 +667,7 @@ a = (1) == (2)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "(1) == (2)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -689,7 +683,7 @@ a = ( 1, 2 ) == ( 1, 1 )
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "( 1, 2 ) == ( 1, 1 )"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -705,7 +699,7 @@ a = { a = 1, b = 2 } == { b = 1, a = 1 }
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "{ a = 1, b = 2 } == { b = 1, a = 1 }"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -721,7 +715,7 @@ a = { x | a = 1 } == { x | a = 2 }
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "{ x | a = 1 } == { x | a = 2 }"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -737,7 +731,7 @@ a = { x | a = 1 } == { x | a = 1 }
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "{ x | a = 1 } == { x | a = 1 }"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -760,7 +754,7 @@ a = { x | a = 1 } == { y | a = 2 }
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "{ x | a = 1 } == { y | a = 2 }"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -801,7 +795,7 @@ b = 1
                         [ ( "A"
                           , [ Review.Test.error
                                 { message = "(==) comparison will result in True"
-                                , details = sameThingOnBothSidesDetails "True"
+                                , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                                 , under = "B.b == b"
                                 }
                                 |> Review.Test.whenFixed """module A exposing (..)
@@ -821,7 +815,7 @@ a = List.map fn 1 == map fn (2 - 1)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "List.map fn 1 == map fn (2 - 1)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -846,7 +840,7 @@ a = (if 1 then 2 else 3) == (if 2 - 1 then 3 - 1 else 4 - 1)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(if 1 then 2 else 3) == (if 2 - 1 then 3 - 1 else 4 - 1)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -869,7 +863,7 @@ a = -1 == -(2 - 1)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "-1 == -(2 - 1)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -885,7 +879,7 @@ a = ({ a = 1 }).a == ({ a = 2 - 1 }).a
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "({ a = 1 }).a == ({ a = 2 - 1 }).a"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -919,7 +913,7 @@ a = (1 |> fn) == (2 - 1 |> fn)
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(==) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "(1 |> fn) == (2 - 1 |> fn)"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -886,8 +886,8 @@ a = ({ a = 1 }).a == ({ a = 2 - 1 }).a
 a = True
 """
                         , Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".a"
                             }
                             |> Review.Test.atExactly { start = { row = 2, column = 37 }, end = { row = 2, column = 39 } }
@@ -895,8 +895,8 @@ a = True
 a = ({ a = 1 }).a == (2 - 1)
 """
                         , Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".a"
                             }
                             |> Review.Test.atExactly { start = { row = 2, column = 16 }, end = { row = 2, column = 18 } }
@@ -928,8 +928,8 @@ a = ({ a = 1 }).a == ({ a = 1 }).b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".a"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/JsonDecodeTest.elm
+++ b/tests/Simplify/JsonDecodeTest.elm
@@ -716,8 +716,8 @@ a = Json.Decode.oneOf [ x ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary oneOf"
-                            , details = [ "There is only a single element in the list of elements to try out." ]
+                            { message = "Json.Decode.oneOf on a singleton list will result in the value inside"
+                            , details = [ "You can replace this call by the value inside the singleton list." ]
                             , under = "Json.Decode.oneOf"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -6371,7 +6371,7 @@ a = List.sortBy (always b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortBy (always a) will always return the same given list"
+                            { message = "List.sortBy with a function that always returns the same constant will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortBy"
                             }
@@ -6387,7 +6387,7 @@ a = List.sortBy (always b) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortBy (always a) will always return the same given list"
+                            { message = "List.sortBy with a function that always returns the same constant will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.sortBy"
                             }
@@ -6403,7 +6403,7 @@ a = List.sortBy (\\_ -> b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortBy (always a) will always return the same given list"
+                            { message = "List.sortBy with a function that always returns the same constant will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortBy"
                             }
@@ -6419,7 +6419,7 @@ a = List.sortBy (\\_ -> b) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortBy (always a) will always return the same given list"
+                            { message = "List.sortBy with a function that always returns the same constant will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.sortBy"
                             }

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -2708,15 +2708,15 @@ a = List.filterMap identity (List.map f x)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.filterMap identity can be combined using List.filterMap"
-                            , details = [ "List.filterMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.map, then List.filterMap with an identity function can be combined into List.filterMap"
+                            , details = [ "You can replace this call by List.filterMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.filterMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (List.filterMap f x)
 """
                         ]
-        , test "should replace List.filterMap identity <| List.map f <| x by (List.filterMap f <| x)" <|
+        , test "should replace List.filterMap identity <| List.map f <| x by List.filterMap f <| x" <|
             \() ->
                 """module A exposing (..)
 a = List.filterMap identity <| List.map f <| x
@@ -2724,15 +2724,15 @@ a = List.filterMap identity <| List.map f <| x
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.filterMap identity can be combined using List.filterMap"
-                            , details = [ "List.filterMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.map, then List.filterMap with an identity function can be combined into List.filterMap"
+                            , details = [ "You can replace this call by List.filterMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.filterMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (List.filterMap f <| x)
+a = List.filterMap f <| x
 """
                         ]
-        , test "should replace x |> List.map f |> List.filterMap identity by (x |> List.filterMap f)" <|
+        , test "should replace x |> List.map f |> List.filterMap identity by x |> List.filterMap f" <|
             \() ->
                 """module A exposing (..)
 a = x |> List.map f |> List.filterMap identity
@@ -2740,12 +2740,12 @@ a = x |> List.map f |> List.filterMap identity
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.filterMap identity can be combined using List.filterMap"
-                            , details = [ "List.filterMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.map, then List.filterMap with an identity function can be combined into List.filterMap"
+                            , details = [ "You can replace this call by List.filterMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.filterMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = (x |> List.filterMap f)
+a = x |> List.filterMap f
 """
                         ]
         , test "should replace List.map f >> List.filterMap identity by List.filterMap f" <|
@@ -2756,8 +2756,8 @@ a = List.map f >> List.filterMap identity
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.filterMap identity can be combined using List.filterMap"
-                            , details = [ "List.filterMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.map, then List.filterMap with an identity function can be combined into List.filterMap"
+                            , details = [ "You can replace this composition by List.filterMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.filterMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2795,8 +2795,8 @@ a = List.filterMap identity << List.map f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.map and List.filterMap identity can be combined using List.filterMap"
-                            , details = [ "List.filterMap is meant for this exact purpose and will also be faster." ]
+                            { message = "List.map, then List.filterMap with an identity function can be combined into List.filterMap"
+                            , details = [ "You can replace this composition by List.filterMap with the same arguments given to List.map which is meant for this exact purpose." ]
                             , under = "List.filterMap"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1214,7 +1214,7 @@ a = List.tail (List.singleton b)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.tail on a list with a single element will result in Just []"
+                            { message = "List.tail on a singleton list will result in Just []"
                             , details = [ "You can replace this call by Just []." ]
                             , under = "List.tail"
                             }
@@ -1230,7 +1230,7 @@ a = List.tail <| List.singleton b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.tail on a list with a single element will result in Just []"
+                            { message = "List.tail on a singleton list will result in Just []"
                             , details = [ "You can replace this call by Just []." ]
                             , under = "List.tail"
                             }
@@ -1246,7 +1246,7 @@ a = List.singleton b |> List.tail
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.tail on a list with a single element will result in Just []"
+                            { message = "List.tail on a singleton list will result in Just []"
                             , details = [ "You can replace this call by Just []." ]
                             , under = "List.tail"
                             }
@@ -1262,7 +1262,7 @@ a = List.tail [ b ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.tail on a list with a single element will result in Just []"
+                            { message = "List.tail on a singleton list will result in Just []"
                             , details = [ "You can replace this call by Just []." ]
                             , under = "List.tail"
                             }

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -6590,7 +6590,7 @@ a = List.sortWith (always (always GT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> GT) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns GT will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -6606,7 +6606,7 @@ a = List.sortWith (always (always GT)) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> GT) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns GT will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.sortWith"
                             }
@@ -6622,7 +6622,7 @@ a = List.sortWith (\\_ -> (always GT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> GT) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns GT will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -6638,7 +6638,7 @@ a = List.sortWith (\\_ _ -> GT)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> GT) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns GT will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -6654,7 +6654,7 @@ a = List.sortWith (always (\\_ -> GT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> GT) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns GT will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -6670,7 +6670,7 @@ a = List.sortWith (always (always EQ))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> EQ) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns EQ will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -6686,7 +6686,7 @@ a = List.sortWith (always (always EQ)) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> EQ) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns EQ will always return the same given list"
                             , details = [ "You can replace this call by the list itself." ]
                             , under = "List.sortWith"
                             }
@@ -6702,7 +6702,7 @@ a = List.sortWith (\\_ -> (always EQ))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> EQ) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns EQ will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -6718,7 +6718,7 @@ a = List.sortWith (\\_ _ -> EQ)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> EQ) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns EQ will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -6734,7 +6734,7 @@ a = List.sortWith (always (\\_ -> EQ))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> EQ) will always return the same given list"
+                            { message = "List.sortWith with a comparison that always returns EQ will always return the same given list"
                             , details = [ "You can replace this call by identity." ]
                             , under = "List.sortWith"
                             }
@@ -6750,7 +6750,7 @@ a = List.sortWith (always (always LT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> LT) is the same as List.reverse"
+                            { message = "List.sortWith with a comparison that always returns LT is the same as List.reverse"
                             , details = [ "You can replace this call by List.reverse." ]
                             , under = "List.sortWith"
                             }
@@ -6766,7 +6766,7 @@ a = List.sortWith (always (always LT)) list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> LT) is the same as List.reverse"
+                            { message = "List.sortWith with a comparison that always returns LT is the same as List.reverse"
                             , details = [ "You can replace this call by List.reverse." ]
                             , under = "List.sortWith"
                             }
@@ -6782,7 +6782,7 @@ a = List.sortWith (always (always LT)) <| list
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> LT) is the same as List.reverse"
+                            { message = "List.sortWith with a comparison that always returns LT is the same as List.reverse"
                             , details = [ "You can replace this call by List.reverse." ]
                             , under = "List.sortWith"
                             }
@@ -6798,7 +6798,7 @@ a = list |> List.sortWith (always (always LT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> LT) is the same as List.reverse"
+                            { message = "List.sortWith with a comparison that always returns LT is the same as List.reverse"
                             , details = [ "You can replace this call by List.reverse." ]
                             , under = "List.sortWith"
                             }
@@ -6814,7 +6814,7 @@ a = List.sortWith (\\_ -> (always LT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> LT) is the same as List.reverse"
+                            { message = "List.sortWith with a comparison that always returns LT is the same as List.reverse"
                             , details = [ "You can replace this call by List.reverse." ]
                             , under = "List.sortWith"
                             }
@@ -6830,7 +6830,7 @@ a = List.sortWith (\\_ _ -> LT)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> LT) is the same as List.reverse"
+                            { message = "List.sortWith with a comparison that always returns LT is the same as List.reverse"
                             , details = [ "You can replace this call by List.reverse." ]
                             , under = "List.sortWith"
                             }
@@ -6846,7 +6846,7 @@ a = List.sortWith (always (\\_ -> LT))
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "List.sortWith (\\_ _ -> LT) is the same as List.reverse"
+                            { message = "List.sortWith with a comparison that always returns LT is the same as List.reverse"
                             , details = [ "You can replace this call by List.reverse." ]
                             , under = "List.sortWith"
                             }

--- a/tests/Simplify/NumberTest.elm
+++ b/tests/Simplify/NumberTest.elm
@@ -5,12 +5,6 @@ import Test exposing (Test, describe, test)
 import TestHelpers exposing (ruleExpectingNaN, ruleWithDefaults)
 
 
-sameThingOnBothSidesDetails : String -> List String
-sameThingOnBothSidesDetails value =
-    [ "Based on the values and/or the context, we can determine the result. You can replace this operation by " ++ value ++ "."
-    ]
-
-
 all : Test
 all =
     describe "Number tests"
@@ -877,7 +871,7 @@ a = 1 < 2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(<) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "1 < 2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -893,7 +887,7 @@ a = 1 < 2 + 3
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(<) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "1 < 2 + 3"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -909,7 +903,7 @@ a = 2 < 1
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(<) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "2 < 1"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -925,7 +919,7 @@ a = 1 > 2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(>) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "1 > 2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -941,7 +935,7 @@ a = 1 >= 2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(>=) comparison will result in False"
-                            , details = sameThingOnBothSidesDetails "False"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by False." ]
                             , under = "1 >= 2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -957,7 +951,7 @@ a = 1 <= 2
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "(<=) comparison will result in True"
-                            , details = sameThingOnBothSidesDetails "True"
+                            , details = [ "Based on the values and/or the context, we can determine the result. You can replace this operation by True." ]
                             , under = "1 <= 2"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/ParserTest.elm
+++ b/tests/Simplify/ParserTest.elm
@@ -29,8 +29,8 @@ a = Parser.oneOf [ x ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary oneOf"
-                            , details = [ "There is only a single element in the list of elements to try out." ]
+                            { message = "Parser.oneOf on a singleton list will result in the value inside"
+                            , details = [ "You can replace this call by the value inside the singleton list." ]
                             , under = "Parser.oneOf"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -47,8 +47,8 @@ a = Parser.Advanced.oneOf [ x ]
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Unnecessary oneOf"
-                            , details = [ "There is only a single element in the list of elements to try out." ]
+                            { message = "Parser.Advanced.oneOf on a singleton list will result in the value inside"
+                            , details = [ "You can replace this call by the value inside the singleton list." ]
                             , under = "Parser.Advanced.oneOf"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/RecordAccessTest.elm
+++ b/tests/Simplify/RecordAccessTest.elm
@@ -288,6 +288,54 @@ a = { d | b = 3 } |> .c
 a = d.c
 """
                         ]
+        , test "should replace constructing record composition into field access function by contructing that field's value" <|
+            \() ->
+                """module A exposing (..)
+a = .b << (\\x -> { b = f <| x })
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (\\x -> (f <| x))
+"""
+                        ]
+        , test "should replace constructing record update composition into field access function by contructing the updated field" <|
+            \() ->
+                """module A exposing (..)
+a = .d << (\\x -> { b | d = f <| x, c = 1 })
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".d"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (\\x -> (f <| x))
+"""
+                        ]
+        , test "should replace constructing record update composition into unrelated field access function by contructing the unchanged record" <|
+            \() ->
+                """module A exposing (..)
+a = .e << (\\x -> { x | b = y })
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
+                            , under = ".e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (\\x -> x.e)
+"""
+                        ]
         , test "should simplify record accesses for let/in expressions" <|
             \() ->
                 """module A exposing (..)

--- a/tests/Simplify/RecordAccessTest.elm
+++ b/tests/Simplify/RecordAccessTest.elm
@@ -17,8 +17,72 @@ a = { b = 3 }.b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 3
+"""
+                        ]
+        , test "should simplify record accesses for explicit records (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = .b { b = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 3
+"""
+                        ]
+        , test "should simplify record accesses for explicit records (using access function application with extra argument)" <|
+            \() ->
+                """module A exposing (..)
+a = .b { b = f } extraArgument
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = f extraArgument
+"""
+                        ]
+        , test "should simplify record accesses for explicit records (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = .b <| { b = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = 3
+"""
+                        ]
+        , test "should simplify record accesses for explicit records (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = { b = 3 } |> .b
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -33,8 +97,8 @@ a = { b = f n }.b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -49,8 +113,8 @@ a = (({ b = 3 })).b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -72,8 +136,8 @@ a = foo { d | b = f x y }.b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -88,12 +152,76 @@ a = foo (({ d | b = f x y })).b
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = foo (f x y)
+"""
+                        ]
+        , test "should simplify record accesses for record updates (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = foo <| .b { d | b = f x y }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = foo <| (f x y)
+"""
+                        ]
+        , test "should simplify record accesses for record updates (using access function application with extra argument)" <|
+            \() ->
+                """module A exposing (..)
+a = foo <| .b { d | b = f x y } extraArgument
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = foo <| (f x y) extraArgument
+"""
+                        ]
+        , test "should simplify record accesses for record updates (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = foo <| .b <| { d | b = f x y }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = foo <| (f x y)
+"""
+                        ]
+        , test "should simplify record accesses for record updates (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = { d | b = f x y } |> .b |> foo
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
+                            , under = ".b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (f x y) |> foo
 """
                         ]
         , test "should simplify record accesses for record updates if it can't find the field" <|
@@ -104,8 +232,56 @@ a = { d | b = 3 }.c
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of an unrelated record update can be simplified to just the original field's value." ]
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
+                            , under = ".c"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = d.c
+"""
+                        ]
+        , test "should simplify record accesses for record updates if it can't find the field (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = .c { d | b = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
+                            , under = ".c"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = d.c
+"""
+                        ]
+        , test "should simplify record accesses for record updates if it can't find the field (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = .c <| { d | b = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
+                            , under = ".c"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = d.c
+"""
+                        ]
+        , test "should simplify record accesses for record updates if it can't find the field (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = { d | b = 3 } |> .c
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Updating a record, then accessing an unchanged field will result in that field from the unchanged record"
+                            , details = [ "You can replace accessing this record by just the original record variable inside the record update." ]
                             , under = ".c"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -120,8 +296,8 @@ a = (let b = c in { e = 3 }).e
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -136,8 +312,56 @@ a = (let b = c in f x).e
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
+                            , under = ".e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (let b = c in (f x).e)
+"""
+                        ]
+        , test "should simplify record accesses for let/in expressions, even if the leaf is not a record expression (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = .e (let b = c in f x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
+                            , under = ".e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (let b = c in (f x).e)
+"""
+                        ]
+        , test "should simplify record accesses for let/in expressions, even if the leaf is not a record expression (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = .e <| let b = c in f x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
+                            , under = ".e"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = let b = c in (f x).e
+"""
+                        ]
+        , test "should simplify record accesses for let/in expressions, even if the leaf is not a record expression (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = (let b = c in f x) |> .e
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -152,8 +376,8 @@ a = (let b = c in x).e
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -168,8 +392,8 @@ a = (((let b = c in {e = 2}))).e
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -184,8 +408,8 @@ a = (let b = c in { e = { f = 2 } }).e.f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".e"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -200,8 +424,8 @@ a = (let b = c in (f x).e).f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside a let/in expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside a let...in will result in accessing it in its result"
+                            , details = [ "You can replace accessing this record outside the let...in by accessing its result record after `in`." ]
                             , under = ".f"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -216,8 +440,56 @@ a = (if x then { f = 3 } else { z | f = 3 }).f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside an if/then/else expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
+                            , under = ".f"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (if x then { f = 3 }.f else { z | f = 3 }.f)
+"""
+                        ]
+        , test "should simplify record accesses for if/then/else expressions (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = .f (if x then { f = 3 } else { z | f = 3 })
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
+                            , under = ".f"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (if x then { f = 3 }.f else { z | f = 3 }.f)
+"""
+                        ]
+        , test "should simplify record accesses for if/then/else expressions (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = .f <| if x then { f = 3 } else { z | f = 3 }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
+                            , under = ".f"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = if x then { f = 3 }.f else { z | f = 3 }.f
+"""
+                        ]
+        , test "should simplify record accesses for if/then/else expressions (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = (if x then { f = 3 } else { z | f = 3 }) |> .f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
                             , under = ".f"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -239,8 +511,8 @@ a = (if x then { f = 3 } else if y then { z | f = 4 } else { z | f = 3 }).f
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside an if/then/else expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
                             , under = ".f"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -257,8 +529,8 @@ a = (if x then { f = 3 } else if y then {f = 2} else
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field outside an if/then/else expression can be simplified to access the field inside it." ]
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
                             , under = ".f"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -279,8 +551,8 @@ type alias Record =
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Field access can be simplified"
-                            , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                            { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                            , details = [ "You can replace accessing this record by just that field's value." ]
                             , under = ".second"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -312,8 +584,8 @@ type alias Record =
                     |> Review.Test.expectErrorsForModules
                         [ ( "A"
                           , [ Review.Test.error
-                                { message = "Field access can be simplified"
-                                , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                                { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                                , details = [ "You can replace accessing this record by just that field's value." ]
                                 , under = ".second"
                                 }
                                 |> Review.Test.whenFixed """module A exposing (..)
@@ -355,8 +627,8 @@ type alias Record =
                     |> Review.Test.expectErrorsForModules
                         [ ( "A"
                           , [ Review.Test.error
-                                { message = "Field access can be simplified"
-                                , details = [ "Accessing the field of a record or record update can be simplified to just that field's value." ]
+                                { message = "Accessing a field of a record where we know that field's value will return that field's value"
+                                , details = [ "You can replace accessing this record by just that field's value." ]
                                 , under = ".second"
                                 }
                                 |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/RecordUpdateTest.elm
+++ b/tests/Simplify/RecordUpdateTest.elm
@@ -15,6 +15,13 @@ a = { b | c = 1, d = b.c, e = c.e, f = g b.f, g = b.g.h }
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+        , test "should not simplify when assigning a field to itself applied to an extra argument" <|
+            \() ->
+                """module A exposing (..)
+a = { b | d = .d b extraArgument }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
         , test "should not simplify when assigning a field in a non-update record assignment" <|
             \() ->
                 """module A exposing (..)
@@ -81,6 +88,86 @@ a = { b | c = 1, d = (b.d) }
                             { message = "Unnecessary field assignment"
                             , details = [ "The field is being set to its own value." ]
                             , under = "b.d"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = { b | c = 1}
+"""
+                        ]
+        , test "should remove the update record syntax when it assigns the previous value of a field to itself and it is the only assignment (using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | d = .d b }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = ".d b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b
+"""
+                        ]
+        , test "should remove the update record syntax when it assigns the previous value of a field to itself and it is the only assignment (using access function <|)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | d = .d <| b }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = ".d <| b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b
+"""
+                        ]
+        , test "should remove the update record syntax when it assigns the previous value of a field to itself and it is the only assignment (using access function |>)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | d = b |> .d }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = "b |> .d"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = b
+"""
+                        ]
+        , test "should remove the updates that assigns the previous value of a field to itself (not first and using access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | c = 1, d = .d b }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = ".d b"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = { b | c = 1}
+"""
+                        ]
+        , test "should remove the updates that assigns the previous value of a field to itself (using parens and access function application)" <|
+            \() ->
+                """module A exposing (..)
+a = { b | c = 1, d = (.d b) }
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary field assignment"
+                            , details = [ "The field is being set to its own value." ]
+                            , under = ".d b"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = { b | c = 1}


### PR DESCRIPTION
- [x] Introduce more general checks for sequence, join, and repeatFlat
- [x] Introduce `MappableProperties`
- [x] Use "can be combined checks" more
- [x] Organize helpers better into sections
- [x] Introduce helpers to create type subset properties

### to discuss
- I'd like to rename "andThen" checks to "mapFlat" which is in my mind easier to understand as `concatMap` and has a nice conststency with e.g. "repeatFlat" which is effectively `repeat >> andThen identity`.