### PR TITLE
Add record type alias constructor simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,7 +89,11 @@
 - `floor 1` to `1`
 - `truncate 1` to `1`
 - `round (toFloat n)` to `n` (and same for ceiling, floor, truncate)
-- `(Record first second).first` to `first`
+- where `type alias Record = { first : Int, second : Int }`:
+    - all simplifications for `(Record first second)` that already exist for literal records,
+      like `(Record first second).first` to `first`
+    - `.second << Record first` to `identity`
+    - `.first << Record first` to `always first`
 - `List.drop -1 list` to `list`
 - `List.drop 3 [ a, b ]` to `[]` (same for lists with determined size like `List.singleton`)
 - `List.drop 2 [ a, b, c ]` to `[ c ]`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -12159,6 +12159,7 @@ accessingRecordCompositionChecks checkInfo =
 
                                         else
                                             let
+                                                maybeAccessedFieldExpressionNode : Maybe (Node Expression)
                                                 maybeAccessedFieldExpressionNode =
                                                     findMap
                                                         (\field ->

--- a/tests/Simplify/RecordAccessTest.elm
+++ b/tests/Simplify/RecordAccessTest.elm
@@ -735,4 +735,26 @@ a =
     always first
 """
                         ]
+        , test "should simplify record accesses for if/then/else expressions as record type alias constructions" <|
+            \() ->
+                """module A exposing (..)
+type alias F =
+    { f : Int }
+a =
+    (if x then F 3 else { z | f = 3 }).f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Accessing a field outside an if...then...else will result in accessing it in each branch"
+                            , details = [ "You can replace accessing this record outside an if...then...else by accessing the record inside each branch." ]
+                            , under = ".f"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+type alias F =
+    { f : Int }
+a =
+    (if x then (F 3).f else { z | f = 3 }.f)
+"""
+                        ]
         ]


### PR DESCRIPTION
Everything left in https://github.com/jfmengels/elm-review-simplify/issues/162  and more
```elm
-- given
type alias Record = { first : Int, second : Int }

-- all those that exist for literal records, for example
(if c then Record first second else Record second first).first
--> if c then (Record first second).first else (Record second first).first

.first << Record first
--> always first

.second << Record first
--> identity
```


