### PR TITLE
Combined call and composition checks

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10649,6 +10649,9 @@ unnecessaryCallOnCheck constructable checkInfo =
 
 Examples
 
+    List.sort []
+    --> []
+
     Json.Decode.map f (Json.Decode.fail x)
     --> Json.Decode.fail x
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2919,6 +2919,19 @@ intoFnCheckOnlyCall callFnCheck =
     { call = callFnCheck, composition = \_ -> Nothing }
 
 
+{-| Try the given `IntoFnCheck`s in order and report the first found error.
+-}
+intoFnChecksFirstThatConstructsError : List IntoFnCheck -> IntoFnCheck
+intoFnChecksFirstThatConstructsError intoFnCheckList =
+    { call =
+        \checkInfo ->
+            findMap (\fnCheck -> fnCheck.call checkInfo) intoFnCheckList
+    , composition =
+        \checkInfo ->
+            findMap (\fnCheck -> fnCheck.composition checkInfo) intoFnCheckList
+    }
+
+
 intoFnChecks : Dict ( ModuleName, String ) ( Int, IntoFnCheck )
 intoFnChecks =
     -- The number of arguments is used to determine how many arguments to pass to the check function.

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4494,7 +4494,7 @@ stringReverseChecks =
 stringLeftChecks : IntoFnCheck
 stringLeftChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck stringCollection
+        [ unnecessaryOnEmptyCheck stringCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case Evaluate.getInt checkInfo checkInfo.firstArg of
@@ -4515,7 +4515,7 @@ stringLeftChecks =
 stringRightChecks : IntoFnCheck
 stringRightChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck stringCollection
+        [ unnecessaryOnEmptyCheck stringCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case Evaluate.getInt checkInfo checkInfo.firstArg of
@@ -4536,7 +4536,7 @@ stringRightChecks =
 stringReplaceChecks : IntoFnCheck
 stringReplaceChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck stringCollection
+        [ unnecessaryOnEmptyCheck stringCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case secondArg checkInfo of
@@ -4725,7 +4725,7 @@ resultMapErrorChecks =
 resultAndThenChecks : IntoFnCheck
 resultAndThenChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck resultWithOkAsWrap
+        [ unnecessaryOnEmptyCheck resultWithOkAsWrap
         , wrapperFlatMapChecks resultWithOkAsWrap
         ]
 
@@ -4784,7 +4784,7 @@ listConcatChecks =
         [ callOnWrapReturnsItsValueCheck listCollection
         , callFromCanBeCombinedCheck
             { fromFn = Fn.List.map, combinedFn = Fn.List.concatMap }
-        , unnecessaryCallOnEmptyCheck listCollection
+        , unnecessaryOnEmptyCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn)
@@ -4847,7 +4847,7 @@ listConcatMapChecks =
 listIndexedMapChecks : IntoFnCheck
 listIndexedMapChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck listCollection
+        [ unnecessaryOnEmptyCheck listCollection
         , intoFnCheckOnlyCall (operationWithExtraArgChecks { operationWithoutExtraArg = Fn.List.map })
         ]
 
@@ -4855,7 +4855,7 @@ listIndexedMapChecks =
 listIntersperseChecks : IntoFnCheck
 listIntersperseChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck listCollection
+        [ unnecessaryOnEmptyCheck listCollection
         , unnecessaryOnWrappedCheck listCollection
         ]
 
@@ -5610,7 +5610,7 @@ listReverseChecks =
 listSortChecks : IntoFnCheck
 listSortChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck listCollection
+        [ unnecessaryOnEmptyCheck listCollection
         , unnecessaryOnWrappedCheck listCollection
         , operationDoesNotChangeResultOfOperationCheck
         ]
@@ -5619,7 +5619,7 @@ listSortChecks =
 listSortByChecks : IntoFnCheck
 listSortByChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck listCollection
+        [ unnecessaryOnEmptyCheck listCollection
         , unnecessaryOnWrappedCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
@@ -5643,7 +5643,7 @@ listSortByChecks =
 listSortWithChecks : IntoFnCheck
 listSortWithChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck listCollection
+        [ unnecessaryOnEmptyCheck listCollection
         , unnecessaryOnWrappedCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
@@ -5689,7 +5689,7 @@ listSortWithChecks =
 listTakeChecks : IntoFnCheck
 listTakeChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck listCollection
+        [ unnecessaryOnEmptyCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case Evaluate.getInt checkInfo checkInfo.firstArg of
@@ -5710,7 +5710,7 @@ listTakeChecks =
 listDropChecks : IntoFnCheck
 listDropChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck listCollection
+        [ unnecessaryOnEmptyCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 Evaluate.getInt checkInfo checkInfo.firstArg
@@ -5787,7 +5787,7 @@ arrayMapChecks =
 arrayIndexedMapChecks : IntoFnCheck
 arrayIndexedMapChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck arrayCollection
+        [ unnecessaryOnEmptyCheck arrayCollection
         , intoFnCheckOnlyCall (operationWithExtraArgChecks { operationWithoutExtraArg = Fn.Array.map })
         ]
 
@@ -6092,7 +6092,7 @@ taskMapNChecks =
 taskAndThenChecks : IntoFnCheck
 taskAndThenChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck taskWithSucceedAsWrap
+        [ unnecessaryOnEmptyCheck taskWithSucceedAsWrap
         , wrapperFlatMapChecks taskWithSucceedAsWrap
         ]
 
@@ -6108,7 +6108,7 @@ taskMapErrorChecks =
 taskOnErrorChecks : IntoFnCheck
 taskOnErrorChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck taskWithFailAsWrap
+        [ unnecessaryOnEmptyCheck taskWithFailAsWrap
         , wrapperFlatMapChecks taskWithFailAsWrap
         ]
 
@@ -6251,7 +6251,7 @@ jsonDecodeMapNChecks =
 jsonDecodeAndThenChecks : IntoFnCheck
 jsonDecodeAndThenChecks =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck jsonDecoderWithSucceedAsWrap
+        [ unnecessaryOnEmptyCheck jsonDecoderWithSucceedAsWrap
         , wrapperFlatMapChecks jsonDecoderWithSucceedAsWrap
         ]
 
@@ -7626,7 +7626,7 @@ emptiableMapChecks :
 emptiableMapChecks emptiable =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall (mapIdentityChecks emptiable)
-        , unnecessaryCallOnEmptyCheck emptiable
+        , unnecessaryOnEmptyCheck emptiable
         ]
 
 
@@ -7659,7 +7659,7 @@ If your mapping function only takes one value as an argument, use `emptiableMapC
 emptiableMapWithExtraArgChecks : TypeProperties (EmptiableProperties empty otherProperties) -> IntoFnCheck
 emptiableMapWithExtraArgChecks emptiable =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck emptiable
+        [ unnecessaryOnEmptyCheck emptiable
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
@@ -7930,7 +7930,7 @@ So for example
 emptiableFlatMapChecks : EmptiableProperties ConstantProperties otherProperties -> IntoFnCheck
 emptiableFlatMapChecks emptiable =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck emptiable
+        [ unnecessaryOnEmptyCheck emptiable
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case constructs (sameInAllBranches (getEmptyExpressionNode checkInfo emptiable)) checkInfo.lookupTable checkInfo.firstArg of
@@ -9608,7 +9608,7 @@ indexAccessChecks collection checkInfo n =
 setChecks : TypeProperties (CollectionProperties (EmptiableProperties empty otherProperties)) -> IntoFnCheck
 setChecks collection =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck collection
+        [ unnecessaryOnEmptyCheck collection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case Evaluate.getInt checkInfo checkInfo.firstArg of
@@ -9683,7 +9683,7 @@ setOnKnownElementChecks collection checkInfo n replacementArgRange =
 emptiableReverseChecks : EmptiableProperties empty otherProperties -> IntoFnCheck
 emptiableReverseChecks emptiable =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck emptiable
+        [ unnecessaryOnEmptyCheck emptiable
         , toggleFnChecks
         ]
 
@@ -10067,7 +10067,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
                         Nothing
             )
         , mapToOperationWithIdentityCanBeCombinedToOperationChecks emptiableWrapper
-        , unnecessaryCallOnEmptyCheck emptiableWrapper
+        , unnecessaryOnEmptyCheck emptiableWrapper
         ]
 
 
@@ -10661,11 +10661,11 @@ Examples
     Task.mapError f << Task.succeed
     --> Task.succeed
 
-Use together with `unnecessaryCallOnEmptyCheck`
+Use together with `unnecessaryOnEmptyCheck`
 
 -}
-unnecessaryCallOnEmptyCheck : EmptiableProperties empty otherProperties -> IntoFnCheck
-unnecessaryCallOnEmptyCheck emptiable =
+unnecessaryOnEmptyCheck : EmptiableProperties empty otherProperties -> IntoFnCheck
+unnecessaryOnEmptyCheck emptiable =
     { call = unnecessaryCallOnCheck emptiable.empty
     , composition =
         case emptiable.empty.kind emptiable.empty.specific of
@@ -10918,7 +10918,7 @@ If your function only takes two arguments like `Dict.filter`, use `emptiableKeep
 emptiableKeepWhenChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> IntoFnCheck
 emptiableKeepWhenChecks emptiable =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck emptiable
+        [ unnecessaryOnEmptyCheck emptiable
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
@@ -10968,7 +10968,7 @@ If your function only takes one argument like `List.filter`, use `emptiableKeepW
 emptiableKeepWhenWithExtraArgChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> IntoFnCheck
 emptiableKeepWhenWithExtraArgChecks emptiable =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck emptiable
+        [ unnecessaryOnEmptyCheck emptiable
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 let
@@ -10990,13 +10990,13 @@ emptiableKeepWhenWithExtraArgChecks emptiable =
 
 collectionRemoveChecks : CollectionProperties (EmptiableProperties empty otherProperties) -> IntoFnCheck
 collectionRemoveChecks collection =
-    unnecessaryCallOnEmptyCheck collection
+    unnecessaryOnEmptyCheck collection
 
 
 collectionSliceChecks : EmptiableProperties ConstantProperties otherProperties -> IntoFnCheck
 collectionSliceChecks collection =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck collection
+        [ unnecessaryOnEmptyCheck collection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case secondArg checkInfo of
@@ -11070,7 +11070,7 @@ collectionSliceChecks collection =
 collectionIntersectChecks : CollectionProperties (EmptiableProperties ConstantProperties otherProperties) -> IntoFnCheck
 collectionIntersectChecks collection =
     intoFnChecksFirstThatConstructsError
-        [ unnecessaryCallOnEmptyCheck collection
+        [ unnecessaryOnEmptyCheck collection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 if collection.empty.specific.is (extractInferResources checkInfo) checkInfo.firstArg then

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4007,7 +4007,7 @@ intToIntChecks : IntoFnCheck
 intToIntChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall unnecessaryConversionToIntOnIntCheck
-        , onCallToInverseReturnsItsArgumentCheck Fn.Basics.toFloat
+        , onSpecificFnCallReturnsItsLastArgCheck Fn.Basics.toFloat
         ]
 
 
@@ -4464,7 +4464,7 @@ stringFromListChecks =
         [ intoFnCheckOnlyCall
             (callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.specific.asString } listCollection)
         , wrapperFromListSingletonChecks stringCollection
-        , onCallToInverseReturnsItsArgumentCheck Fn.String.toList
+        , onSpecificFnCallReturnsItsLastArgCheck Fn.String.toList
         ]
 
 
@@ -4629,7 +4629,7 @@ stringLinesChecks =
 
 stringToListChecks : IntoFnCheck
 stringToListChecks =
-    onCallToInverseReturnsItsArgumentCheck Fn.String.fromList
+    onSpecificFnCallReturnsItsLastArgCheck Fn.String.fromList
 
 
 stringFoldlChecks : IntoFnCheck
@@ -5749,7 +5749,7 @@ arrayToListChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall
             (callOnEmptyReturnsCheck { resultAsString = listCollection.empty.specific.asString } arrayCollection)
-        , onCallToInverseReturnsItsArgumentCheck Fn.Array.fromList
+        , onSpecificFnCallReturnsItsLastArgCheck Fn.Array.fromList
         , callFromCanBeCombinedCheck
             { fromFn = Fn.Array.repeat, combinedFn = Fn.List.repeat }
         ]
@@ -5765,7 +5765,7 @@ arrayFromListChecks : IntoFnCheck
 arrayFromListChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall (emptiableFromListChecks arrayCollection)
-        , onCallToInverseReturnsItsArgumentCheck Fn.Array.toList
+        , onSpecificFnCallReturnsItsLastArgCheck Fn.Array.toList
         ]
 
 
@@ -5888,7 +5888,7 @@ setFromListChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall (emptiableFromListChecks setCollection)
         , wrapperFromListSingletonChecks setCollection
-        , onCallToInverseReturnsItsArgumentCheck Fn.Set.toList
+        , onSpecificFnCallReturnsItsLastArgCheck Fn.Set.toList
         ]
 
 
@@ -5970,7 +5970,7 @@ dictFromListChecks : IntoFnCheck
 dictFromListChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall (emptiableFromListChecks dictCollection)
-        , onCallToInverseReturnsItsArgumentCheck Fn.Dict.toList
+        , onSpecificFnCallReturnsItsLastArgCheck Fn.Dict.toList
         ]
 
 
@@ -10518,8 +10518,8 @@ operationDoesNotChangeResultOfOperationCheck =
 
 toggleFnChecks : IntoFnCheck
 toggleFnChecks =
-    { call = \checkInfo -> (onCallToInverseReturnsItsArgumentCheck checkInfo.fn).call checkInfo
-    , composition = \checkInfo -> (onCallToInverseReturnsItsArgumentCheck checkInfo.later.fn).composition checkInfo
+    { call = \checkInfo -> (onSpecificFnCallReturnsItsLastArgCheck checkInfo.fn).call checkInfo
+    , composition = \checkInfo -> (onSpecificFnCallReturnsItsLastArgCheck checkInfo.later.fn).composition checkInfo
     }
 
 
@@ -10557,8 +10557,8 @@ would be an incorrect fix. See for example
     --> not [ 0, 0 ] but actually [ 0 ]
 
 -}
-onCallToInverseReturnsItsArgumentCheck : ( ModuleName, String ) -> IntoFnCheck
-onCallToInverseReturnsItsArgumentCheck inverseFn =
+onSpecificFnCallReturnsItsLastArgCheck : ( ModuleName, String ) -> IntoFnCheck
+onSpecificFnCallReturnsItsLastArgCheck inverseFn =
     { call =
         \checkInfo ->
             case AstHelpers.getSpecificFnCall inverseFn checkInfo.lookupTable checkInfo.firstArg of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10864,8 +10864,6 @@ For example
 
     Cmd.batch << List.singleton --> identity
 
-Use together with `onWrapAlwaysReturnsIncomingCompositionCheck`
-
 -}
 callOnWrapReturnsItsValueCheck :
     { otherProperties

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -12710,7 +12710,7 @@ E.g. for `(i << h) << (g << f)`
     getInnerComposition { earlier = (g << f), later = (i << h) }
     --> { earlier = g, later = h }
 
-which works for nested parens ans any combination of `>>` and `<<`.
+which works for nested parens and any combination of `>>` and `<<`.
 
 The returned `removeEarlier/LaterRange` can be used together with `Fix.removeRange` to only remove one side of the composition.
 The returned `isEmbeddedInComposition` is true if there are other functions composed before `earlier` or after `later`.

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5768,7 +5768,7 @@ arrayToIndexedListChecks =
 arrayFromListChecks : IntoFnCheck
 arrayFromListChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (collectionFromListChecks arrayCollection)
+        [ intoFnCheckOnlyCall (emptiableFromListChecks arrayCollection)
         , onCallToInverseReturnsItsArgumentCheck Fn.Array.toList
         ]
 
@@ -5890,7 +5890,7 @@ arrayFoldrChecks =
 setFromListChecks : IntoFnCheck
 setFromListChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (collectionFromListChecks setCollection)
+        [ intoFnCheckOnlyCall (emptiableFromListChecks setCollection)
         , wrapperFromListSingletonChecks setCollection
         , onCallToInverseReturnsItsArgumentCheck Fn.Set.toList
         ]
@@ -5973,7 +5973,7 @@ setFoldrChecks =
 dictFromListChecks : IntoFnCheck
 dictFromListChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (collectionFromListChecks dictCollection)
+        [ intoFnCheckOnlyCall (emptiableFromListChecks dictCollection)
         , onCallToInverseReturnsItsArgumentCheck Fn.Dict.toList
         ]
 
@@ -11299,8 +11299,8 @@ collectionSizeChecks collection checkInfo =
             Nothing
 
 
-collectionFromListChecks : CollectionProperties (EmptiableProperties ConstantProperties otherProperties) -> CheckInfo -> Maybe (Error {})
-collectionFromListChecks collection =
+emptiableFromListChecks : EmptiableProperties ConstantProperties otherProperties -> CheckInfo -> Maybe (Error {})
+emptiableFromListChecks collection =
     callOnEmptyReturnsCheck { resultAsString = collection.empty.specific.asString } listCollection
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10013,11 +10013,17 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
         ]
 
 
-basicsIdentityConstant : ConstantProperties
-basicsIdentityConstant =
+identityFunctionProperties :
+    { description : String
+    , is : Infer.Resources {} -> Node Expression -> Bool
+    , asString : QualifyResources {} -> String
+    , fn : ( ModuleName, String )
+    }
+identityFunctionProperties =
     { description = "an identity function"
     , is = \res expr -> AstHelpers.isIdentity res.lookupTable expr
     , asString = \res -> qualifiedToString (qualify Fn.Basics.identity res)
+    , fn = Fn.Basics.identity
     }
 
 
@@ -10041,7 +10047,7 @@ mapToOperationWithIdentityCanBeCombinedToOperationChecks mappable =
         checkIntoFn : ( ModuleName, String ) -> IntoFnCheck
         checkIntoFn combinedFn =
             onSpecificFnCallCanBeCombinedCheck
-                { args = [ basicsIdentityConstant ]
+                { args = [ identityFunctionProperties ]
                 , earlierFn = mappable.mapFn
                 , combinedFn = combinedFn
                 }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10661,8 +10661,6 @@ Examples
     Task.mapError f << Task.succeed
     --> Task.succeed
 
-Use together with `unnecessaryOnEmptyCheck`
-
 -}
 unnecessaryOnEmptyCheck : EmptiableProperties empty otherProperties -> IntoFnCheck
 unnecessaryOnEmptyCheck emptiable =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4709,8 +4709,8 @@ mapWrapErrorInfo mapFn wrapper =
         wrapFnInErrorInfo =
             qualifiedToString (qualify wrapper.wrap.fn defaultQualifyResources)
     in
-    { message = qualifiedToString mapFn ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " will result in " ++ wrapFnInErrorInfo ++ " with the function applied to the value inside"
-    , details = [ "You can replace this call by " ++ wrapFnInErrorInfo ++ " with the function directly applied to the value inside " ++ constructWithOneArgDescriptionDefinite "the" wrapper.wrap.description ++ " itself." ]
+    { message = qualifiedToString mapFn ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " will result in " ++ wrapFnInErrorInfo ++ " with the function applied to the value inside"
+    , details = [ "You can replace this call by " ++ wrapFnInErrorInfo ++ " with the function directly applied to the value inside " ++ constructWithOneValueDescriptionDefinite "the" wrapper.wrap.description ++ " itself." ]
     }
 
 
@@ -6228,7 +6228,7 @@ Note that for example `Cmd.batch [ a ]` is not a "wrap" because it keeps the typ
 -}
 type alias WrapperProperties otherProperties =
     { otherProperties
-        | wrap : ConstructWithOneArgProperties
+        | wrap : ConstructWithOneValueProperties
     }
 
 
@@ -6353,7 +6353,7 @@ Examples:
   - a non-empty list with exactly one element
   - an empty string
 
-The first 2 are examples of a subset with `ConstructWithOneArgProperties`,
+The first 2 are examples of a subset with `ConstructWithOneValueProperties`,
 the last one is an example of a subset with `ConstantProperties`
 
 -}
@@ -6370,7 +6370,7 @@ type alias TypeSubsetProperties specificProperties =
 
 -}
 type TypeSubsetKindProperties
-    = ConstructWithOneValue ConstructWithOneArgProperties
+    = ConstructWithOneValue ConstructWithOneValueProperties
     | Constant ConstantProperties
 
 
@@ -6381,14 +6381,14 @@ type alias ConstantProperties =
     }
 
 
-type alias ConstructWithOneArgProperties =
-    { description : ConstructWithOneArgDescription
+type alias ConstructWithOneValueProperties =
+    { description : ConstructWithOneValueDescription
     , fn : ( ModuleName, String )
     , getValue : ModuleNameLookupTable -> Node Expression -> Maybe (Node Expression)
     }
 
 
-type ConstructWithOneArgDescription
+type ConstructWithOneValueDescription
     = A String
     | An String
 
@@ -6410,7 +6410,7 @@ typeSubsetDescriptionIndefinite typeSubsetProperties =
             constantProperties.description
 
         ConstructWithOneValue constructWithOneValue ->
-            constructWithOneArgDescriptionIndefinite constructWithOneValue.description
+            constructWithOneValueDescriptionIndefinite constructWithOneValue.description
 
 
 typeSubsetDescriptionDefinite : String -> TypeSubsetProperties specificProperties -> String
@@ -6420,7 +6420,7 @@ typeSubsetDescriptionDefinite definiteArticle typeSubsetProperties =
             constantProperties.description
 
         ConstructWithOneValue constructWithOneValue ->
-            constructWithOneArgDescriptionDefinite definiteArticle constructWithOneValue.description
+            constructWithOneValueDescriptionDefinite definiteArticle constructWithOneValue.description
 
 
 typeSubsetDescriptionWithoutArticle : TypeSubsetProperties specificProperties -> String
@@ -6430,7 +6430,7 @@ typeSubsetDescriptionWithoutArticle typeSubsetProperties =
             constantProperties.description
 
         ConstructWithOneValue constructWithOneValue ->
-            constructWithOneArgDescriptionWithoutArticle constructWithOneValue.description
+            constructWithOneValueDescriptionWithoutArticle constructWithOneValue.description
 
 
 {-| Create `ConstantProperties` for a value with a given fully qualified name.
@@ -6446,10 +6446,10 @@ constantFnProperties fullyQualified =
     }
 
 
-{-| Create `ConstructWithOneArgProperties` for a function call with a given fully qualified name with a given `ConstructWithOneArgDescription`.
+{-| Create `ConstructWithOneValueProperties` for a function call with a given fully qualified name with a given `ConstructWithOneValueDescription`.
 -}
-fnCallConstructWithOneArgProperties : ConstructWithOneArgDescription -> ( ModuleName, String ) -> ConstructWithOneArgProperties
-fnCallConstructWithOneArgProperties description fullyQualified =
+fnCallConstructWithOneValueProperties : ConstructWithOneValueDescription -> ( ModuleName, String ) -> ConstructWithOneValueProperties
+fnCallConstructWithOneValueProperties description fullyQualified =
     { description = description
     , fn = fullyQualified
     , getValue =
@@ -6514,8 +6514,8 @@ fromListGetLiteral constructibleFromList lookupTable expressionNode =
                     Nothing
 
 
-constructWithOneArgDescriptionIndefinite : ConstructWithOneArgDescription -> String
-constructWithOneArgDescriptionIndefinite incomingArgDescription =
+constructWithOneValueDescriptionIndefinite : ConstructWithOneValueDescription -> String
+constructWithOneValueDescriptionIndefinite incomingArgDescription =
     case incomingArgDescription of
         A description ->
             "a " ++ description
@@ -6524,8 +6524,8 @@ constructWithOneArgDescriptionIndefinite incomingArgDescription =
             "an " ++ description
 
 
-constructWithOneArgDescriptionDefinite : String -> ConstructWithOneArgDescription -> String
-constructWithOneArgDescriptionDefinite startWithDefiniteArticle referenceArgDescription =
+constructWithOneValueDescriptionDefinite : String -> ConstructWithOneValueDescription -> String
+constructWithOneValueDescriptionDefinite startWithDefiniteArticle referenceArgDescription =
     case referenceArgDescription of
         A description ->
             startWithDefiniteArticle ++ " " ++ description
@@ -6534,8 +6534,8 @@ constructWithOneArgDescriptionDefinite startWithDefiniteArticle referenceArgDesc
             startWithDefiniteArticle ++ " " ++ description
 
 
-constructWithOneArgDescriptionWithoutArticle : ConstructWithOneArgDescription -> String
-constructWithOneArgDescriptionWithoutArticle referenceArgDescription =
+constructWithOneValueDescriptionWithoutArticle : ConstructWithOneValueDescription -> String
+constructWithOneValueDescriptionWithoutArticle referenceArgDescription =
     case referenceArgDescription of
         A description ->
             description
@@ -6685,9 +6685,9 @@ randomGeneratorWrapper =
     }
 
 
-randomGeneratorConstantConstruct : ConstructWithOneArgProperties
+randomGeneratorConstantConstruct : ConstructWithOneValueProperties
 randomGeneratorConstantConstruct =
-    fnCallConstructWithOneArgProperties (A "constant generator") Fn.Random.constant
+    fnCallConstructWithOneValueProperties (A "constant generator") Fn.Random.constant
 
 
 maybeWithJustAsWrap : TypeProperties (EmptiableProperties ConstantProperties (WrapperProperties (MappableProperties {})))
@@ -6699,12 +6699,12 @@ maybeWithJustAsWrap =
     }
 
 
-maybeJustConstruct : ConstructWithOneArgProperties
+maybeJustConstruct : ConstructWithOneValueProperties
 maybeJustConstruct =
-    fnCallConstructWithOneArgProperties (A "just maybe") Fn.Maybe.justVariant
+    fnCallConstructWithOneValueProperties (A "just maybe") Fn.Maybe.justVariant
 
 
-resultWithOkAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
+resultWithOkAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneValueProperties (MappableProperties {})))
 resultWithOkAsWrap =
     { represents = "result"
     , wrap = resultOkayConstruct
@@ -6713,17 +6713,17 @@ resultWithOkAsWrap =
     }
 
 
-resultOkayConstruct : ConstructWithOneArgProperties
+resultOkayConstruct : ConstructWithOneValueProperties
 resultOkayConstruct =
-    fnCallConstructWithOneArgProperties (An "okay result") Fn.Result.okVariant
+    fnCallConstructWithOneValueProperties (An "okay result") Fn.Result.okVariant
 
 
-resultErrorConstruct : ConstructWithOneArgProperties
+resultErrorConstruct : ConstructWithOneValueProperties
 resultErrorConstruct =
-    fnCallConstructWithOneArgProperties (An "error") Fn.Result.errVariant
+    fnCallConstructWithOneValueProperties (An "error") Fn.Result.errVariant
 
 
-resultWithErrAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
+resultWithErrAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneValueProperties (MappableProperties {})))
 resultWithErrAsWrap =
     { represents = "result"
     , wrap = resultErrorConstruct
@@ -6732,7 +6732,7 @@ resultWithErrAsWrap =
     }
 
 
-taskWithSucceedAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
+taskWithSucceedAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneValueProperties (MappableProperties {})))
 taskWithSucceedAsWrap =
     { represents = "task"
     , wrap = taskSucceedingConstruct
@@ -6741,17 +6741,17 @@ taskWithSucceedAsWrap =
     }
 
 
-taskSucceedingConstruct : ConstructWithOneArgProperties
+taskSucceedingConstruct : ConstructWithOneValueProperties
 taskSucceedingConstruct =
-    fnCallConstructWithOneArgProperties (A "succeeding task") Fn.Task.succeed
+    fnCallConstructWithOneValueProperties (A "succeeding task") Fn.Task.succeed
 
 
-taskFailingConstruct : ConstructWithOneArgProperties
+taskFailingConstruct : ConstructWithOneValueProperties
 taskFailingConstruct =
-    fnCallConstructWithOneArgProperties (A "failing task") Fn.Task.fail
+    fnCallConstructWithOneValueProperties (A "failing task") Fn.Task.fail
 
 
-taskWithFailAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
+taskWithFailAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneValueProperties (MappableProperties {})))
 taskWithFailAsWrap =
     { represents = "task"
     , wrap = taskFailingConstruct
@@ -6760,7 +6760,7 @@ taskWithFailAsWrap =
     }
 
 
-jsonDecoderWithSucceedAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneArgProperties (MappableProperties {})))
+jsonDecoderWithSucceedAsWrap : TypeProperties (WrapperProperties (EmptiableProperties ConstructWithOneValueProperties (MappableProperties {})))
 jsonDecoderWithSucceedAsWrap =
     { represents = "json decoder"
     , wrap = jsonDecoderSucceedingConstruct
@@ -6769,14 +6769,14 @@ jsonDecoderWithSucceedAsWrap =
     }
 
 
-jsonDecoderSucceedingConstruct : ConstructWithOneArgProperties
+jsonDecoderSucceedingConstruct : ConstructWithOneValueProperties
 jsonDecoderSucceedingConstruct =
-    fnCallConstructWithOneArgProperties (A "succeeding decoder") Fn.Json.Decode.succeed
+    fnCallConstructWithOneValueProperties (A "succeeding decoder") Fn.Json.Decode.succeed
 
 
-jsonDecoderFailingConstruct : ConstructWithOneArgProperties
+jsonDecoderFailingConstruct : ConstructWithOneValueProperties
 jsonDecoderFailingConstruct =
-    fnCallConstructWithOneArgProperties (A "failing decoder") Fn.Json.Decode.fail
+    fnCallConstructWithOneValueProperties (A "failing decoder") Fn.Json.Decode.fail
 
 
 listCollection : TypeProperties (CollectionProperties (EmptiableProperties ConstantProperties (WrapperProperties (ConstructibleFromListProperties (MappableProperties {})))))
@@ -6802,7 +6802,7 @@ listEmptyConstantSpecific =
     }
 
 
-listSingletonConstruct : ConstructWithOneArgProperties
+listSingletonConstruct : ConstructWithOneValueProperties
 listSingletonConstruct =
     { description = A "singleton list"
     , fn = Fn.List.singleton
@@ -6901,9 +6901,9 @@ stringEmptyConstantSpecific =
     }
 
 
-singleCharConstruct : ConstructWithOneArgProperties
+singleCharConstruct : ConstructWithOneValueProperties
 singleCharConstruct =
-    fnCallConstructWithOneArgProperties (A "single-char string") Fn.String.fromChar
+    fnCallConstructWithOneValueProperties (A "single-char string") Fn.String.fromChar
 
 
 stringDetermineLength : Infer.Resources res -> Node Expression -> Maybe CollectionSize
@@ -7053,9 +7053,9 @@ setCollection =
     }
 
 
-setSingletonConstruct : ConstructWithOneArgProperties
+setSingletonConstruct : ConstructWithOneValueProperties
 setSingletonConstruct =
-    fnCallConstructWithOneArgProperties (A "singleton set") Fn.Set.singleton
+    fnCallConstructWithOneValueProperties (A "singleton set") Fn.Set.singleton
 
 
 setGetElements : Infer.Resources a -> Node Expression -> Maybe { known : List (Node Expression), allKnown : Bool }
@@ -7853,8 +7853,8 @@ wrapperFlatMapChecks wrapper =
                                 Just wrapCalls ->
                                     Just
                                         (Rule.errorWithFix
-                                            { message = qualifiedToString checkInfo.fn ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " is the same as applying the function to the value from " ++ constructWithOneArgDescriptionDefinite "the" wrapper.wrap.description
-                                            , details = [ "You can replace this call by the function directly applied to the value inside " ++ constructWithOneArgDescriptionDefinite "the" wrapper.wrap.description ++ "." ]
+                                            { message = qualifiedToString checkInfo.fn ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " is the same as applying the function to the value from " ++ constructWithOneValueDescriptionDefinite "the" wrapper.wrap.description
+                                            , details = [ "You can replace this call by the function directly applied to the value inside " ++ constructWithOneValueDescriptionDefinite "the" wrapper.wrap.description ++ "." ]
                                             }
                                             checkInfo.fnRange
                                             (Fix.removeRange { start = checkInfo.fnRange.start, end = (Node.range checkInfo.firstArg).start }
@@ -7873,7 +7873,7 @@ wrapperFlatMapChecks wrapper =
                         ( True, (Node functionRange _) :: [] ) ->
                             Just
                                 { info =
-                                    { message = qualifiedToString checkInfo.later.fn ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " is the same as applying the function to the value from " ++ constructWithOneArgDescriptionDefinite "the" wrapper.wrap.description
+                                    { message = qualifiedToString checkInfo.later.fn ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " is the same as applying the function to the value from " ++ constructWithOneValueDescriptionDefinite "the" wrapper.wrap.description
                                     , details = [ "You can replace this composition by the function given to " ++ qualifiedToString checkInfo.later.fn ++ "." ]
                                     }
                                 , fix =
@@ -7909,8 +7909,8 @@ wrapperFlatMapChecks wrapper =
                     Just wrapCalls ->
                         Just
                             (Rule.errorWithFix
-                                { message = qualifiedToString checkInfo.fn ++ " with a function that always returns " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " is the same as " ++ qualifiedToString wrapper.mapFn ++ " with the function returning the value inside"
-                                , details = [ "You can replace this call by " ++ qualifiedToString wrapper.mapFn ++ " with the function returning the value inside " ++ constructWithOneArgDescriptionDefinite "the" wrapper.wrap.description ++ "." ]
+                                { message = qualifiedToString checkInfo.fn ++ " with a function that always returns " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " is the same as " ++ qualifiedToString wrapper.mapFn ++ " with the function returning the value inside"
+                                , details = [ "You can replace this call by " ++ qualifiedToString wrapper.mapFn ++ " with the function returning the value inside " ++ constructWithOneValueDescriptionDefinite "the" wrapper.wrap.description ++ "." ]
                                 }
                                 checkInfo.fnRange
                                 (Fix.replaceRangeBy checkInfo.fnRange
@@ -8028,7 +8028,7 @@ unwrapToMaybeChecks emptiableWrapper =
         ]
 
 
-fromMaybeWithEmptyValueOnNothingCheck : WrapperProperties (EmptiableProperties ConstructWithOneArgProperties otherProperties) -> IntoFnCheck
+fromMaybeWithEmptyValueOnNothingCheck : WrapperProperties (EmptiableProperties ConstructWithOneValueProperties otherProperties) -> IntoFnCheck
 fromMaybeWithEmptyValueOnNothingCheck wrapper =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall
@@ -8423,8 +8423,8 @@ wrapperMemberChecks wrapper checkInfo =
                     in
                     Just
                         (Rule.errorWithFix
-                            { message = qualifiedToString checkInfo.fn ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " is the same as directly checking for equality"
-                            , details = [ "You can replace this call by checking whether the member to find and the value inside " ++ constructWithOneArgDescriptionDefinite "the" wrapper.wrap.description ++ " are equal." ]
+                            { message = qualifiedToString checkInfo.fn ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " is the same as directly checking for equality"
+                            , details = [ "You can replace this call by checking whether the member to find and the value inside " ++ constructWithOneValueDescriptionDefinite "the" wrapper.wrap.description ++ " are equal." ]
                             }
                             checkInfo.fnRange
                             (List.concat
@@ -8921,8 +8921,8 @@ sequenceOnCollectionWithAllElementsWrapped ( collection, elementWrapper ) checkI
                     Just wrappeds ->
                         Just
                             (Rule.errorWithFix
-                                { message = qualifiedToString checkInfo.fn ++ " on a " ++ collection.represents ++ " where each element is " ++ constructWithOneArgDescriptionIndefinite elementWrapper.wrap.description ++ " will result in " ++ qualifiedToString elementWrapper.wrap.fn ++ " on the values inside"
-                                , details = [ "You can replace this call by " ++ qualifiedToString elementWrapper.wrap.fn ++ " on a list where each element is replaced by its value inside " ++ constructWithOneArgDescriptionDefinite "the" elementWrapper.wrap.description ++ "." ]
+                                { message = qualifiedToString checkInfo.fn ++ " on a " ++ collection.represents ++ " where each element is " ++ constructWithOneValueDescriptionIndefinite elementWrapper.wrap.description ++ " will result in " ++ qualifiedToString elementWrapper.wrap.fn ++ " on the values inside"
+                                , details = [ "You can replace this call by " ++ qualifiedToString elementWrapper.wrap.fn ++ " on a list where each element is replaced by its value inside " ++ constructWithOneValueDescriptionDefinite "the" elementWrapper.wrap.description ++ "." ]
                                 }
                                 checkInfo.fnRange
                                 (Fix.replaceRangeBy
@@ -9012,8 +9012,8 @@ sequenceRepeatChecks wrapper =
                         Just wrapCall ->
                             Just
                                 (Rule.errorWithFix
-                                    { message = qualifiedToString checkInfo.fn ++ " with " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " will result in " ++ qualifiedToString wrapper.wrap.fn ++ " with " ++ qualifiedToString Fn.List.repeat ++ " with the value in " ++ constructWithOneArgDescriptionDefinite "that" wrapper.wrap.description
-                                    , details = [ "You can replace the call by " ++ qualifiedToString wrapper.wrap.fn ++ " with " ++ qualifiedToString Fn.List.repeat ++ " with the same length and the value inside " ++ constructWithOneArgDescriptionDefinite "the given" wrapper.wrap.description ++ "." ]
+                                    { message = qualifiedToString checkInfo.fn ++ " with " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " will result in " ++ qualifiedToString wrapper.wrap.fn ++ " with " ++ qualifiedToString Fn.List.repeat ++ " with the value in " ++ constructWithOneValueDescriptionDefinite "that" wrapper.wrap.description
+                                    , details = [ "You can replace the call by " ++ qualifiedToString wrapper.wrap.fn ++ " with " ++ qualifiedToString Fn.List.repeat ++ " with the same length and the value inside " ++ constructWithOneValueDescriptionDefinite "the given" wrapper.wrap.description ++ "." ]
                                     }
                                     checkInfo.fnRange
                                     (replaceBySubExpressionFix wrapCall.nodeRange wrapCall.firstArg
@@ -9681,8 +9681,8 @@ wrapperMapNChecks wrapper checkInfo =
                 in
                 Just
                     (Rule.errorWithFix
-                        { message = qualifiedToString checkInfo.fn ++ " where each " ++ wrapper.represents ++ " is " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " will result in " ++ wrapFnDescription ++ " on the values inside"
-                        , details = [ "You can replace this call by " ++ wrapFnDescription ++ " with the function applied to the values inside each " ++ constructWithOneArgDescriptionWithoutArticle wrapper.wrap.description ++ "." ]
+                        { message = qualifiedToString checkInfo.fn ++ " where each " ++ wrapper.represents ++ " is " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " will result in " ++ wrapFnDescription ++ " on the values inside"
+                        , details = [ "You can replace this call by " ++ wrapFnDescription ++ " with the function applied to the values inside each " ++ constructWithOneValueDescriptionWithoutArticle wrapper.wrap.description ++ "." ]
                         }
                         checkInfo.fnRange
                         (keepOnlyFix
@@ -10142,7 +10142,7 @@ onWrappedIsEquivalentToMapWrapOnValueCheck ( wrapper, valueMappable ) =
                             in
                             Just
                                 (Rule.errorWithFix
-                                    { message = qualifiedToString checkInfo.fn ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " is the same as " ++ replacement defaultQualifyResources ++ " on the value inside"
+                                    { message = qualifiedToString checkInfo.fn ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " is the same as " ++ replacement defaultQualifyResources ++ " on the value inside"
                                     , details = [ "You can replace this call by " ++ replacement defaultQualifyResources ++ " on the value inside the singleton list." ]
                                     }
                                     checkInfo.fnRange
@@ -10169,7 +10169,7 @@ onWrappedIsEquivalentToMapWrapOnValueCheck ( wrapper, valueMappable ) =
                 in
                 Just
                     { info =
-                        { message = qualifiedToString checkInfo.later.fn ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " is the same as " ++ replacement defaultQualifyResources ++ " on the value inside"
+                        { message = qualifiedToString checkInfo.later.fn ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " is the same as " ++ replacement defaultQualifyResources ++ " on the value inside"
                         , details = [ "You can replace this call by " ++ replacement defaultQualifyResources ++ "." ]
                         }
                     , fix = compositionReplaceByFix (replacement checkInfo) checkInfo
@@ -10622,14 +10622,14 @@ callOnEmptyReturnsCheck config collection checkInfo =
 
 
 unnecessaryCompositionAfterCheck :
-    ConstructWithOneArgProperties
+    ConstructWithOneValueProperties
     -> CompositionIntoCheckInfo
     -> Maybe ErrorInfoAndFix
 unnecessaryCompositionAfterCheck construct checkInfo =
     if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == construct.fn) then
         Just
             { info =
-                { message = qualifiedToString checkInfo.later.fn ++ " on " ++ constructWithOneArgDescriptionIndefinite construct.description ++ " will result in " ++ constructWithOneArgDescriptionDefinite "the unchanged" construct.description
+                { message = qualifiedToString checkInfo.later.fn ++ " on " ++ constructWithOneValueDescriptionIndefinite construct.description ++ " will result in " ++ constructWithOneValueDescriptionDefinite "the unchanged" construct.description
                 , details = [ "You can replace this composition by " ++ qualifiedToString (qualify construct.fn checkInfo) ++ "." ]
                 }
             , fix =
@@ -10727,8 +10727,8 @@ onWrappedReturnsItsValueCheck wrapper =
                         Just wraps ->
                             Just
                                 (Rule.errorWithFix
-                                    { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " will result in the value inside"
-                                    , details = [ "You can replace this call by the value inside " ++ constructWithOneArgDescriptionDefinite "the" wrapper.wrap.description ++ "." ]
+                                    { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " will result in the value inside"
+                                    , details = [ "You can replace this call by the value inside " ++ constructWithOneValueDescriptionDefinite "the" wrapper.wrap.description ++ "." ]
                                     }
                                     checkInfo.fnRange
                                     (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range wrapperArg }
@@ -10743,7 +10743,7 @@ onWrappedReturnsItsValueCheck wrapper =
             if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == wrapper.wrap.fn) then
                 Just
                     (compositionAlwaysReturnsIncomingError
-                        (qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " will always result in the value inside")
+                        (qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " will always result in the value inside")
                         checkInfo
                     )
 
@@ -10779,8 +10779,8 @@ onWrappedReturnsJustItsValueCheck wrapper =
                         Just wraps ->
                             Just
                                 (Rule.errorWithFix
-                                    { message = qualifiedToString checkInfo.fn ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " will result in Just the value inside"
-                                    , details = [ "You can replace this call by Just the value inside " ++ constructWithOneArgDescriptionDefinite "the" wrapper.wrap.description ++ "." ]
+                                    { message = qualifiedToString checkInfo.fn ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " will result in Just the value inside"
+                                    , details = [ "You can replace this call by Just the value inside " ++ constructWithOneValueDescriptionDefinite "the" wrapper.wrap.description ++ "." ]
                                     }
                                     checkInfo.fnRange
                                     (Fix.removeRange { start = (Node.range withWrapArg).end, end = checkInfo.parentRange.end }
@@ -10801,7 +10801,7 @@ onWrappedReturnsJustItsValueCheck wrapper =
             if onlyLastArgIsCurried checkInfo.later && (checkInfo.earlier.fn == wrapper.wrap.fn) then
                 Just
                     { info =
-                        { message = qualifiedToString checkInfo.later.fn ++ " on " ++ constructWithOneArgDescriptionIndefinite wrapper.wrap.description ++ " will always result in Just the value inside"
+                        { message = qualifiedToString checkInfo.later.fn ++ " on " ++ constructWithOneValueDescriptionIndefinite wrapper.wrap.description ++ " will always result in Just the value inside"
                         , details = [ "You can replace this call by Just." ]
                         }
                     , fix = compositionReplaceByFnFix Fn.Maybe.justVariant checkInfo

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4498,7 +4498,7 @@ stringLengthChecks =
 
 stringSliceChecks : IntoFnCheck
 stringSliceChecks =
-    intoFnCheckOnlyCall (collectionSliceChecks stringCollection)
+    collectionSliceChecks stringCollection
 
 
 stringReverseChecks : IntoFnCheck
@@ -4511,10 +4511,10 @@ stringReverseChecks =
 
 stringLeftChecks : IntoFnCheck
 stringLeftChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ unnecessaryCallOnEmptyCheck stringCollection
-            , \checkInfo ->
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryCallOnEmptyCheck stringCollection
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
                 case Evaluate.getInt checkInfo checkInfo.firstArg of
                     Just length ->
                         callWithNonPositiveIntCanBeReplacedByCheck
@@ -4526,16 +4526,16 @@ stringLeftChecks =
 
                     Nothing ->
                         Nothing
-            ]
-        )
+            )
+        ]
 
 
 stringRightChecks : IntoFnCheck
 stringRightChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ unnecessaryCallOnEmptyCheck stringCollection
-            , \checkInfo ->
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryCallOnEmptyCheck stringCollection
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
                 case Evaluate.getInt checkInfo checkInfo.firstArg of
                     Just length ->
                         callWithNonPositiveIntCanBeReplacedByCheck
@@ -4547,16 +4547,16 @@ stringRightChecks =
 
                     Nothing ->
                         Nothing
-            ]
-        )
+            )
+        ]
 
 
 stringReplaceChecks : IntoFnCheck
 stringReplaceChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ unnecessaryCallOnEmptyCheck stringCollection
-            , \checkInfo ->
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryCallOnEmptyCheck stringCollection
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
                 case secondArg checkInfo of
                     Just replacementArg ->
                         firstThatConstructsJust
@@ -4599,8 +4599,8 @@ stringReplaceChecks =
 
                     Nothing ->
                         Nothing
-            ]
-        )
+            )
+        ]
 
 
 stringAppendChecks : IntoFnCheck
@@ -4667,7 +4667,7 @@ stringFoldrChecks =
 maybeMapChecks : IntoFnCheck
 maybeMapChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (emptiableMapChecks maybeWithJustAsWrap)
+        [ emptiableMapChecks maybeWithJustAsWrap
         , mapOnWrappedChecks maybeWithJustAsWrap
         ]
 
@@ -4686,7 +4686,7 @@ maybeAndThenChecks : IntoFnCheck
 maybeAndThenChecks =
     intoFnChecksFirstThatConstructsError
         [ wrapperFlatMapChecks maybeWithJustAsWrap
-        , intoFnCheckOnlyCall (emptiableFlatMapChecks maybeWithJustAsWrap)
+        , emptiableFlatMapChecks maybeWithJustAsWrap
         ]
 
 
@@ -4702,7 +4702,7 @@ maybeWithDefaultChecks =
 resultMapChecks : IntoFnCheck
 resultMapChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = emptiableMapChecks resultWithOkAsWrap, composition = unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap }
+        [ emptiableMapChecks resultWithOkAsWrap
         , mapOnWrappedChecks resultWithOkAsWrap
         ]
 
@@ -4735,7 +4735,7 @@ mapWrapErrorInfo mapFn wrapper =
 resultMapErrorChecks : IntoFnCheck
 resultMapErrorChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = emptiableMapChecks resultWithErrAsWrap, composition = unnecessaryCompositionAfterEmptyCheck resultWithErrAsWrap }
+        [ emptiableMapChecks resultWithErrAsWrap
         , mapOnWrappedChecks resultWithErrAsWrap
         ]
 
@@ -4743,7 +4743,7 @@ resultMapErrorChecks =
 resultAndThenChecks : IntoFnCheck
 resultAndThenChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = unnecessaryCallOnEmptyCheck resultWithOkAsWrap, composition = unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap }
+        [ unnecessaryCallOnEmptyCheck resultWithOkAsWrap
         , wrapperFlatMapChecks resultWithOkAsWrap
         ]
 
@@ -4806,7 +4806,7 @@ listConcatChecks =
         [ callOnWrapReturnsItsValueCheck listCollection
         , callFromCanBeCombinedCheck
             { fromFn = Fn.List.map, combinedFn = Fn.List.concatMap }
-        , intoFnCheckOnlyCall (unnecessaryCallOnEmptyCheck listCollection)
+        , unnecessaryCallOnEmptyCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn)
@@ -4861,25 +4861,23 @@ listConcatMapChecks : IntoFnCheck
 listConcatMapChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall (operationWithIdentityIsEquivalentToFnCheck Fn.List.concat)
-        , intoFnCheckOnlyCall (emptiableFlatMapChecks listCollection)
+        , emptiableFlatMapChecks listCollection
         , wrapperFlatMapChecks listCollection
         ]
 
 
 listIndexedMapChecks : IntoFnCheck
 listIndexedMapChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ unnecessaryCallOnEmptyCheck listCollection
-            , operationWithExtraArgChecks { operationWithoutExtraArg = Fn.List.map }
-            ]
-        )
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryCallOnEmptyCheck listCollection
+        , intoFnCheckOnlyCall (operationWithExtraArgChecks { operationWithoutExtraArg = Fn.List.map })
+        ]
 
 
 listIntersperseChecks : IntoFnCheck
 listIntersperseChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (unnecessaryCallOnEmptyCheck listCollection)
+        [ unnecessaryCallOnEmptyCheck listCollection
         , unnecessaryCallOnWrappedCheck listCollection
         ]
 
@@ -4988,7 +4986,7 @@ listTailChecks =
 listMapChecks : IntoFnCheck
 listMapChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (emptiableMapChecks listCollection)
+        [ emptiableMapChecks listCollection
         , listMapOnSingletonCheck
         , { call = dictToListMapChecks, composition = dictToListIntoListMapCompositionCheck }
         , { call = arrayToIndexedListToListMapChecks, composition = arrayToIndexedListMapCompositionCheck }
@@ -5547,7 +5545,7 @@ listAnyChecks =
 
 listFilterChecks : IntoFnCheck
 listFilterChecks =
-    intoFnCheckOnlyCall (emptiableKeepWhenChecks listCollection)
+    emptiableKeepWhenChecks listCollection
 
 
 listPartitionChecks : IntoFnCheck
@@ -5634,7 +5632,7 @@ listReverseChecks =
 listSortChecks : IntoFnCheck
 listSortChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (unnecessaryCallOnEmptyCheck listCollection)
+        [ unnecessaryCallOnEmptyCheck listCollection
         , unnecessaryCallOnWrappedCheck listCollection
         , operationDoesNotChangeResultOfOperationCheck
         ]
@@ -5643,7 +5641,7 @@ listSortChecks =
 listSortByChecks : IntoFnCheck
 listSortByChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (unnecessaryCallOnEmptyCheck listCollection)
+        [ unnecessaryCallOnEmptyCheck listCollection
         , unnecessaryCallOnWrappedCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
@@ -5667,7 +5665,7 @@ listSortByChecks =
 listSortWithChecks : IntoFnCheck
 listSortWithChecks =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (unnecessaryCallOnEmptyCheck listCollection)
+        [ unnecessaryCallOnEmptyCheck listCollection
         , unnecessaryCallOnWrappedCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
@@ -5712,9 +5710,10 @@ listSortWithChecks =
 
 listTakeChecks : IntoFnCheck
 listTakeChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ \checkInfo ->
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryCallOnEmptyCheck listCollection
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
                 case Evaluate.getInt checkInfo checkInfo.firstArg of
                     Just length ->
                         callWithNonPositiveIntCanBeReplacedByCheck
@@ -5726,16 +5725,16 @@ listTakeChecks =
 
                     Nothing ->
                         Nothing
-            , unnecessaryCallOnEmptyCheck listCollection
-            ]
-        )
+            )
+        ]
 
 
 listDropChecks : IntoFnCheck
 listDropChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ \checkInfo ->
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryCallOnEmptyCheck listCollection
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
                 Evaluate.getInt checkInfo checkInfo.firstArg
                     |> Maybe.andThen
                         (\count ->
@@ -5753,9 +5752,8 @@ listDropChecks =
                                 ]
                                 ()
                         )
-            , unnecessaryCallOnEmptyCheck listCollection
-            ]
-        )
+            )
+        ]
 
 
 listUnzipChecks : IntoFnCheck
@@ -5805,17 +5803,15 @@ arrayInitializeChecks =
 
 arrayMapChecks : IntoFnCheck
 arrayMapChecks =
-    intoFnCheckOnlyCall (emptiableMapChecks arrayCollection)
+    emptiableMapChecks arrayCollection
 
 
 arrayIndexedMapChecks : IntoFnCheck
 arrayIndexedMapChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ unnecessaryCallOnEmptyCheck arrayCollection
-            , operationWithExtraArgChecks { operationWithoutExtraArg = Fn.Array.map }
-            ]
-        )
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryCallOnEmptyCheck arrayCollection
+        , intoFnCheckOnlyCall (operationWithExtraArgChecks { operationWithoutExtraArg = Fn.Array.map })
+        ]
 
 
 arrayIsEmptyChecks : IntoFnCheck
@@ -5877,17 +5873,17 @@ arrayLengthOnArrayRepeatOrInitializeChecks checkInfo =
 
 arraySetChecks : IntoFnCheck
 arraySetChecks =
-    intoFnCheckOnlyCall (setChecks arrayCollection)
+    setChecks arrayCollection
 
 
 arraySliceChecks : IntoFnCheck
 arraySliceChecks =
-    intoFnCheckOnlyCall (collectionSliceChecks arrayCollection)
+    collectionSliceChecks arrayCollection
 
 
 arrayFilterChecks : IntoFnCheck
 arrayFilterChecks =
-    intoFnCheckOnlyCall (emptiableKeepWhenChecks arrayCollection)
+    emptiableKeepWhenChecks arrayCollection
 
 
 arrayAppendChecks : IntoFnCheck
@@ -5940,12 +5936,12 @@ setInsertChecks =
 
 setRemoveChecks : IntoFnCheck
 setRemoveChecks =
-    intoFnCheckOnlyCall (collectionRemoveChecks setCollection)
+    collectionRemoveChecks setCollection
 
 
 setFilterChecks : IntoFnCheck
 setFilterChecks =
-    intoFnCheckOnlyCall (emptiableKeepWhenChecks setCollection)
+    emptiableKeepWhenChecks setCollection
 
 
 setPartitionChecks : IntoFnCheck
@@ -5955,7 +5951,7 @@ setPartitionChecks =
 
 setIntersectChecks : IntoFnCheck
 setIntersectChecks =
-    intoFnCheckOnlyCall (collectionIntersectChecks setCollection)
+    collectionIntersectChecks setCollection
 
 
 setDiffChecks : IntoFnCheck
@@ -5970,7 +5966,7 @@ setUnionChecks =
 
 setMapChecks : IntoFnCheck
 setMapChecks =
-    intoFnCheckOnlyCall (emptiableMapChecks setCollection)
+    emptiableMapChecks setCollection
 
 
 setToListChecks : IntoFnCheck
@@ -6017,12 +6013,12 @@ dictMemberChecks =
 
 dictRemoveChecks : IntoFnCheck
 dictRemoveChecks =
-    intoFnCheckOnlyCall (collectionRemoveChecks dictCollection)
+    collectionRemoveChecks dictCollection
 
 
 dictFilterChecks : IntoFnCheck
 dictFilterChecks =
-    intoFnCheckOnlyCall (emptiableKeepWhenWithExtraArgChecks dictCollection)
+    emptiableKeepWhenWithExtraArgChecks dictCollection
 
 
 dictPartitionChecks : IntoFnCheck
@@ -6032,12 +6028,12 @@ dictPartitionChecks =
 
 dictMapChecks : IntoFnCheck
 dictMapChecks =
-    intoFnCheckOnlyCall (emptiableMapWithExtraArgChecks dictCollection)
+    emptiableMapWithExtraArgChecks dictCollection
 
 
 dictIntersectChecks : IntoFnCheck
 dictIntersectChecks =
-    intoFnCheckOnlyCall (collectionIntersectChecks dictCollection)
+    collectionIntersectChecks dictCollection
 
 
 dictDiffChecks : IntoFnCheck
@@ -6076,7 +6072,7 @@ platformCmdBatchChecks =
 
 platformCmdMapChecks : IntoFnCheck
 platformCmdMapChecks =
-    intoFnCheckOnlyCall (emptiableMapChecks cmdCollection)
+    emptiableMapChecks cmdCollection
 
 
 
@@ -6090,7 +6086,7 @@ platformSubBatchChecks =
 
 platformSubChecks : IntoFnCheck
 platformSubChecks =
-    intoFnCheckOnlyCall (emptiableMapChecks subCollection)
+    emptiableMapChecks subCollection
 
 
 
@@ -6100,7 +6096,7 @@ platformSubChecks =
 taskMapChecks : IntoFnCheck
 taskMapChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = emptiableMapChecks taskWithSucceedAsWrap, composition = unnecessaryCompositionAfterEmptyCheck taskWithSucceedAsWrap }
+        [ emptiableMapChecks taskWithSucceedAsWrap
         , mapOnWrappedChecks taskWithSucceedAsWrap
         ]
 
@@ -6118,7 +6114,7 @@ taskMapNChecks =
 taskAndThenChecks : IntoFnCheck
 taskAndThenChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = unnecessaryCallOnEmptyCheck taskWithSucceedAsWrap, composition = unnecessaryCompositionAfterEmptyCheck taskWithSucceedAsWrap }
+        [ unnecessaryCallOnEmptyCheck taskWithSucceedAsWrap
         , wrapperFlatMapChecks taskWithSucceedAsWrap
         ]
 
@@ -6126,7 +6122,7 @@ taskAndThenChecks =
 taskMapErrorChecks : IntoFnCheck
 taskMapErrorChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = emptiableMapChecks taskWithFailAsWrap, composition = unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap }
+        [ emptiableMapChecks taskWithFailAsWrap
         , mapOnWrappedChecks taskWithFailAsWrap
         ]
 
@@ -6134,7 +6130,7 @@ taskMapErrorChecks =
 taskOnErrorChecks : IntoFnCheck
 taskOnErrorChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = unnecessaryCallOnEmptyCheck taskWithFailAsWrap, composition = unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap }
+        [ unnecessaryCallOnEmptyCheck taskWithFailAsWrap
         , wrapperFlatMapChecks taskWithFailAsWrap
         ]
 
@@ -6259,7 +6255,7 @@ htmlAttributesClassListChecks =
 jsonDecodeMapChecks : IntoFnCheck
 jsonDecodeMapChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = emptiableMapChecks jsonDecoderWithSucceedAsWrap, composition = unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap }
+        [ emptiableMapChecks jsonDecoderWithSucceedAsWrap
         , mapOnWrappedChecks jsonDecoderWithSucceedAsWrap
         ]
 
@@ -6277,7 +6273,7 @@ jsonDecodeMapNChecks =
 jsonDecodeAndThenChecks : IntoFnCheck
 jsonDecodeAndThenChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call = unnecessaryCallOnEmptyCheck jsonDecoderWithSucceedAsWrap, composition = unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap }
+        [ unnecessaryCallOnEmptyCheck jsonDecoderWithSucceedAsWrap
         , wrapperFlatMapChecks jsonDecoderWithSucceedAsWrap
         ]
 
@@ -7648,11 +7644,10 @@ If your mapping function also takes extra information like the key or index as a
 -}
 emptiableMapChecks :
     TypeProperties (EmptiableProperties empty otherProperties)
-    -> CheckInfo
-    -> Maybe (Error {})
+    -> IntoFnCheck
 emptiableMapChecks emptiable =
-    firstThatConstructsJust
-        [ mapIdentityChecks emptiable
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall (mapIdentityChecks emptiable)
         , unnecessaryCallOnEmptyCheck emptiable
         ]
 
@@ -7683,29 +7678,28 @@ mapIdentityChecks mappable checkInfo =
 If your mapping function only takes one value as an argument, use `emptiableMapChecks`.
 
 -}
-emptiableMapWithExtraArgChecks :
-    TypeProperties (EmptiableProperties empty otherProperties)
-    -> CheckInfo
-    -> Maybe (Error {})
+emptiableMapWithExtraArgChecks : TypeProperties (EmptiableProperties empty otherProperties) -> IntoFnCheck
 emptiableMapWithExtraArgChecks emptiable =
-    firstThatConstructsJust
+    intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck emptiable
-        , \checkInfo ->
-            case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
-                Just alwaysResult ->
-                    if AstHelpers.isIdentity checkInfo.lookupTable alwaysResult then
-                        Just
-                            (alwaysReturnsLastArgError
-                                (qualifiedToString checkInfo.fn ++ " with a function that maps to the unchanged value")
-                                emptiable
-                                checkInfo
-                            )
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
+                    Just alwaysResult ->
+                        if AstHelpers.isIdentity checkInfo.lookupTable alwaysResult then
+                            Just
+                                (alwaysReturnsLastArgError
+                                    (qualifiedToString checkInfo.fn ++ " with a function that maps to the unchanged value")
+                                    emptiable
+                                    checkInfo
+                                )
 
-                    else
+                        else
+                            Nothing
+
+                    Nothing ->
                         Nothing
-
-                Nothing ->
-                    Nothing
+            )
         ]
 
 
@@ -7955,25 +7949,24 @@ So for example
     List.concatMap f [] --> []
 
 -}
-emptiableFlatMapChecks :
-    EmptiableProperties ConstantProperties otherProperties
-    -> CheckInfo
-    -> Maybe (Error {})
+emptiableFlatMapChecks : EmptiableProperties ConstantProperties otherProperties -> IntoFnCheck
 emptiableFlatMapChecks emptiable =
-    firstThatConstructsJust
+    intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck emptiable
-        , \checkInfo ->
-            case constructs (sameInAllBranches (getEmptyExpressionNode checkInfo emptiable)) checkInfo.lookupTable checkInfo.firstArg of
-                Just _ ->
-                    Just
-                        (alwaysResultsInUnparenthesizedConstantError
-                            (qualifiedToString checkInfo.fn ++ " with a function that will always return " ++ emptiable.empty.specific.description)
-                            { replacement = emptiable.empty.specific.asString }
-                            checkInfo
-                        )
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                case constructs (sameInAllBranches (getEmptyExpressionNode checkInfo emptiable)) checkInfo.lookupTable checkInfo.firstArg of
+                    Just _ ->
+                        Just
+                            (alwaysResultsInUnparenthesizedConstantError
+                                (qualifiedToString checkInfo.fn ++ " with a function that will always return " ++ emptiable.empty.specific.description)
+                                { replacement = emptiable.empty.specific.asString }
+                                checkInfo
+                            )
 
-                Nothing ->
-                    Nothing
+                    Nothing ->
+                        Nothing
+            )
         ]
 
 
@@ -9628,31 +9621,33 @@ indexAccessChecks collection checkInfo n =
                 Nothing
 
 
-setChecks : TypeProperties (CollectionProperties (EmptiableProperties empty otherProperties)) -> CheckInfo -> Maybe (Error {})
+setChecks : TypeProperties (CollectionProperties (EmptiableProperties empty otherProperties)) -> IntoFnCheck
 setChecks collection =
-    firstThatConstructsJust
+    intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck collection
-        , \checkInfo ->
-            case Evaluate.getInt checkInfo checkInfo.firstArg of
-                Just n ->
-                    if n < 0 then
-                        Just
-                            (alwaysReturnsLastArgError
-                                (qualifiedToString checkInfo.fn ++ " with negative index")
-                                collection
-                                checkInfo
-                            )
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                case Evaluate.getInt checkInfo checkInfo.firstArg of
+                    Just n ->
+                        if n < 0 then
+                            Just
+                                (alwaysReturnsLastArgError
+                                    (qualifiedToString checkInfo.fn ++ " with negative index")
+                                    collection
+                                    checkInfo
+                                )
 
-                    else
-                        case secondArg checkInfo of
-                            Just replacementArg ->
-                                setOnKnownElementChecks collection checkInfo n (Node.range replacementArg)
+                        else
+                            case secondArg checkInfo of
+                                Just replacementArg ->
+                                    setOnKnownElementChecks collection checkInfo n (Node.range replacementArg)
 
-                            Nothing ->
-                                Nothing
+                                Nothing ->
+                                    Nothing
 
-                Nothing ->
-                    Nothing
+                    Nothing ->
+                        Nothing
+            )
         ]
 
 
@@ -9704,7 +9699,7 @@ setOnKnownElementChecks collection checkInfo n replacementArgRange =
 emptiableReverseChecks : EmptiableProperties empty otherProperties -> IntoFnCheck
 emptiableReverseChecks emptiable =
     intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall (unnecessaryCallOnEmptyCheck emptiable)
+        [ unnecessaryCallOnEmptyCheck emptiable
         , toggleFnChecks
         ]
 
@@ -10088,7 +10083,7 @@ emptiableWrapperFilterMapChecks emptiableWrapper =
                         Nothing
             )
         , mapToOperationWithIdentityCanBeCombinedToOperationChecks emptiableWrapper
-        , intoFnCheckOnlyCall (unnecessaryCallOnEmptyCheck emptiableWrapper)
+        , unnecessaryCallOnEmptyCheck emptiableWrapper
         ]
 
 
@@ -10661,12 +10656,41 @@ unnecessaryCallOnCheck constructable checkInfo =
             Nothing
 
 
-unnecessaryCallOnEmptyCheck :
-    EmptiableProperties empty otherProperties
-    -> CheckInfo
-    -> Maybe (Error {})
+{-| The operation is equivalent to identity when applied on an empty value:
+
+    fn .. empty --> empty
+
+    -- only when a constructor fn exists
+    fn .. << emptyConstructor --> emptyConstructor
+
+Examples
+
+    Json.Decode.map f (Json.Decode.fail x)
+    --> Json.Decode.fail x
+
+    Json.Decode.map f << Json.Decode.fail
+    --> Json.Decode.fail
+
+    Task.mapError f (Task.succeed a)
+    --> Task.succeed a
+
+    Task.mapError f << Task.succeed
+    --> Task.succeed
+
+Use together with `unnecessaryCallOnEmptyCheck`
+
+-}
+unnecessaryCallOnEmptyCheck : EmptiableProperties empty otherProperties -> IntoFnCheck
 unnecessaryCallOnEmptyCheck emptiable =
-    unnecessaryCallOnCheck emptiable.empty
+    { call = unnecessaryCallOnCheck emptiable.empty
+    , composition =
+        case emptiable.empty.kind emptiable.empty.specific of
+            Constant _ ->
+                \_ -> Nothing
+
+            ConstructWithOneArg constructWithOneArg ->
+                \checkInfo -> unnecessaryCompositionAfterCheck constructWithOneArg checkInfo
+    }
 
 
 callOnEmptyReturnsCheck :
@@ -10699,29 +10723,6 @@ callOnEmptyReturnsCheck config collection checkInfo =
 
         Nothing ->
             Nothing
-
-
-{-| The operation is equivalent to identity when applied on an empty value:
-
-    operation << empty --> empty
-
-Examples
-
-    Json.Decode.map f << Json.Decode.fail
-    --> Json.Decode.fail
-
-    Task.mapError << Task.succeed
-    --> Task.succeed
-
-Use together with `unnecessaryCallOnEmptyCheck`
-
--}
-unnecessaryCompositionAfterEmptyCheck :
-    EmptiableProperties ConstructWithOneArgProperties otherProperties
-    -> CompositionIntoCheckInfo
-    -> Maybe ErrorInfoAndFix
-unnecessaryCompositionAfterEmptyCheck emptiable =
-    unnecessaryCompositionAfterCheck emptiable.empty.specific
 
 
 unnecessaryCompositionAfterCheck :
@@ -10930,17 +10931,19 @@ callOnWrapReturnsJustItsValue wrapper =
 If your function only takes two arguments like `Dict.filter`, use `emptiableKeepWhenWithExtraArgChecks`
 
 -}
-emptiableKeepWhenChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> CheckInfo -> Maybe (Error {})
+emptiableKeepWhenChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> IntoFnCheck
 emptiableKeepWhenChecks emptiable =
-    firstThatConstructsJust
+    intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck emptiable
-        , \checkInfo ->
-            case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
-                Just constantFunctionResult ->
-                    keepWhenWithConstantFunctionResultChecks constantFunctionResult emptiable checkInfo
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
+                    Just constantFunctionResult ->
+                        keepWhenWithConstantFunctionResultChecks constantFunctionResult emptiable checkInfo
 
-                Nothing ->
-                    Nothing
+                    Nothing ->
+                        Nothing
+            )
         ]
 
 
@@ -10978,119 +10981,125 @@ keepWhenWithConstantFunctionResultChecks constantFunctionResult emptiable checkI
 If your function only takes one argument like `List.filter`, use `emptiableKeepWhenChecks`
 
 -}
-emptiableKeepWhenWithExtraArgChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> CheckInfo -> Maybe (Error {})
+emptiableKeepWhenWithExtraArgChecks : TypeProperties (EmptiableProperties ConstantProperties otherProperties) -> IntoFnCheck
 emptiableKeepWhenWithExtraArgChecks emptiable =
-    firstThatConstructsJust
+    intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck emptiable
-        , \checkInfo ->
-            let
-                maybeFilterFunctionResult : Maybe (Node Expression)
-                maybeFilterFunctionResult =
-                    checkInfo.firstArg
-                        |> AstHelpers.getAlwaysResult checkInfo.lookupTable
-                        |> Maybe.andThen (AstHelpers.getAlwaysResult checkInfo.lookupTable)
-            in
-            case maybeFilterFunctionResult of
-                Just constantFunctionResult ->
-                    keepWhenWithConstantFunctionResultChecks constantFunctionResult emptiable checkInfo
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                let
+                    maybeFilterFunctionResult : Maybe (Node Expression)
+                    maybeFilterFunctionResult =
+                        checkInfo.firstArg
+                            |> AstHelpers.getAlwaysResult checkInfo.lookupTable
+                            |> Maybe.andThen (AstHelpers.getAlwaysResult checkInfo.lookupTable)
+                in
+                case maybeFilterFunctionResult of
+                    Just constantFunctionResult ->
+                        keepWhenWithConstantFunctionResultChecks constantFunctionResult emptiable checkInfo
 
-                Nothing ->
-                    Nothing
+                    Nothing ->
+                        Nothing
+            )
         ]
 
 
-collectionRemoveChecks : CollectionProperties (EmptiableProperties empty otherProperties) -> CheckInfo -> Maybe (Error {})
+collectionRemoveChecks : CollectionProperties (EmptiableProperties empty otherProperties) -> IntoFnCheck
 collectionRemoveChecks collection =
     unnecessaryCallOnEmptyCheck collection
 
 
-collectionSliceChecks : EmptiableProperties ConstantProperties otherProperties -> CheckInfo -> Maybe (Error {})
+collectionSliceChecks : EmptiableProperties ConstantProperties otherProperties -> IntoFnCheck
 collectionSliceChecks collection =
-    firstThatConstructsJust
+    intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck collection
-        , \checkInfo ->
-            case secondArg checkInfo of
-                Just endArg ->
-                    firstThatConstructsJust
-                        [ \() ->
-                            if Normalize.areAllTheSame checkInfo checkInfo.firstArg [ endArg ] then
-                                Just
-                                    (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with equal start and end index")
-                                        { replacement = collection.empty.specific.asString }
-                                        checkInfo
-                                    )
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                case secondArg checkInfo of
+                    Just endArg ->
+                        firstThatConstructsJust
+                            [ \() ->
+                                if Normalize.areAllTheSame checkInfo checkInfo.firstArg [ endArg ] then
+                                    Just
+                                        (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with equal start and end index")
+                                            { replacement = collection.empty.specific.asString }
+                                            checkInfo
+                                        )
 
-                            else
-                                Nothing
-                        , \() ->
-                            case Evaluate.getInt checkInfo endArg of
-                                Just endInt ->
-                                    firstThatConstructsJust
-                                        [ \() ->
-                                            case endInt of
-                                                0 ->
-                                                    Just
-                                                        (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with end index 0")
-                                                            { replacement = collection.empty.specific.asString }
-                                                            checkInfo
-                                                        )
+                                else
+                                    Nothing
+                            , \() ->
+                                case Evaluate.getInt checkInfo endArg of
+                                    Just endInt ->
+                                        firstThatConstructsJust
+                                            [ \() ->
+                                                case endInt of
+                                                    0 ->
+                                                        Just
+                                                            (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with end index 0")
+                                                                { replacement = collection.empty.specific.asString }
+                                                                checkInfo
+                                                            )
 
-                                                _ ->
-                                                    Nothing
-                                        , \() ->
-                                            case Evaluate.getInt checkInfo checkInfo.firstArg of
-                                                Just startInt ->
-                                                    if startInt > endInt then
-                                                        if startInt >= 0 && endInt >= 0 then
-                                                            Just
-                                                                (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with a start index greater than the end index")
-                                                                    { replacement = collection.empty.specific.asString }
-                                                                    checkInfo
-                                                                )
+                                                    _ ->
+                                                        Nothing
+                                            , \() ->
+                                                case Evaluate.getInt checkInfo checkInfo.firstArg of
+                                                    Just startInt ->
+                                                        if startInt > endInt then
+                                                            if startInt >= 0 && endInt >= 0 then
+                                                                Just
+                                                                    (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with a start index greater than the end index")
+                                                                        { replacement = collection.empty.specific.asString }
+                                                                        checkInfo
+                                                                    )
 
-                                                        else if startInt <= -1 && endInt <= -1 then
-                                                            Just
-                                                                (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with a negative start index closer to the right than the negative end index")
-                                                                    { replacement = collection.empty.specific.asString }
-                                                                    checkInfo
-                                                                )
+                                                            else if startInt <= -1 && endInt <= -1 then
+                                                                Just
+                                                                    (alwaysResultsInUnparenthesizedConstantError (qualifiedToString checkInfo.fn ++ " with a negative start index closer to the right than the negative end index")
+                                                                        { replacement = collection.empty.specific.asString }
+                                                                        checkInfo
+                                                                    )
+
+                                                            else
+                                                                Nothing
 
                                                         else
                                                             Nothing
 
-                                                    else
+                                                    Nothing ->
                                                         Nothing
+                                            ]
+                                            ()
 
-                                                Nothing ->
-                                                    Nothing
-                                        ]
-                                        ()
+                                    Nothing ->
+                                        Nothing
+                            ]
+                            ()
 
-                                Nothing ->
-                                    Nothing
-                        ]
-                        ()
-
-                Nothing ->
-                    Nothing
+                    Nothing ->
+                        Nothing
+            )
         ]
 
 
-collectionIntersectChecks : CollectionProperties (EmptiableProperties ConstantProperties otherProperties) -> CheckInfo -> Maybe (Error {})
+collectionIntersectChecks : CollectionProperties (EmptiableProperties ConstantProperties otherProperties) -> IntoFnCheck
 collectionIntersectChecks collection =
-    firstThatConstructsJust
-        [ \checkInfo ->
-            if collection.empty.specific.is (extractInferResources checkInfo) checkInfo.firstArg then
-                Just
-                    (alwaysResultsInUnparenthesizedConstantError
-                        (qualifiedToString checkInfo.fn ++ " on " ++ collection.empty.specific.description)
-                        { replacement = collection.empty.specific.asString }
-                        checkInfo
-                    )
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryCallOnEmptyCheck collection
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                if collection.empty.specific.is (extractInferResources checkInfo) checkInfo.firstArg then
+                    Just
+                        (alwaysResultsInUnparenthesizedConstantError
+                            (qualifiedToString checkInfo.fn ++ " on " ++ collection.empty.specific.description)
+                            { replacement = collection.empty.specific.asString }
+                            checkInfo
+                        )
 
-            else
-                Nothing
-        , unnecessaryCallOnEmptyCheck collection
+                else
+                    Nothing
+            )
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2974,7 +2974,7 @@ intoFnChecks =
         , ( Fn.Result.andThen, ( 2, resultAndThenChecks ) )
         , ( Fn.Result.withDefault, ( 2, resultWithDefaultChecks ) )
         , ( Fn.Result.toMaybe, ( 1, resultToMaybeChecks ) )
-        , ( Fn.Result.fromMaybe, ( 2, resultFromMaybeChecks ) )
+        , ( Fn.Result.fromMaybe, ( 2, resultfromMaybeWithEmptyValueOnNothingCheck ) )
         , ( Fn.List.append, ( 2, listAppendChecks ) )
         , ( Fn.List.head, ( 1, listHeadChecks ) )
         , ( Fn.List.tail, ( 1, listTailChecks ) )
@@ -4763,9 +4763,9 @@ resultToMaybeChecks =
         ]
 
 
-resultFromMaybeChecks : IntoFnCheck
-resultFromMaybeChecks =
-    fromMaybeChecks resultWithOkAsWrap
+resultfromMaybeWithEmptyValueOnNothingCheck : IntoFnCheck
+resultfromMaybeWithEmptyValueOnNothingCheck =
+    fromMaybeWithEmptyValueOnNothingCheck resultWithOkAsWrap
 
 
 
@@ -8153,8 +8153,8 @@ unwrapToMaybeChecks emptiableWrapper =
         ]
 
 
-fromMaybeChecks : WrapperProperties (EmptiableProperties ConstructWithOneArgProperties otherProperties) -> IntoFnCheck
-fromMaybeChecks wrapper =
+fromMaybeWithEmptyValueOnNothingCheck : WrapperProperties (EmptiableProperties ConstructWithOneArgProperties otherProperties) -> IntoFnCheck
+fromMaybeWithEmptyValueOnNothingCheck wrapper =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall
             (\checkInfo ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6370,7 +6370,7 @@ type alias TypeSubsetProperties specificProperties =
 
 -}
 type TypeSubsetKindProperties
-    = ConstructWithOneArg ConstructWithOneArgProperties
+    = ConstructWithOneValue ConstructWithOneArgProperties
     | Constant ConstantProperties
 
 
@@ -6399,8 +6399,8 @@ isInTypeSubset typeSubsetProperties resources expressionNode =
         Constant constantProperties ->
             constantProperties.is (extractInferResources resources) expressionNode
 
-        ConstructWithOneArg constructWithOneArg ->
-            isJust (constructWithOneArg.getValue resources.lookupTable expressionNode)
+        ConstructWithOneValue constructWithOneValue ->
+            isJust (constructWithOneValue.getValue resources.lookupTable expressionNode)
 
 
 typeSubsetDescriptionIndefinite : TypeSubsetProperties specificProperties -> String
@@ -6409,8 +6409,8 @@ typeSubsetDescriptionIndefinite typeSubsetProperties =
         Constant constantProperties ->
             constantProperties.description
 
-        ConstructWithOneArg constructWithOneArg ->
-            constructWithOneArgDescriptionIndefinite constructWithOneArg.description
+        ConstructWithOneValue constructWithOneValue ->
+            constructWithOneArgDescriptionIndefinite constructWithOneValue.description
 
 
 typeSubsetDescriptionDefinite : String -> TypeSubsetProperties specificProperties -> String
@@ -6419,8 +6419,8 @@ typeSubsetDescriptionDefinite definiteArticle typeSubsetProperties =
         Constant constantProperties ->
             constantProperties.description
 
-        ConstructWithOneArg constructWithOneArg ->
-            constructWithOneArgDescriptionDefinite definiteArticle constructWithOneArg.description
+        ConstructWithOneValue constructWithOneValue ->
+            constructWithOneArgDescriptionDefinite definiteArticle constructWithOneValue.description
 
 
 typeSubsetDescriptionWithoutArticle : TypeSubsetProperties specificProperties -> String
@@ -6429,8 +6429,8 @@ typeSubsetDescriptionWithoutArticle typeSubsetProperties =
         Constant constantProperties ->
             constantProperties.description
 
-        ConstructWithOneArg constructWithOneArg ->
-            constructWithOneArgDescriptionWithoutArticle constructWithOneArg.description
+        ConstructWithOneValue constructWithOneValue ->
+            constructWithOneArgDescriptionWithoutArticle constructWithOneValue.description
 
 
 {-| Create `ConstantProperties` for a value with a given fully qualified name.
@@ -6708,7 +6708,7 @@ resultWithOkAsWrap : TypeProperties (WrapperProperties (EmptiableProperties Cons
 resultWithOkAsWrap =
     { represents = "result"
     , wrap = resultOkayConstruct
-    , empty = { specific = resultErrorConstruct, kind = ConstructWithOneArg }
+    , empty = { specific = resultErrorConstruct, kind = ConstructWithOneValue }
     , mapFn = Fn.Result.map
     }
 
@@ -6727,7 +6727,7 @@ resultWithErrAsWrap : TypeProperties (WrapperProperties (EmptiableProperties Con
 resultWithErrAsWrap =
     { represents = "result"
     , wrap = resultErrorConstruct
-    , empty = { specific = resultOkayConstruct, kind = ConstructWithOneArg }
+    , empty = { specific = resultOkayConstruct, kind = ConstructWithOneValue }
     , mapFn = Fn.Result.mapError
     }
 
@@ -6736,7 +6736,7 @@ taskWithSucceedAsWrap : TypeProperties (WrapperProperties (EmptiableProperties C
 taskWithSucceedAsWrap =
     { represents = "task"
     , wrap = taskSucceedingConstruct
-    , empty = { specific = taskFailingConstruct, kind = ConstructWithOneArg }
+    , empty = { specific = taskFailingConstruct, kind = ConstructWithOneValue }
     , mapFn = Fn.Task.map
     }
 
@@ -6755,7 +6755,7 @@ taskWithFailAsWrap : TypeProperties (WrapperProperties (EmptiableProperties Cons
 taskWithFailAsWrap =
     { represents = "task"
     , wrap = taskFailingConstruct
-    , empty = { specific = taskSucceedingConstruct, kind = ConstructWithOneArg }
+    , empty = { specific = taskSucceedingConstruct, kind = ConstructWithOneValue }
     , mapFn = Fn.Task.mapError
     }
 
@@ -6764,7 +6764,7 @@ jsonDecoderWithSucceedAsWrap : TypeProperties (WrapperProperties (EmptiablePrope
 jsonDecoderWithSucceedAsWrap =
     { represents = "json decoder"
     , wrap = jsonDecoderSucceedingConstruct
-    , empty = { specific = jsonDecoderFailingConstruct, kind = ConstructWithOneArg }
+    , empty = { specific = jsonDecoderFailingConstruct, kind = ConstructWithOneValue }
     , mapFn = Fn.Json.Decode.map
     }
 
@@ -10513,7 +10513,7 @@ So for example
 -}
 unnecessaryOnWrappedCheck : WrapperProperties otherProperties -> IntoFnCheck
 unnecessaryOnWrappedCheck wrapper =
-    { call = unnecessaryCallOnCheck { specific = wrapper.wrap, kind = ConstructWithOneArg }
+    { call = unnecessaryCallOnCheck { specific = wrapper.wrap, kind = ConstructWithOneValue }
     , composition = unnecessaryCompositionAfterCheck wrapper.wrap
     }
 
@@ -10584,8 +10584,8 @@ unnecessaryOnEmptyCheck emptiable =
             Constant _ ->
                 \_ -> Nothing
 
-            ConstructWithOneArg constructWithOneArg ->
-                \checkInfo -> unnecessaryCompositionAfterCheck constructWithOneArg checkInfo
+            ConstructWithOneValue constructWithOneValue ->
+                \checkInfo -> unnecessaryCompositionAfterCheck constructWithOneValue checkInfo
     }
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4967,7 +4967,7 @@ listMapChecks =
         [ emptiableMapChecks listCollection
         , listMapOnSingletonCheck
         , { call = dictToListMapChecks, composition = dictToListIntoListMapCompositionCheck }
-        , { call = arrayToIndexedListToListMapChecks, composition = arrayToIndexedListMapCompositionCheck }
+        ,  arrayToIndexedListToListMapChecks
         ]
 
 
@@ -5114,40 +5114,66 @@ dictToListMapChecks listMapCheckInfo =
             Nothing
 
 
-arrayToIndexedListToListMapChecks : CheckInfo -> Maybe (Error {})
-arrayToIndexedListToListMapChecks listMapCheckInfo =
-    case secondArg listMapCheckInfo of
-        Just listArgument ->
-            case AstHelpers.getSpecificFnCall Fn.Array.toIndexedList listMapCheckInfo.lookupTable listArgument of
-                Just arrayToIndexedList ->
-                    if AstHelpers.isTupleSecondAccess listMapCheckInfo.lookupTable listMapCheckInfo.firstArg then
+arrayToIndexedListToListMapChecks : IntoFnCheck
+arrayToIndexedListToListMapChecks =
+    { call =
+        \listMapCheckInfo ->
+            case secondArg listMapCheckInfo of
+                Just listArgument ->
+                    case AstHelpers.getSpecificFnCall Fn.Array.toIndexedList listMapCheckInfo.lookupTable listArgument of
+                        Just arrayToIndexedList ->
+                            if AstHelpers.isTupleSecondAccess listMapCheckInfo.lookupTable listMapCheckInfo.firstArg then
+                                let
+                                    combinedFn : ( ModuleName, String )
+                                    combinedFn =
+                                        Fn.Array.toList
+                                in
+                                Just
+                                    (Rule.errorWithFix
+                                        { message = qualifiedToString Fn.Array.toIndexedList ++ ", then " ++ qualifiedToString Fn.List.map ++ " " ++ qualifiedToString Fn.Tuple.second ++ " is the same as " ++ qualifiedToString combinedFn
+                                        , details = [ "You can replace this call by " ++ qualifiedToString combinedFn ++ " on the array given to " ++ qualifiedToString Fn.Array.toIndexedList ++ " which is meant for this exact purpose and will also be faster." ]
+                                        }
+                                        listMapCheckInfo.fnRange
+                                        (keepOnlyFix { parentRange = Node.range listArgument, keep = Node.range arrayToIndexedList.firstArg }
+                                            ++ [ Fix.replaceRangeBy
+                                                    (Range.combine [ listMapCheckInfo.fnRange, Node.range listMapCheckInfo.firstArg ])
+                                                    (qualifiedToString (qualify combinedFn listMapCheckInfo))
+                                               ]
+                                        )
+                                    )
+
+                            else
+                                Nothing
+
+                        Nothing ->
+                            Nothing
+
+                Nothing ->
+                    Nothing
+    , composition =
+        \checkInfo ->
+            case ( checkInfo.earlier.fn, checkInfo.later.args ) of
+                ( ( [ "Array" ], "toIndexedList" ), elementMappingArg :: [] ) ->
+                    if AstHelpers.isTupleSecondAccess checkInfo.lookupTable elementMappingArg then
                         let
                             combinedFn : ( ModuleName, String )
                             combinedFn =
                                 Fn.Array.toList
                         in
                         Just
-                            (Rule.errorWithFix
+                            { info =
                                 { message = qualifiedToString Fn.Array.toIndexedList ++ ", then " ++ qualifiedToString Fn.List.map ++ " " ++ qualifiedToString Fn.Tuple.second ++ " is the same as " ++ qualifiedToString combinedFn
-                                , details = [ "You can replace this call by " ++ qualifiedToString combinedFn ++ " on the array given to " ++ qualifiedToString Fn.Array.toIndexedList ++ " which is meant for this exact purpose and will also be faster." ]
+                                , details = [ "You can replace this composition by " ++ qualifiedToString combinedFn ++ " which is meant for this exact purpose and will also be faster." ]
                                 }
-                                listMapCheckInfo.fnRange
-                                (keepOnlyFix { parentRange = Node.range listArgument, keep = Node.range arrayToIndexedList.firstArg }
-                                    ++ [ Fix.replaceRangeBy
-                                            (Range.combine [ listMapCheckInfo.fnRange, Node.range listMapCheckInfo.firstArg ])
-                                            (qualifiedToString (qualify combinedFn listMapCheckInfo))
-                                       ]
-                                )
-                            )
+                            , fix = compositionReplaceByFnFix combinedFn checkInfo
+                            }
 
                     else
                         Nothing
 
-                Nothing ->
+                _ ->
                     Nothing
-
-        Nothing ->
-            Nothing
+    }
 
 
 dictToListIntoListMapCompositionCheck : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
@@ -5170,31 +5196,6 @@ dictToListIntoListMapCompositionCheck checkInfo =
 
             else if AstHelpers.isTupleSecondAccess checkInfo.lookupTable elementMappingArg then
                 Just (error { tuplePart = "second", toEntryAspectList = "values" })
-
-            else
-                Nothing
-
-        _ ->
-            Nothing
-
-
-arrayToIndexedListMapCompositionCheck : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-arrayToIndexedListMapCompositionCheck checkInfo =
-    case ( checkInfo.earlier.fn, checkInfo.later.args ) of
-        ( ( [ "Array" ], "toIndexedList" ), elementMappingArg :: [] ) ->
-            if AstHelpers.isTupleSecondAccess checkInfo.lookupTable elementMappingArg then
-                let
-                    combinedFn : ( ModuleName, String )
-                    combinedFn =
-                        Fn.Array.toList
-                in
-                Just
-                    { info =
-                        { message = qualifiedToString Fn.Array.toIndexedList ++ ", then " ++ qualifiedToString Fn.List.map ++ " " ++ qualifiedToString Fn.Tuple.second ++ " is the same as " ++ qualifiedToString combinedFn
-                        , details = [ "You can replace this composition by " ++ qualifiedToString combinedFn ++ " which is meant for this exact purpose and will also be faster." ]
-                        }
-                    , fix = compositionReplaceByFnFix combinedFn checkInfo
-                    }
 
             else
                 Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5273,7 +5273,7 @@ listMinimumChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall
             (callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.specific.asString } listCollection)
-        , callOnWrapReturnsJustItsValue listCollection
+        , onWrappedReturnsJustItsValueCheck listCollection
         ]
 
 
@@ -5282,7 +5282,7 @@ listMaximumChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall
             (callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.specific.asString } listCollection)
-        , callOnWrapReturnsJustItsValue listCollection
+        , onWrappedReturnsJustItsValueCheck listCollection
         ]
 
 
@@ -8144,7 +8144,7 @@ unwrapToMaybeChecks :
     -> IntoFnCheck
 unwrapToMaybeChecks emptiableWrapper =
     intoFnChecksFirstThatConstructsError
-        [ callOnWrapReturnsJustItsValue emptiableWrapper
+        [ onWrappedReturnsJustItsValueCheck emptiableWrapper
         , intoFnCheckOnlyCall
             (callOnEmptyReturnsCheck
                 { resultAsString = \res -> qualifiedToString (qualify Fn.Maybe.nothingVariant res) }
@@ -10861,8 +10861,8 @@ For example
     Result.toMaybe << Ok --> Just
 
 -}
-callOnWrapReturnsJustItsValue : WrapperProperties otherProperties -> IntoFnCheck
-callOnWrapReturnsJustItsValue wrapper =
+onWrappedReturnsJustItsValueCheck : WrapperProperties otherProperties -> IntoFnCheck
+onWrappedReturnsJustItsValueCheck wrapper =
     { call =
         \checkInfo ->
             case fullyAppliedLastArg checkInfo of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -7784,8 +7784,6 @@ So for example
     Random.map f << Random.constant
     --> Random.constant << f
 
-Use together with `mapAfterWrapCompositionChecks`.
-
 -}
 mapOnWrappedChecks : WrapperProperties otherProperties -> IntoFnCheck
 mapOnWrappedChecks wrapper =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -8297,8 +8297,6 @@ So for example with `emptiableWrapperFlatFromListChecks stringCollection`
     String.concat [ "hello", "", "world" ]
     --> String.concat [ "hello", "world" ]
 
-Use together with `wrapperFlatFromListCompositionChecks`.
-
 -}
 emptiableWrapperFlatFromListChecks : EmptiableProperties ConstantProperties otherProperties -> IntoFnCheck
 emptiableWrapperFlatFromListChecks batchable =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3884,19 +3884,16 @@ basicsAlwaysChecks =
 
 basicsNegateChecks : IntoFnCheck
 basicsNegateChecks =
-    { call = toggleCallChecks, composition = toggleCompositionChecks }
+    toggleFnChecks
 
 
 basicsNotChecks : IntoFnCheck
 basicsNotChecks =
-    { call =
-        firstThatConstructsJust
-            [ notOnKnownBoolCheck
-            , toggleCallChecks
-            , isNotOnBooleanOperatorCheck
-            ]
-    , composition = toggleCompositionChecks
-    }
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall notOnKnownBoolCheck
+        , toggleFnChecks
+        , intoFnCheckOnlyCall isNotOnBooleanOperatorCheck
+        ]
 
 
 notOnKnownBoolCheck : CheckInfo -> Maybe (Error {})
@@ -4008,13 +4005,10 @@ basicsToFloatChecks =
 
 intToIntChecks : IntoFnCheck
 intToIntChecks =
-    { call =
-        firstThatConstructsJust
-            [ unnecessaryConversionToIntOnIntCheck
-            , onCallToInverseReturnsItsArgumentCheck Fn.Basics.toFloat
-            ]
-    , composition = inversesCompositionCheck Fn.Basics.toFloat
-    }
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall unnecessaryConversionToIntOnIntCheck
+        , onCallToInverseReturnsItsArgumentCheck Fn.Basics.toFloat
+        ]
 
 
 unnecessaryConversionToIntOnIntCheck : CheckInfo -> Maybe (Error {})
@@ -4482,18 +4476,14 @@ tuplePartCompositionChecks partConfig =
 
 stringFromListChecks : IntoFnCheck
 stringFromListChecks =
-    { call =
-        firstThatConstructsJust
-            [ callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.specific.asString } listCollection
-            , wrapperFromListSingletonChecks stringCollection
-            , onCallToInverseReturnsItsArgumentCheck Fn.String.toList
-            ]
-    , composition =
-        firstThatConstructsJust
-            [ wrapperFromListSingletonCompositionChecks stringCollection
-            , inversesCompositionCheck Fn.String.toList
-            ]
-    }
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall
+            (callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.specific.asString } listCollection)
+        , { call = wrapperFromListSingletonChecks stringCollection
+          , composition = wrapperFromListSingletonCompositionChecks stringCollection
+          }
+        , onCallToInverseReturnsItsArgumentCheck Fn.String.toList
+        ]
 
 
 stringIsEmptyChecks : IntoFnCheck
@@ -4513,17 +4503,10 @@ stringSliceChecks =
 
 stringReverseChecks : IntoFnCheck
 stringReverseChecks =
-    { call =
-        firstThatConstructsJust
-            [ emptiableReverseChecks stringCollection
-            , unnecessaryCallOnWrappedCheck stringCollection
-            ]
-    , composition =
-        firstThatConstructsJust
-            [ unnecessaryCompositionAfterWrapCheck stringCollection
-            , toggleCompositionChecks
-            ]
-    }
+    intoFnChecksFirstThatConstructsError
+        [ emptiableReverseChecks stringCollection
+        , { call = unnecessaryCallOnWrappedCheck stringCollection, composition = unnecessaryCompositionAfterWrapCheck stringCollection }
+        ]
 
 
 stringLeftChecks : IntoFnCheck
@@ -4664,9 +4647,7 @@ stringLinesChecks =
 
 stringToListChecks : IntoFnCheck
 stringToListChecks =
-    { call = onCallToInverseReturnsItsArgumentCheck Fn.String.fromList
-    , composition = inversesCompositionCheck Fn.String.fromList
-    }
+    onCallToInverseReturnsItsArgumentCheck Fn.String.fromList
 
 
 stringFoldlChecks : IntoFnCheck
@@ -5647,17 +5628,10 @@ listRepeatChecks =
 
 listReverseChecks : IntoFnCheck
 listReverseChecks =
-    { call =
-        firstThatConstructsJust
-            [ emptiableReverseChecks listCollection
-            , unnecessaryCallOnWrappedCheck listCollection
-            ]
-    , composition =
-        firstThatConstructsJust
-            [ unnecessaryCompositionAfterWrapCheck listCollection
-            , toggleCompositionChecks
-            ]
-    }
+    intoFnChecksFirstThatConstructsError
+        [ emptiableReverseChecks listCollection
+        , { call = unnecessaryCallOnWrappedCheck listCollection, composition = unnecessaryCompositionAfterWrapCheck listCollection }
+        ]
 
 
 listSortChecks : IntoFnCheck
@@ -5806,14 +5780,9 @@ listUnzipChecks =
 arrayToListChecks : IntoFnCheck
 arrayToListChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call =
-                firstThatConstructsJust
-                    [ callOnEmptyReturnsCheck { resultAsString = listCollection.empty.specific.asString } arrayCollection
-                    , onCallToInverseReturnsItsArgumentCheck Fn.Array.fromList
-                    ]
-          , composition =
-                inversesCompositionCheck Fn.Array.fromList
-          }
+        [ intoFnCheckOnlyCall
+            (callOnEmptyReturnsCheck { resultAsString = listCollection.empty.specific.asString } arrayCollection)
+        , onCallToInverseReturnsItsArgumentCheck Fn.Array.fromList
         , callFromCanBeCombinedCheck
             { fromFn = Fn.Array.repeat, combinedFn = Fn.List.repeat }
         ]
@@ -5827,13 +5796,10 @@ arrayToIndexedListChecks =
 
 arrayFromListChecks : IntoFnCheck
 arrayFromListChecks =
-    { call =
-        firstThatConstructsJust
-            [ collectionFromListChecks arrayCollection
-            , onCallToInverseReturnsItsArgumentCheck Fn.Array.toList
-            ]
-    , composition = inversesCompositionCheck Fn.Array.toList
-    }
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall (collectionFromListChecks arrayCollection)
+        , onCallToInverseReturnsItsArgumentCheck Fn.Array.toList
+        ]
 
 
 arrayRepeatChecks : IntoFnCheck
@@ -5954,18 +5920,11 @@ arrayFoldrChecks =
 
 setFromListChecks : IntoFnCheck
 setFromListChecks =
-    { call =
-        firstThatConstructsJust
-            [ collectionFromListChecks setCollection
-            , wrapperFromListSingletonChecks setCollection
-            , onCallToInverseReturnsItsArgumentCheck Fn.Set.toList
-            ]
-    , composition =
-        firstThatConstructsJust
-            [ wrapperFromListSingletonCompositionChecks setCollection
-            , inversesCompositionCheck Fn.Set.toList
-            ]
-    }
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall (collectionFromListChecks setCollection)
+        , { call = wrapperFromListSingletonChecks setCollection, composition = wrapperFromListSingletonCompositionChecks setCollection }
+        , onCallToInverseReturnsItsArgumentCheck Fn.Set.toList
+        ]
 
 
 setIsEmptyChecks : IntoFnCheck
@@ -6044,14 +6003,10 @@ setFoldrChecks =
 
 dictFromListChecks : IntoFnCheck
 dictFromListChecks =
-    { call =
-        firstThatConstructsJust
-            [ collectionFromListChecks dictCollection
-            , onCallToInverseReturnsItsArgumentCheck Fn.Dict.toList
-            ]
-    , composition =
-        inversesCompositionCheck Fn.Dict.toList
-    }
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall (collectionFromListChecks dictCollection)
+        , onCallToInverseReturnsItsArgumentCheck Fn.Dict.toList
+        ]
 
 
 dictIsEmptyChecks : IntoFnCheck
@@ -9755,11 +9710,11 @@ setOnKnownElementChecks collection checkInfo n replacementArgRange =
             Nothing
 
 
-emptiableReverseChecks : EmptiableProperties empty otherProperties -> CheckInfo -> Maybe (Error {})
+emptiableReverseChecks : EmptiableProperties empty otherProperties -> IntoFnCheck
 emptiableReverseChecks emptiable =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck emptiable
-        , toggleCallChecks
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall (unnecessaryCallOnEmptyCheck emptiable)
+        , toggleFnChecks
         ]
 
 
@@ -10590,14 +10545,11 @@ operationDoesNotChangeResultOfOperationCompositionCheck checkInfo =
         Nothing
 
 
-toggleCallChecks : CheckInfo -> Maybe (Error {})
-toggleCallChecks checkInfo =
-    onCallToInverseReturnsItsArgumentCheck checkInfo.fn checkInfo
-
-
-toggleCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-toggleCompositionChecks checkInfo =
-    inversesCompositionCheck checkInfo.later.fn checkInfo
+toggleFnChecks : IntoFnCheck
+toggleFnChecks =
+    { call = \checkInfo -> (onCallToInverseReturnsItsArgumentCheck checkInfo.fn).call checkInfo
+    , composition = \checkInfo -> (onCallToInverseReturnsItsArgumentCheck checkInfo.later.fn).composition checkInfo
+    }
 
 
 {-| Chaining two operations that are inverses of each other and therefore cancel each other out.
@@ -10606,84 +10558,63 @@ For example
     Array.fromList (Array.toList array)
     --> array
 
+    Array.fromList << Array.toList
+    --> identity
+
     Array.toList (Array.fromList list)
     --> list
 
-Tip: Add `inversesCompositionCheck` for the same thing as a composition check.
+    Array.toList << Array.fromList
+    --> identity
 
 These usually exist in pairs, like above so make sure to add this check for both functions.
 But there are exceptions!
 
-    Set.fromList (Set.toList set)
-    --> set
-
-This will always work because `Set.toList` will never produce a list with duplicate elements. However
-
-    Set.toList (Set.fromList list)
-    --> list
-
-would be an incorrect fix. See for example
-
-    Set.toList (Set.fromList [ 0, 0 ])
-    --> not [ 0, 0 ] bit actually [ 0 ]
-
--}
-onCallToInverseReturnsItsArgumentCheck : ( ModuleName, String ) -> CheckInfo -> Maybe (Error {})
-onCallToInverseReturnsItsArgumentCheck inverseFn checkInfo =
-    case AstHelpers.getSpecificFnCall inverseFn checkInfo.lookupTable checkInfo.firstArg of
-        Just call ->
-            Just
-                (Rule.errorWithFix
-                    { message = qualifiedToString inverseFn ++ ", then " ++ qualifiedToString checkInfo.fn ++ " cancels each other out"
-                    , details = [ "You can replace this call by the argument given to " ++ qualifiedToString inverseFn ++ "." ]
-                    }
-                    checkInfo.fnRange
-                    (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range call.firstArg })
-                )
-
-        Nothing ->
-            Nothing
-
-
-{-| Composing two operations that are inverses of each other and therefore cancel each other out.
-For example
-
-    -- inversesCompositionCheck { later = ( [ "Array" ], "fromList" ), earlier = ( [ "Array" ], "toList" ) }
-    Array.toList >> Array.fromList
-    --> identity
-
-    -- inversesCompositionCheck { later = ( [ "Array" ], "toList" ) , earlier = ( [ "Array" ], "fromList" ) }
-    Array.fromList >> Array.toList
-    --> identity
-
-Tip: Add `onCallToInverseReturnsItsArgumentCheck` for the same thing as a function call check.
-
-These usually exist in pairs, like above so make sure to add this check for both functions.
-But there are exceptions!
+    Set.fromList (Set.toList set) --> set
 
     Set.fromList << Set.toList --> identity
 
-This will always work because `Set.toList` will never produce a list with duplicate elements. However
+This will always work because `Set.toList` will never produce a list with duplicate elements. However!
+
+    Set.toList (Set.fromList list) --> list
 
     Set.toList << Set.fromList --> identity
 
 would be an incorrect fix. See for example
 
     Set.toList (Set.fromList [ 0, 0 ])
-    --> not [ 0, 0 ] bit actually [ 0 ]
+    --> not [ 0, 0 ] but actually [ 0 ]
 
 -}
-inversesCompositionCheck : ( ModuleName, String ) -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-inversesCompositionCheck earlierInverseFn checkInfo =
-    if checkInfo.earlier.fn == earlierInverseFn then
-        Just
-            (compositionAlwaysReturnsIncomingError
-                (qualifiedToString checkInfo.earlier.fn ++ ", then " ++ qualifiedToString checkInfo.later.fn ++ " cancels each other out")
-                checkInfo
-            )
+onCallToInverseReturnsItsArgumentCheck : ( ModuleName, String ) -> IntoFnCheck
+onCallToInverseReturnsItsArgumentCheck inverseFn =
+    { call =
+        \checkInfo ->
+            case AstHelpers.getSpecificFnCall inverseFn checkInfo.lookupTable checkInfo.firstArg of
+                Just call ->
+                    Just
+                        (Rule.errorWithFix
+                            { message = qualifiedToString inverseFn ++ ", then " ++ qualifiedToString checkInfo.fn ++ " cancels each other out"
+                            , details = [ "You can replace this call by the argument given to " ++ qualifiedToString inverseFn ++ "." ]
+                            }
+                            checkInfo.fnRange
+                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range call.firstArg })
+                        )
 
-    else
-        Nothing
+                Nothing ->
+                    Nothing
+    , composition =
+        \checkInfo ->
+            if checkInfo.earlier.fn == inverseFn then
+                Just
+                    (compositionAlwaysReturnsIncomingError
+                        (qualifiedToString checkInfo.earlier.fn ++ ", then " ++ qualifiedToString checkInfo.later.fn ++ " cancels each other out")
+                        checkInfo
+                    )
+
+            else
+                Nothing
+    }
 
 
 unnecessaryCompositionAfterWrapCheck : WrapperProperties otherProperties -> CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4781,7 +4781,7 @@ listAppendChecks =
 listConcatChecks : IntoFnCheck
 listConcatChecks =
     intoFnChecksFirstThatConstructsError
-        [ callOnWrapReturnsItsValueCheck listCollection
+        [ onWrappedReturnsItsValueCheck listCollection
         , callFromCanBeCombinedCheck
             { fromFn = Fn.List.map, combinedFn = Fn.List.concatMap }
         , unnecessaryOnEmptyCheck listCollection
@@ -5221,7 +5221,7 @@ listMemberChecks =
 listSumChecks : IntoFnCheck
 listSumChecks =
     intoFnChecksFirstThatConstructsError
-        [ callOnWrapReturnsItsValueCheck listCollection
+        [ onWrappedReturnsItsValueCheck listCollection
         , intoFnCheckOnlyCall
             (firstThatConstructsJust
                 [ callOnEmptyReturnsCheck { resultAsString = \_ -> "0" } listCollection
@@ -5245,7 +5245,7 @@ listSumChecks =
 listProductChecks : IntoFnCheck
 listProductChecks =
     intoFnChecksFirstThatConstructsError
-        [ callOnWrapReturnsItsValueCheck listCollection
+        [ onWrappedReturnsItsValueCheck listCollection
         , intoFnCheckOnlyCall
             (firstThatConstructsJust
                 [ callOnEmptyReturnsCheck { resultAsString = \_ -> "1" } listCollection
@@ -7492,7 +7492,7 @@ subCollection =
 
 oneOfChecks : IntoFnCheck
 oneOfChecks =
-    callOnWrapReturnsItsValueCheck listCollection
+    onWrappedReturnsItsValueCheck listCollection
 
 
 {-| Checks for a "oneOfConstants" operation:
@@ -8055,7 +8055,7 @@ withDefaultChecks :
     -> IntoFnCheck
 withDefaultChecks emptiable =
     intoFnChecksFirstThatConstructsError
-        [ callOnWrapReturnsItsValueCheck emptiable
+        [ onWrappedReturnsItsValueCheck emptiable
         , intoFnCheckOnlyCall (emptiableWithDefaultChecks emptiable)
         ]
 
@@ -8257,7 +8257,7 @@ So for example with `emptiableWrapperFlatFromListChecks stringCollection`
 emptiableWrapperFlatFromListChecks : EmptiableProperties ConstantProperties otherProperties -> IntoFnCheck
 emptiableWrapperFlatFromListChecks batchable =
     intoFnChecksFirstThatConstructsError
-        [ callOnWrapReturnsItsValueCheck listCollection
+        [ onWrappedReturnsItsValueCheck listCollection
         , intoFnCheckOnlyCall (callOnEmptyReturnsCheck { resultAsString = batchable.empty.specific.asString } listCollection)
         , intoFnCheckOnlyCall
             (\checkInfo ->
@@ -10803,12 +10803,8 @@ For example
     Cmd.batch << List.singleton --> identity
 
 -}
-callOnWrapReturnsItsValueCheck :
-    { otherProperties
-        | wrap : ConstructWithOneArgProperties
-    }
-    -> IntoFnCheck
-callOnWrapReturnsItsValueCheck wrapper =
+onWrappedReturnsItsValueCheck : WrapperProperties otherProperties -> IntoFnCheck
+onWrappedReturnsItsValueCheck wrapper =
     { call =
         \checkInfo ->
             case fullyAppliedLastArg checkInfo of

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10168,8 +10168,6 @@ Examples:
   - `Animation.loop (List.repeat n x) --> Animation.repeat n x` using [`mdgriffith/elm-style-animation`](https://package.elm-lang.org/packages/mdgriffith/elm-style-animation/4.0.0/)
   - `FormattedText.concat (List.intersperse s list) --> FormattedText.join s list` using [`NoRedInk/elm-formatted-text-19`](https://package.elm-lang.org/packages/NoRedInk/elm-formatted-text-19/1.0.0/)
 
-Use in combination with `compositionFromCanBeCombinedCheck`
-
 -}
 callFromCanBeCombinedCheck :
     { fromFn : ( ModuleName, String ), combinedFn : ( ModuleName, String ) }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4487,7 +4487,7 @@ stringReverseChecks : IntoFnCheck
 stringReverseChecks =
     intoFnChecksFirstThatConstructsError
         [ emptiableReverseChecks stringCollection
-        , unnecessaryCallOnWrappedCheck stringCollection
+        , unnecessaryOnWrappedCheck stringCollection
         ]
 
 
@@ -4856,7 +4856,7 @@ listIntersperseChecks : IntoFnCheck
 listIntersperseChecks =
     intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
+        , unnecessaryOnWrappedCheck listCollection
         ]
 
 
@@ -5603,7 +5603,7 @@ listReverseChecks : IntoFnCheck
 listReverseChecks =
     intoFnChecksFirstThatConstructsError
         [ emptiableReverseChecks listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
+        , unnecessaryOnWrappedCheck listCollection
         ]
 
 
@@ -5611,7 +5611,7 @@ listSortChecks : IntoFnCheck
 listSortChecks =
     intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
+        , unnecessaryOnWrappedCheck listCollection
         , operationDoesNotChangeResultOfOperationCheck
         ]
 
@@ -5620,7 +5620,7 @@ listSortByChecks : IntoFnCheck
 listSortByChecks =
     intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
+        , unnecessaryOnWrappedCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
@@ -5644,7 +5644,7 @@ listSortWithChecks : IntoFnCheck
 listSortWithChecks =
     intoFnChecksFirstThatConstructsError
         [ unnecessaryCallOnEmptyCheck listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
+        , unnecessaryOnWrappedCheck listCollection
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 let
@@ -10209,7 +10209,7 @@ Note that some functions called "sequence" have equal element and result types, 
     Bytes.Encode.sequence << List.singleton
     --: Bytes.Encode.Encoder -> Bytes.Encode.Encoder
 
-which means you can simplify them to `encoder`/`identity` using `unnecessaryCallOnWrappedCheck`.
+which means you can simplify them to `encoder`/`identity` using `unnecessaryOnWrappedCheck`.
 
 -}
 onWrappedIsEquivalentToMapWrapOnValueCheck :
@@ -10600,8 +10600,8 @@ So for example
     List.reverse << List.singleton --> List.singleton
 
 -}
-unnecessaryCallOnWrappedCheck : WrapperProperties otherProperties -> IntoFnCheck
-unnecessaryCallOnWrappedCheck wrapper =
+unnecessaryOnWrappedCheck : WrapperProperties otherProperties -> IntoFnCheck
+unnecessaryOnWrappedCheck wrapper =
     { call = unnecessaryCallOnCheck { specific = wrapper.wrap, kind = ConstructWithOneArg }
     , composition = unnecessaryCompositionAfterCheck wrapper.wrap
     }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2974,7 +2974,7 @@ intoFnChecks =
         , ( Fn.Result.andThen, ( 2, resultAndThenChecks ) )
         , ( Fn.Result.withDefault, ( 2, resultWithDefaultChecks ) )
         , ( Fn.Result.toMaybe, ( 1, resultToMaybeChecks ) )
-        , ( Fn.Result.fromMaybe, ( 2, resultfromMaybeWithEmptyValueOnNothingCheck ) )
+        , ( Fn.Result.fromMaybe, ( 2, resultFromMaybeWithEmptyValueOnNothingCheck ) )
         , ( Fn.List.append, ( 2, listAppendChecks ) )
         , ( Fn.List.head, ( 1, listHeadChecks ) )
         , ( Fn.List.tail, ( 1, listTailChecks ) )
@@ -4763,8 +4763,8 @@ resultToMaybeChecks =
         ]
 
 
-resultfromMaybeWithEmptyValueOnNothingCheck : IntoFnCheck
-resultfromMaybeWithEmptyValueOnNothingCheck =
+resultFromMaybeWithEmptyValueOnNothingCheck : IntoFnCheck
+resultFromMaybeWithEmptyValueOnNothingCheck =
     fromMaybeWithEmptyValueOnNothingCheck resultWithOkAsWrap
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4259,41 +4259,32 @@ tuplePairChecks =
 tupleFirstChecks : IntoFnCheck
 tupleFirstChecks =
     intoFnChecksFirstThatConstructsError
-        [ { call =
-                tuplePartChecks
-                    { part = TupleFirst
-                    , description = "first"
-                    , mapUnrelatedFn = Fn.Tuple.mapSecond
-                    , mapFn = Fn.Tuple.mapFirst
-                    }
-          , composition =
-                firstThatConstructsJust
-                    [ tuplePartCompositionChecks
-                        { part = TupleFirst
-                        , description = "first"
-                        , mapUnrelatedFn = Fn.Tuple.mapSecond
-                        , mapFn = Fn.Tuple.mapFirst
-                        }
-                    , \checkInfo ->
-                        case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
-                            ( ( [ "Tuple" ], "pair" ), first :: [] ) ->
-                                Just
-                                    { info =
-                                        { message = qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in that first part"
-                                        , details = [ "You can replace this call by always with the first argument given to " ++ qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ "." ]
-                                        }
-                                    , fix =
-                                        replaceBySubExpressionFix checkInfo.earlier.range first
-                                            ++ [ Fix.insertAt checkInfo.earlier.range.start
-                                                    (qualifiedToString (qualify Fn.Basics.always checkInfo) ++ " ")
-                                               , Fix.removeRange checkInfo.later.removeRange
-                                               ]
-                                    }
+        [ tuplePartChecks
+            { part = TupleFirst
+            , description = "first"
+            , mapUnrelatedFn = Fn.Tuple.mapSecond
+            , mapFn = Fn.Tuple.mapFirst
+            }
+        , intoFnCheckOnlyComposition
+            (\checkInfo ->
+                case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
+                    ( ( [ "Tuple" ], "pair" ), first :: [] ) ->
+                        Just
+                            { info =
+                                { message = qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in that first part"
+                                , details = [ "You can replace this call by always with the first argument given to " ++ qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ "." ]
+                                }
+                            , fix =
+                                replaceBySubExpressionFix checkInfo.earlier.range first
+                                    ++ [ Fix.insertAt checkInfo.earlier.range.start
+                                            (qualifiedToString (qualify Fn.Basics.always checkInfo) ++ " ")
+                                       , Fix.removeRange checkInfo.later.removeRange
+                                       ]
+                            }
 
-                            _ ->
-                                Nothing
-                    ]
-          }
+                    _ ->
+                        Nothing
+            )
         , callFromCanBeCombinedCheck
             { fromFn = Fn.List.partition, combinedFn = Fn.List.filter }
         , callFromCanBeCombinedCheck
@@ -4305,22 +4296,15 @@ tupleFirstChecks =
 
 tupleSecondChecks : IntoFnCheck
 tupleSecondChecks =
-    { call =
-        tuplePartChecks
+    intoFnChecksFirstThatConstructsError
+        [ tuplePartChecks
             { part = TupleSecond
             , description = "second"
             , mapFn = Fn.Tuple.mapSecond
             , mapUnrelatedFn = Fn.Tuple.mapFirst
             }
-    , composition =
-        firstThatConstructsJust
-            [ tuplePartCompositionChecks
-                { part = TupleSecond
-                , description = "second"
-                , mapFn = Fn.Tuple.mapSecond
-                , mapUnrelatedFn = Fn.Tuple.mapFirst
-                }
-            , \checkInfo ->
+        , intoFnCheckOnlyComposition
+            (\checkInfo ->
                 case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
                     ( ( [ "Tuple" ], "pair" ), _ :: [] ) ->
                         Just
@@ -4331,8 +4315,8 @@ tupleSecondChecks =
 
                     _ ->
                         Nothing
-            ]
-    }
+            )
+        ]
 
 
 type TuplePart
@@ -4346,127 +4330,127 @@ tuplePartChecks :
     , mapFn : ( ModuleName, String )
     , mapUnrelatedFn : ( ModuleName, String )
     }
-    -> CheckInfo
-    -> Maybe (Error {})
+    -> IntoFnCheck
 tuplePartChecks partConfig =
-    firstThatConstructsJust
-        [ \checkInfo ->
-            Maybe.map
-                (\tuple ->
-                    Rule.errorWithFix
-                        { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on a known tuple will result in the tuple's " ++ partConfig.description ++ " part"
-                        , details = [ "You can replace this call by the tuple's " ++ partConfig.description ++ " part." ]
-                        }
-                        checkInfo.fnRange
-                        (replaceBySubExpressionFix checkInfo.parentRange
-                            (case partConfig.part of
-                                TupleFirst ->
-                                    tuple.first
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall
+            (\checkInfo ->
+                Maybe.map
+                    (\tuple ->
+                        Rule.errorWithFix
+                            { message = qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on a known tuple will result in the tuple's " ++ partConfig.description ++ " part"
+                            , details = [ "You can replace this call by the tuple's " ++ partConfig.description ++ " part." ]
+                            }
+                            checkInfo.fnRange
+                            (replaceBySubExpressionFix checkInfo.parentRange
+                                (case partConfig.part of
+                                    TupleFirst ->
+                                        tuple.first
 
-                                TupleSecond ->
-                                    tuple.second
+                                    TupleSecond ->
+                                        tuple.second
+                                )
                             )
-                        )
-                )
-                (AstHelpers.getTuple2 checkInfo.lookupTable checkInfo.firstArg)
-        , \checkInfo ->
-            case AstHelpers.getSpecificFnCall partConfig.mapUnrelatedFn checkInfo.lookupTable checkInfo.firstArg of
-                Just mapSecondCall ->
-                    case mapSecondCall.argsAfterFirst of
-                        unmappedTuple :: [] ->
-                            Just
-                                (Rule.errorWithFix
-                                    { message = "Unnecessary " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " before " ++ qualifiedToString checkInfo.fn
-                                    , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " call by the unchanged tuple." ]
-                                    }
-                                    checkInfo.fnRange
-                                    (keepOnlyFix { parentRange = mapSecondCall.nodeRange, keep = Node.range unmappedTuple })
-                                )
-
-                        _ ->
-                            Nothing
-
-                Nothing ->
-                    Nothing
-        , \checkInfo ->
-            case AstHelpers.getSpecificFnCall Fn.Tuple.mapBoth checkInfo.lookupTable checkInfo.firstArg of
-                Just tupleMapBothCall ->
-                    case tupleMapBothCall.argsAfterFirst of
-                        secondMapperArg :: _ :: [] ->
-                            Just
-                                (Rule.errorWithFix
-                                    { message = qualifiedToString Fn.Tuple.mapBoth ++ " before " ++ qualifiedToString checkInfo.fn ++ " is the same as " ++ qualifiedToString partConfig.mapFn
-                                    , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString Fn.Tuple.mapBoth ++ " call by " ++ qualifiedToString partConfig.mapFn ++ " with the same " ++ partConfig.description ++ " mapping and tuple." ]
-                                    }
-                                    checkInfo.fnRange
-                                    (case partConfig.part of
-                                        TupleFirst ->
-                                            Fix.replaceRangeBy tupleMapBothCall.fnRange
-                                                (qualifiedToString (qualify partConfig.mapFn checkInfo))
-                                                :: keepOnlyFix
-                                                    { parentRange = Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg, Node.range secondMapperArg ]
-                                                    , keep = Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg ]
-                                                    }
-
-                                        TupleSecond ->
-                                            [ Fix.replaceRangeBy (Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg ])
-                                                (qualifiedToString (qualify partConfig.mapFn checkInfo))
-                                            ]
+                    )
+                    (AstHelpers.getTuple2 checkInfo.lookupTable checkInfo.firstArg)
+            )
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                case AstHelpers.getSpecificFnCall partConfig.mapUnrelatedFn checkInfo.lookupTable checkInfo.firstArg of
+                    Just mapSecondCall ->
+                        case mapSecondCall.argsAfterFirst of
+                            unmappedTuple :: [] ->
+                                Just
+                                    (Rule.errorWithFix
+                                        { message = "Unnecessary " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " before " ++ qualifiedToString checkInfo.fn
+                                        , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " call by the unchanged tuple." ]
+                                        }
+                                        checkInfo.fnRange
+                                        (keepOnlyFix { parentRange = mapSecondCall.nodeRange, keep = Node.range unmappedTuple })
                                     )
-                                )
 
-                        _ ->
-                            Nothing
+                            _ ->
+                                Nothing
 
-                Nothing ->
-                    Nothing
-        ]
+                    Nothing ->
+                        Nothing
+            )
+        , intoFnCheckOnlyCall
+            (\checkInfo ->
+                case AstHelpers.getSpecificFnCall Fn.Tuple.mapBoth checkInfo.lookupTable checkInfo.firstArg of
+                    Just tupleMapBothCall ->
+                        case tupleMapBothCall.argsAfterFirst of
+                            secondMapperArg :: _ :: [] ->
+                                Just
+                                    (Rule.errorWithFix
+                                        { message = qualifiedToString Fn.Tuple.mapBoth ++ " before " ++ qualifiedToString checkInfo.fn ++ " is the same as " ++ qualifiedToString partConfig.mapFn
+                                        , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString Fn.Tuple.mapBoth ++ " call by " ++ qualifiedToString partConfig.mapFn ++ " with the same " ++ partConfig.description ++ " mapping and tuple." ]
+                                        }
+                                        checkInfo.fnRange
+                                        (case partConfig.part of
+                                            TupleFirst ->
+                                                Fix.replaceRangeBy tupleMapBothCall.fnRange
+                                                    (qualifiedToString (qualify partConfig.mapFn checkInfo))
+                                                    :: keepOnlyFix
+                                                        { parentRange = Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg, Node.range secondMapperArg ]
+                                                        , keep = Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg ]
+                                                        }
 
+                                            TupleSecond ->
+                                                [ Fix.replaceRangeBy (Range.combine [ tupleMapBothCall.fnRange, Node.range tupleMapBothCall.firstArg ])
+                                                    (qualifiedToString (qualify partConfig.mapFn checkInfo))
+                                                ]
+                                        )
+                                    )
 
-tuplePartCompositionChecks :
-    { part : TuplePart, description : String, mapFn : ( ModuleName, String ), mapUnrelatedFn : ( ModuleName, String ) }
-    -> CompositionIntoCheckInfo
-    -> Maybe ErrorInfoAndFix
-tuplePartCompositionChecks partConfig =
-    firstThatConstructsJust
-        [ \checkInfo ->
-            if checkInfo.earlier.fn == partConfig.mapUnrelatedFn then
-                Just
-                    { info =
-                        { message = "Unnecessary " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " before " ++ qualifiedToString checkInfo.later.fn
-                        , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can remove the " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " call." ]
-                        }
-                    , fix = [ Fix.removeRange checkInfo.earlier.removeRange ]
-                    }
+                            _ ->
+                                Nothing
 
-            else
-                Nothing
-        , \checkInfo ->
-            case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
-                ( ( [ "Tuple" ], "mapBoth" ), firstMapperArg :: _ :: [] ) ->
+                    Nothing ->
+                        Nothing
+            )
+        , intoFnCheckOnlyComposition
+            (\checkInfo ->
+                if checkInfo.earlier.fn == partConfig.mapUnrelatedFn then
                     Just
                         { info =
-                            { message = qualifiedToString Fn.Tuple.mapBoth ++ " before " ++ qualifiedToString checkInfo.later.fn ++ " is the same as " ++ qualifiedToString partConfig.mapFn
-                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString Fn.Tuple.mapBoth ++ " call by " ++ qualifiedToString partConfig.mapFn ++ " with the same " ++ partConfig.description ++ " mapping." ]
+                            { message = "Unnecessary " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " before " ++ qualifiedToString checkInfo.later.fn
+                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can remove the " ++ qualifiedToString partConfig.mapUnrelatedFn ++ " call." ]
                             }
-                        , fix =
-                            case partConfig.part of
-                                TupleFirst ->
-                                    Fix.replaceRangeBy checkInfo.earlier.fnRange
-                                        (qualifiedToString (qualify partConfig.mapFn checkInfo))
-                                        :: keepOnlyFix
-                                            { parentRange = checkInfo.earlier.range
-                                            , keep = Range.combine [ checkInfo.earlier.fnRange, Node.range firstMapperArg ]
-                                            }
-
-                                TupleSecond ->
-                                    [ Fix.replaceRangeBy (Range.combine [ checkInfo.earlier.fnRange, Node.range firstMapperArg ])
-                                        (qualifiedToString (qualify partConfig.mapFn checkInfo))
-                                    ]
+                        , fix = [ Fix.removeRange checkInfo.earlier.removeRange ]
                         }
 
-                _ ->
+                else
                     Nothing
+            )
+        , intoFnCheckOnlyComposition
+            (\checkInfo ->
+                case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
+                    ( ( [ "Tuple" ], "mapBoth" ), firstMapperArg :: _ :: [] ) ->
+                        Just
+                            { info =
+                                { message = qualifiedToString Fn.Tuple.mapBoth ++ " before " ++ qualifiedToString checkInfo.later.fn ++ " is the same as " ++ qualifiedToString partConfig.mapFn
+                                , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the " ++ qualifiedToString Fn.Tuple.mapBoth ++ " call by " ++ qualifiedToString partConfig.mapFn ++ " with the same " ++ partConfig.description ++ " mapping." ]
+                                }
+                            , fix =
+                                case partConfig.part of
+                                    TupleFirst ->
+                                        Fix.replaceRangeBy checkInfo.earlier.fnRange
+                                            (qualifiedToString (qualify partConfig.mapFn checkInfo))
+                                            :: keepOnlyFix
+                                                { parentRange = checkInfo.earlier.range
+                                                , keep = Range.combine [ checkInfo.earlier.fnRange, Node.range firstMapperArg ]
+                                                }
+
+                                    TupleSecond ->
+                                        [ Fix.replaceRangeBy (Range.combine [ checkInfo.earlier.fnRange, Node.range firstMapperArg ])
+                                            (qualifiedToString (qualify partConfig.mapFn checkInfo))
+                                        ]
+                            }
+
+                    _ ->
+                        Nothing
+            )
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2904,6 +2904,7 @@ type alias ErrorInfoAndFix =
 {-| Checking both the function call of and composition into a specific fn.
 
 Construct the record directly or use `intoFnCheckOnlyCall`/`intoFnCheckOnlyComposition`.
+Provide multiple checks using `intoFnChecksFirstThatConstructsError`.
 
 -}
 type alias IntoFnCheck =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -2926,163 +2926,163 @@ intoFnChecks =
     -- Any additional arguments will be ignored in order to avoid removing too many arguments
     -- when replacing the entire argument, which is quite common.
     Dict.fromList
-        [ ( Fn.Basics.identity, ( 1, intoFnCheckOnlyCall basicsIdentityChecks ) )
-        , ( Fn.Basics.always, ( 2, { call = basicsAlwaysChecks, composition = basicsAlwaysCompositionChecks } ) )
-        , ( Fn.Basics.not, ( 1, { call = basicsNotChecks, composition = toggleCompositionChecks } ) )
-        , ( Fn.Basics.negate, ( 1, { call = basicsNegateChecks, composition = toggleCompositionChecks } ) )
-        , ( Fn.Basics.toFloat, ( 1, intoFnCheckOnlyCall basicsToFloatChecks ) )
-        , ( Fn.Basics.round, ( 1, { call = intToIntChecks, composition = inversesCompositionCheck Fn.Basics.toFloat } ) )
-        , ( Fn.Basics.ceiling, ( 1, { call = intToIntChecks, composition = inversesCompositionCheck Fn.Basics.toFloat } ) )
-        , ( Fn.Basics.floor, ( 1, { call = intToIntChecks, composition = inversesCompositionCheck Fn.Basics.toFloat } ) )
-        , ( Fn.Basics.truncate, ( 1, { call = intToIntChecks, composition = inversesCompositionCheck Fn.Basics.toFloat } ) )
-        , ( Fn.Tuple.first, ( 1, { call = tupleFirstChecks, composition = tupleFirstCompositionChecks } ) )
-        , ( Fn.Tuple.second, ( 1, { call = tupleSecondChecks, composition = tupleSecondCompositionChecks } ) )
-        , ( Fn.Tuple.pair, ( 2, intoFnCheckOnlyCall tuplePairChecks ) )
-        , ( Fn.Maybe.map, ( 2, { call = maybeMapChecks, composition = maybeMapCompositionChecks } ) )
-        , ( Fn.Maybe.map2, ( 3, intoFnCheckOnlyCall maybeMapNChecks ) )
-        , ( Fn.Maybe.map3, ( 4, intoFnCheckOnlyCall maybeMapNChecks ) )
-        , ( Fn.Maybe.map4, ( 5, intoFnCheckOnlyCall maybeMapNChecks ) )
-        , ( Fn.Maybe.map5, ( 6, intoFnCheckOnlyCall maybeMapNChecks ) )
-        , ( Fn.Maybe.andThen, ( 2, { call = maybeAndThenChecks, composition = maybeAndThenCompositionChecks } ) )
-        , ( Fn.Maybe.withDefault, ( 2, { call = withDefaultChecks maybeWithJustAsWrap, composition = wrapperWithDefaultChecks maybeWithJustAsWrap } ) )
-        , ( Fn.Result.map, ( 2, { call = resultMapChecks, composition = resultMapCompositionChecks } ) )
-        , ( Fn.Result.map2, ( 3, intoFnCheckOnlyCall resultMapNChecks ) )
-        , ( Fn.Result.map3, ( 4, intoFnCheckOnlyCall resultMapNChecks ) )
-        , ( Fn.Result.map4, ( 5, intoFnCheckOnlyCall resultMapNChecks ) )
-        , ( Fn.Result.map5, ( 6, intoFnCheckOnlyCall resultMapNChecks ) )
-        , ( Fn.Result.mapError, ( 2, { call = resultMapErrorChecks, composition = resultMapErrorCompositionChecks } ) )
-        , ( Fn.Result.andThen, ( 2, { call = resultAndThenChecks, composition = resultAndThenCompositionChecks } ) )
-        , ( Fn.Result.withDefault, ( 2, { call = withDefaultChecks resultWithOkAsWrap, composition = wrapperWithDefaultChecks resultWithOkAsWrap } ) )
-        , ( Fn.Result.toMaybe, ( 1, { call = unwrapToMaybeChecks resultWithOkAsWrap, composition = resultToMaybeCompositionChecks } ) )
-        , ( Fn.Result.fromMaybe, ( 2, { call = resultFromMaybeChecks, composition = wrapperFromMaybeCompositionChecks resultWithOkAsWrap } ) )
-        , ( Fn.List.append, ( 2, intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } listCollection) ) )
-        , ( Fn.List.head, ( 1, intoFnCheckOnlyCall listHeadChecks ) )
-        , ( Fn.List.tail, ( 1, intoFnCheckOnlyCall listTailChecks ) )
-        , ( Fn.List.member, ( 2, intoFnCheckOnlyCall listMemberChecks ) )
-        , ( Fn.List.map, ( 2, { call = listMapChecks, composition = listMapCompositionChecks } ) )
-        , ( Fn.List.filter, ( 2, intoFnCheckOnlyCall (emptiableKeepWhenChecks listCollection) ) )
-        , ( Fn.List.filterMap, ( 2, { call = listFilterMapChecks, composition = listFilterMapCompositionChecks } ) )
-        , ( Fn.List.concat, ( 1, { call = listConcatChecks, composition = listConcatCompositionChecks } ) )
-        , ( Fn.List.concatMap, ( 2, { call = listConcatMapChecks, composition = listConcatMapCompositionChecks } ) )
-        , ( Fn.List.indexedMap, ( 2, intoFnCheckOnlyCall listIndexedMapChecks ) )
-        , ( Fn.List.intersperse, ( 2, { call = listIntersperseChecks, composition = listIntersperseCompositionChecks } ) )
-        , ( Fn.List.sum, ( 1, { call = listSumChecks, composition = sumCompositionChecks listCollection } ) )
-        , ( Fn.List.product, ( 1, { call = listProductChecks, composition = productCompositionChecks listCollection } ) )
-        , ( Fn.List.minimum, ( 1, { call = listMinimumChecks, composition = minimumCompositionChecks listCollection } ) )
-        , ( Fn.List.maximum, ( 1, { call = listMaximumChecks, composition = maximumCompositionChecks listCollection } ) )
-        , ( Fn.List.foldl, ( 3, { call = listFoldlChecks, composition = listFoldlCompositionChecks } ) )
-        , ( Fn.List.foldr, ( 3, { call = listFoldrChecks, composition = listFoldrCompositionChecks } ) )
-        , ( Fn.List.all, ( 2, intoFnCheckOnlyCall listAllChecks ) )
-        , ( Fn.List.any, ( 2, intoFnCheckOnlyCall listAnyChecks ) )
-        , ( Fn.List.range, ( 2, intoFnCheckOnlyCall listRangeChecks ) )
-        , ( Fn.List.length, ( 1, intoFnCheckOnlyCall (collectionSizeChecks listCollection) ) )
-        , ( Fn.List.repeat, ( 2, intoFnCheckOnlyCall listRepeatChecks ) )
-        , ( Fn.List.isEmpty, ( 1, intoFnCheckOnlyCall (collectionIsEmptyChecks listCollection) ) )
-        , ( Fn.List.partition, ( 2, intoFnCheckOnlyCall (collectionPartitionChecks listCollection) ) )
-        , ( Fn.List.reverse, ( 1, { call = listReverseChecks, composition = listReverseCompositionChecks } ) )
-        , ( Fn.List.sort, ( 1, { call = listSortChecks, composition = listSortCompositionChecks } ) )
-        , ( Fn.List.sortBy, ( 2, { call = listSortByChecks, composition = listSortByCompositionChecks } ) )
-        , ( Fn.List.sortWith, ( 2, intoFnCheckOnlyCall listSortWithChecks ) )
-        , ( Fn.List.take, ( 2, intoFnCheckOnlyCall listTakeChecks ) )
-        , ( Fn.List.drop, ( 2, intoFnCheckOnlyCall listDropChecks ) )
-        , ( Fn.List.map2, ( 3, intoFnCheckOnlyCall (emptiableMapNChecks listCollection) ) )
-        , ( Fn.List.map3, ( 4, intoFnCheckOnlyCall (emptiableMapNChecks listCollection) ) )
-        , ( Fn.List.map4, ( 5, intoFnCheckOnlyCall (emptiableMapNChecks listCollection) ) )
-        , ( Fn.List.map5, ( 6, intoFnCheckOnlyCall (emptiableMapNChecks listCollection) ) )
-        , ( Fn.List.unzip, ( 1, intoFnCheckOnlyCall listUnzipChecks ) )
-        , ( Fn.Array.toList, ( 1, { call = arrayToListChecks, composition = arrayToListCompositionChecks } ) )
-        , ( Fn.Array.toIndexedList, ( 1, intoFnCheckOnlyCall arrayToIndexedListChecks ) )
-        , ( Fn.Array.fromList, ( 1, { call = arrayFromListChecks, composition = arrayFromListCompositionChecks } ) )
-        , ( Fn.Array.map, ( 2, intoFnCheckOnlyCall (emptiableMapChecks arrayCollection) ) )
-        , ( Fn.Array.indexedMap, ( 2, intoFnCheckOnlyCall arrayIndexedMapChecks ) )
-        , ( Fn.Array.filter, ( 2, intoFnCheckOnlyCall (emptiableKeepWhenChecks arrayCollection) ) )
-        , ( Fn.Array.isEmpty, ( 1, intoFnCheckOnlyCall (collectionIsEmptyChecks arrayCollection) ) )
-        , ( Fn.Array.length, ( 1, intoFnCheckOnlyCall arrayLengthChecks ) )
-        , ( Fn.Array.repeat, ( 2, intoFnCheckOnlyCall arrayRepeatChecks ) )
-        , ( Fn.Array.initialize, ( 2, intoFnCheckOnlyCall arrayInitializeChecks ) )
-        , ( Fn.Array.append, ( 2, intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } arrayCollection) ) )
-        , ( Fn.Array.get, ( 2, intoFnCheckOnlyCall (getChecks arrayCollection) ) )
-        , ( Fn.Array.set, ( 3, intoFnCheckOnlyCall (setChecks arrayCollection) ) )
-        , ( Fn.Array.slice, ( 3, intoFnCheckOnlyCall (collectionSliceChecks arrayCollection) ) )
-        , ( Fn.Array.foldl, ( 3, intoFnCheckOnlyCall arrayFoldlChecks ) )
-        , ( Fn.Array.foldr, ( 3, intoFnCheckOnlyCall arrayFoldrChecks ) )
-        , ( Fn.Set.map, ( 2, intoFnCheckOnlyCall (emptiableMapChecks setCollection) ) )
-        , ( Fn.Set.filter, ( 2, intoFnCheckOnlyCall (emptiableKeepWhenChecks setCollection) ) )
-        , ( Fn.Set.remove, ( 2, intoFnCheckOnlyCall (collectionRemoveChecks setCollection) ) )
-        , ( Fn.Set.isEmpty, ( 1, intoFnCheckOnlyCall (collectionIsEmptyChecks setCollection) ) )
-        , ( Fn.Set.size, ( 1, intoFnCheckOnlyCall (collectionSizeChecks setCollection) ) )
-        , ( Fn.Set.member, ( 2, intoFnCheckOnlyCall (collectionMemberChecks setCollection) ) )
-        , ( Fn.Set.fromList, ( 1, { call = setFromListChecks, composition = setFromListCompositionChecks } ) )
-        , ( Fn.Set.toList, ( 1, intoFnCheckOnlyCall (emptiableToListChecks setCollection) ) )
-        , ( Fn.Set.partition, ( 2, intoFnCheckOnlyCall (collectionPartitionChecks setCollection) ) )
-        , ( Fn.Set.intersect, ( 2, intoFnCheckOnlyCall (collectionIntersectChecks setCollection) ) )
-        , ( Fn.Set.diff, ( 2, intoFnCheckOnlyCall (collectionDiffChecks setCollection) ) )
-        , ( Fn.Set.union, ( 2, intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } setCollection) ) )
-        , ( Fn.Set.insert, ( 2, intoFnCheckOnlyCall (collectionInsertChecks setCollection) ) )
-        , ( Fn.Set.foldl, ( 3, intoFnCheckOnlyCall setFoldlChecks ) )
-        , ( Fn.Set.foldr, ( 3, intoFnCheckOnlyCall setFoldrChecks ) )
-        , ( Fn.Dict.isEmpty, ( 1, intoFnCheckOnlyCall (collectionIsEmptyChecks dictCollection) ) )
-        , ( Fn.Dict.fromList, ( 1, { call = dictFromListChecks, composition = dictFromListCompositionChecks } ) )
-        , ( Fn.Dict.toList, ( 1, intoFnCheckOnlyCall (emptiableToListChecks dictCollection) ) )
-        , ( Fn.Dict.size, ( 1, intoFnCheckOnlyCall (collectionSizeChecks dictCollection) ) )
-        , ( Fn.Dict.member, ( 2, intoFnCheckOnlyCall (collectionMemberChecks dictCollection) ) )
-        , ( Fn.Dict.remove, ( 2, intoFnCheckOnlyCall (collectionRemoveChecks dictCollection) ) )
-        , ( Fn.Dict.filter, ( 2, intoFnCheckOnlyCall dictFilterChecks ) )
-        , ( Fn.Dict.partition, ( 2, intoFnCheckOnlyCall dictPartitionChecks ) )
-        , ( Fn.Dict.map, ( 2, intoFnCheckOnlyCall dictMapChecks ) )
-        , ( Fn.Dict.intersect, ( 2, intoFnCheckOnlyCall (collectionIntersectChecks dictCollection) ) )
-        , ( Fn.Dict.diff, ( 2, intoFnCheckOnlyCall (collectionDiffChecks dictCollection) ) )
-        , ( Fn.Dict.union, ( 2, intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = False } dictCollection) ) )
-        , ( Fn.Dict.foldl, ( 3, intoFnCheckOnlyCall dictFoldlChecks ) )
-        , ( Fn.Dict.foldr, ( 3, intoFnCheckOnlyCall dictFoldrChecks ) )
-        , ( Fn.String.toList, ( 1, { call = stringToListChecks, composition = stringToListCompositionChecks } ) )
-        , ( Fn.String.fromList, ( 1, { call = stringFromListChecks, composition = stringFromListCompositionChecks } ) )
-        , ( Fn.String.isEmpty, ( 1, intoFnCheckOnlyCall (collectionIsEmptyChecks stringCollection) ) )
-        , ( Fn.String.concat, ( 1, { call = stringConcatChecks, composition = stringConcatCompositionChecks } ) )
-        , ( Fn.String.join, ( 2, intoFnCheckOnlyCall stringJoinChecks ) )
-        , ( Fn.String.length, ( 1, intoFnCheckOnlyCall (collectionSizeChecks stringCollection) ) )
-        , ( Fn.String.repeat, ( 2, intoFnCheckOnlyCall stringRepeatChecks ) )
-        , ( Fn.String.replace, ( 3, intoFnCheckOnlyCall stringReplaceChecks ) )
-        , ( Fn.String.words, ( 1, intoFnCheckOnlyCall stringWordsChecks ) )
-        , ( Fn.String.lines, ( 1, intoFnCheckOnlyCall stringLinesChecks ) )
-        , ( Fn.String.reverse, ( 1, { call = stringReverseChecks, composition = stringReverseCompositionChecks } ) )
-        , ( Fn.String.slice, ( 3, intoFnCheckOnlyCall (collectionSliceChecks stringCollection) ) )
-        , ( Fn.String.left, ( 2, intoFnCheckOnlyCall stringLeftChecks ) )
-        , ( Fn.String.right, ( 2, intoFnCheckOnlyCall stringRightChecks ) )
-        , ( Fn.String.append, ( 2, intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } stringCollection) ) )
-        , ( Fn.String.foldl, ( 3, intoFnCheckOnlyCall stringFoldlChecks ) )
-        , ( Fn.String.foldr, ( 3, intoFnCheckOnlyCall stringFoldrChecks ) )
-        , ( Fn.Platform.Cmd.batch, ( 1, { call = emptiableWrapperFlatFromListChecks cmdCollection, composition = wrapperFlatFromListCompositionChecks } ) )
-        , ( Fn.Platform.Cmd.map, ( 2, intoFnCheckOnlyCall (emptiableMapChecks cmdCollection) ) )
-        , ( Fn.Platform.Sub.batch, ( 1, { call = emptiableWrapperFlatFromListChecks subCollection, composition = wrapperFlatFromListCompositionChecks } ) )
-        , ( Fn.Platform.Sub.map, ( 2, intoFnCheckOnlyCall (emptiableMapChecks subCollection) ) )
-        , ( Fn.Task.map, ( 2, { call = taskMapChecks, composition = taskMapCompositionChecks } ) )
-        , ( Fn.Task.map2, ( 3, intoFnCheckOnlyCall taskMapNChecks ) )
-        , ( Fn.Task.map3, ( 4, intoFnCheckOnlyCall taskMapNChecks ) )
-        , ( Fn.Task.map4, ( 5, intoFnCheckOnlyCall taskMapNChecks ) )
-        , ( Fn.Task.map5, ( 6, intoFnCheckOnlyCall taskMapNChecks ) )
-        , ( Fn.Task.andThen, ( 2, { call = taskAndThenChecks, composition = taskAndThenCompositionChecks } ) )
-        , ( Fn.Task.mapError, ( 2, { call = taskMapErrorChecks, composition = taskMapErrorCompositionChecks } ) )
-        , ( Fn.Task.onError, ( 2, { call = taskOnErrorChecks, composition = taskOnErrorCompositionChecks } ) )
-        , ( Fn.Task.sequence, ( 1, { call = taskSequenceChecks, composition = taskSequenceCompositionChecks } ) )
-        , ( Fn.Json.Decode.oneOf, ( 1, intoFnCheckOnlyCall oneOfChecks ) )
-        , ( Fn.Json.Decode.map, ( 2, { call = jsonDecodeMapChecks, composition = jsonDecodeMapCompositionChecks } ) )
-        , ( Fn.Json.Decode.map2, ( 3, intoFnCheckOnlyCall jsonDecodeMapNChecks ) )
-        , ( Fn.Json.Decode.map3, ( 4, intoFnCheckOnlyCall jsonDecodeMapNChecks ) )
-        , ( Fn.Json.Decode.map4, ( 5, intoFnCheckOnlyCall jsonDecodeMapNChecks ) )
-        , ( Fn.Json.Decode.map5, ( 6, intoFnCheckOnlyCall jsonDecodeMapNChecks ) )
-        , ( Fn.Json.Decode.map6, ( 7, intoFnCheckOnlyCall jsonDecodeMapNChecks ) )
-        , ( Fn.Json.Decode.map7, ( 8, intoFnCheckOnlyCall jsonDecodeMapNChecks ) )
-        , ( Fn.Json.Decode.map8, ( 9, intoFnCheckOnlyCall jsonDecodeMapNChecks ) )
-        , ( Fn.Json.Decode.andThen, ( 2, { call = jsonDecodeAndThenChecks, composition = jsonDecodeAndThenCompositionChecks } ) )
-        , ( Fn.Html.Attributes.classList, ( 1, intoFnCheckOnlyCall htmlAttributesClassListChecks ) )
-        , ( Fn.Parser.oneOf, ( 1, intoFnCheckOnlyCall oneOfChecks ) )
-        , ( Fn.Parser.Advanced.oneOf, ( 1, intoFnCheckOnlyCall oneOfChecks ) )
-        , ( Fn.Random.uniform, ( 2, intoFnCheckOnlyCall randomUniformChecks ) )
-        , ( Fn.Random.weighted, ( 2, intoFnCheckOnlyCall randomWeightedChecks ) )
-        , ( Fn.Random.list, ( 2, intoFnCheckOnlyCall randomListChecks ) )
-        , ( Fn.Random.map, ( 2, { call = randomMapChecks, composition = randomMapCompositionChecks } ) )
-        , ( Fn.Random.andThen, ( 2, { call = randomAndThenChecks, composition = randomAndThenCompositionChecks } ) )
+        [ ( Fn.Basics.identity, ( 1, basicsIdentityChecks ) )
+        , ( Fn.Basics.always, ( 2, basicsAlwaysChecks ) )
+        , ( Fn.Basics.not, ( 1, basicsNotChecks ) )
+        , ( Fn.Basics.negate, ( 1, basicsNegateChecks ) )
+        , ( Fn.Basics.toFloat, ( 1, basicsToFloatChecks ) )
+        , ( Fn.Basics.round, ( 1, intToIntChecks ) )
+        , ( Fn.Basics.ceiling, ( 1, intToIntChecks ) )
+        , ( Fn.Basics.floor, ( 1, intToIntChecks ) )
+        , ( Fn.Basics.truncate, ( 1, intToIntChecks ) )
+        , ( Fn.Tuple.first, ( 1, tupleFirstChecks ) )
+        , ( Fn.Tuple.second, ( 1, tupleSecondChecks ) )
+        , ( Fn.Tuple.pair, ( 2, tuplePairChecks ) )
+        , ( Fn.Maybe.map, ( 2, maybeMapChecks ) )
+        , ( Fn.Maybe.map2, ( 3, maybeMapNChecks ) )
+        , ( Fn.Maybe.map3, ( 4, maybeMapNChecks ) )
+        , ( Fn.Maybe.map4, ( 5, maybeMapNChecks ) )
+        , ( Fn.Maybe.map5, ( 6, maybeMapNChecks ) )
+        , ( Fn.Maybe.andThen, ( 2, maybeAndThenChecks ) )
+        , ( Fn.Maybe.withDefault, ( 2, maybeWithDefaultChecks ) )
+        , ( Fn.Result.map, ( 2, resultMapChecks ) )
+        , ( Fn.Result.map2, ( 3, resultMapNChecks ) )
+        , ( Fn.Result.map3, ( 4, resultMapNChecks ) )
+        , ( Fn.Result.map4, ( 5, resultMapNChecks ) )
+        , ( Fn.Result.map5, ( 6, resultMapNChecks ) )
+        , ( Fn.Result.mapError, ( 2, resultMapErrorChecks ) )
+        , ( Fn.Result.andThen, ( 2, resultAndThenChecks ) )
+        , ( Fn.Result.withDefault, ( 2, resultWithDefaultChecks ) )
+        , ( Fn.Result.toMaybe, ( 1, resultToMaybeChecks ) )
+        , ( Fn.Result.fromMaybe, ( 2, resultFromMaybeChecks ) )
+        , ( Fn.List.append, ( 2, listAppendChecks ) )
+        , ( Fn.List.head, ( 1, listHeadChecks ) )
+        , ( Fn.List.tail, ( 1, listTailChecks ) )
+        , ( Fn.List.member, ( 2, listMemberChecks ) )
+        , ( Fn.List.map, ( 2, listMapChecks ) )
+        , ( Fn.List.filter, ( 2, listFilterChecks ) )
+        , ( Fn.List.filterMap, ( 2, listFilterMapChecks ) )
+        , ( Fn.List.concat, ( 1, listConcatChecks ) )
+        , ( Fn.List.concatMap, ( 2, listConcatMapChecks ) )
+        , ( Fn.List.indexedMap, ( 2, listIndexedMapChecks ) )
+        , ( Fn.List.intersperse, ( 2, listIntersperseChecks ) )
+        , ( Fn.List.sum, ( 1, listSumChecks ) )
+        , ( Fn.List.product, ( 1, listProductChecks ) )
+        , ( Fn.List.minimum, ( 1, listMinimumChecks ) )
+        , ( Fn.List.maximum, ( 1, listMaximumChecks ) )
+        , ( Fn.List.foldl, ( 3, listFoldlChecks ) )
+        , ( Fn.List.foldr, ( 3, listFoldrChecks ) )
+        , ( Fn.List.all, ( 2, listAllChecks ) )
+        , ( Fn.List.any, ( 2, listAnyChecks ) )
+        , ( Fn.List.range, ( 2, listRangeChecks ) )
+        , ( Fn.List.length, ( 1, listLengthChecks ) )
+        , ( Fn.List.repeat, ( 2, listRepeatChecks ) )
+        , ( Fn.List.isEmpty, ( 1, listIsEmptyChecks ) )
+        , ( Fn.List.partition, ( 2, listPartitionChecks ) )
+        , ( Fn.List.reverse, ( 1, listReverseChecks ) )
+        , ( Fn.List.sort, ( 1, listSortChecks ) )
+        , ( Fn.List.sortBy, ( 2, listSortByChecks ) )
+        , ( Fn.List.sortWith, ( 2, listSortWithChecks ) )
+        , ( Fn.List.take, ( 2, listTakeChecks ) )
+        , ( Fn.List.drop, ( 2, listDropChecks ) )
+        , ( Fn.List.map2, ( 3, listMapNChecks ) )
+        , ( Fn.List.map3, ( 4, listMapNChecks ) )
+        , ( Fn.List.map4, ( 5, listMapNChecks ) )
+        , ( Fn.List.map5, ( 6, listMapNChecks ) )
+        , ( Fn.List.unzip, ( 1, listUnzipChecks ) )
+        , ( Fn.Array.toList, ( 1, arrayToListChecks ) )
+        , ( Fn.Array.toIndexedList, ( 1, arrayToIndexedListChecks ) )
+        , ( Fn.Array.fromList, ( 1, arrayFromListChecks ) )
+        , ( Fn.Array.map, ( 2, arrayMapChecks ) )
+        , ( Fn.Array.indexedMap, ( 2, arrayIndexedMapChecks ) )
+        , ( Fn.Array.filter, ( 2, arrayFilterChecks ) )
+        , ( Fn.Array.isEmpty, ( 1, arrayIsEmptyChecks ) )
+        , ( Fn.Array.length, ( 1, arrayLengthChecks ) )
+        , ( Fn.Array.repeat, ( 2, arrayRepeatChecks ) )
+        , ( Fn.Array.initialize, ( 2, arrayInitializeChecks ) )
+        , ( Fn.Array.append, ( 2, arrayAppendChecks ) )
+        , ( Fn.Array.get, ( 2, arrayGetChecks ) )
+        , ( Fn.Array.set, ( 3, arraySetChecks ) )
+        , ( Fn.Array.slice, ( 3, arraySliceChecks ) )
+        , ( Fn.Array.foldl, ( 3, arrayFoldlChecks ) )
+        , ( Fn.Array.foldr, ( 3, arrayFoldrChecks ) )
+        , ( Fn.Set.map, ( 2, setMapChecks ) )
+        , ( Fn.Set.filter, ( 2, setFilterChecks ) )
+        , ( Fn.Set.remove, ( 2, setRemoveChecks ) )
+        , ( Fn.Set.isEmpty, ( 1, setIsEmptyChecks ) )
+        , ( Fn.Set.size, ( 1, setSizeChecks ) )
+        , ( Fn.Set.member, ( 2, setMemberChecks ) )
+        , ( Fn.Set.fromList, ( 1, setFromListChecks ) )
+        , ( Fn.Set.toList, ( 1, setToListChecks ) )
+        , ( Fn.Set.partition, ( 2, setPartitionChecks ) )
+        , ( Fn.Set.intersect, ( 2, setIntersectChecks ) )
+        , ( Fn.Set.diff, ( 2, setDiffChecks ) )
+        , ( Fn.Set.union, ( 2, setUnionChecks ) )
+        , ( Fn.Set.insert, ( 2, setInsertChecks ) )
+        , ( Fn.Set.foldl, ( 3, setFoldlChecks ) )
+        , ( Fn.Set.foldr, ( 3, setFoldrChecks ) )
+        , ( Fn.Dict.isEmpty, ( 1, dictIsEmptyChecks ) )
+        , ( Fn.Dict.fromList, ( 1, dictFromListChecks ) )
+        , ( Fn.Dict.toList, ( 1, dictToListChecks ) )
+        , ( Fn.Dict.size, ( 1, dictSizeChecks ) )
+        , ( Fn.Dict.member, ( 2, dictMemberChecks ) )
+        , ( Fn.Dict.remove, ( 2, dictRemoveChecks ) )
+        , ( Fn.Dict.filter, ( 2, dictFilterChecks ) )
+        , ( Fn.Dict.partition, ( 2, dictPartitionChecks ) )
+        , ( Fn.Dict.map, ( 2, dictMapChecks ) )
+        , ( Fn.Dict.intersect, ( 2, dictIntersectChecks ) )
+        , ( Fn.Dict.diff, ( 2, dictDiffChecks ) )
+        , ( Fn.Dict.union, ( 2, dictUnionChecks ) )
+        , ( Fn.Dict.foldl, ( 3, dictFoldlChecks ) )
+        , ( Fn.Dict.foldr, ( 3, dictFoldrChecks ) )
+        , ( Fn.String.toList, ( 1, stringToListChecks ) )
+        , ( Fn.String.fromList, ( 1, stringFromListChecks ) )
+        , ( Fn.String.isEmpty, ( 1, stringIsEmptyChecks ) )
+        , ( Fn.String.concat, ( 1, stringConcatChecks ) )
+        , ( Fn.String.join, ( 2, stringJoinChecks ) )
+        , ( Fn.String.length, ( 1, stringLengthChecks ) )
+        , ( Fn.String.repeat, ( 2, stringRepeatChecks ) )
+        , ( Fn.String.replace, ( 3, stringReplaceChecks ) )
+        , ( Fn.String.words, ( 1, stringWordsChecks ) )
+        , ( Fn.String.lines, ( 1, stringLinesChecks ) )
+        , ( Fn.String.reverse, ( 1, stringReverseChecks ) )
+        , ( Fn.String.slice, ( 3, stringSliceChecks ) )
+        , ( Fn.String.left, ( 2, stringLeftChecks ) )
+        , ( Fn.String.right, ( 2, stringRightChecks ) )
+        , ( Fn.String.append, ( 2, stringAppendChecks ) )
+        , ( Fn.String.foldl, ( 3, stringFoldlChecks ) )
+        , ( Fn.String.foldr, ( 3, stringFoldrChecks ) )
+        , ( Fn.Platform.Cmd.batch, ( 1, platformCmdBatchChecks ) )
+        , ( Fn.Platform.Cmd.map, ( 2, platformCmdMapChecks ) )
+        , ( Fn.Platform.Sub.batch, ( 1, platformSubBatchChecks ) )
+        , ( Fn.Platform.Sub.map, ( 2, platformSubChecks ) )
+        , ( Fn.Task.map, ( 2, taskMapChecks ) )
+        , ( Fn.Task.map2, ( 3, taskMapNChecks ) )
+        , ( Fn.Task.map3, ( 4, taskMapNChecks ) )
+        , ( Fn.Task.map4, ( 5, taskMapNChecks ) )
+        , ( Fn.Task.map5, ( 6, taskMapNChecks ) )
+        , ( Fn.Task.andThen, ( 2, taskAndThenChecks ) )
+        , ( Fn.Task.mapError, ( 2, taskMapErrorChecks ) )
+        , ( Fn.Task.onError, ( 2, taskOnErrorChecks ) )
+        , ( Fn.Task.sequence, ( 1, taskSequenceChecks ) )
+        , ( Fn.Json.Decode.oneOf, ( 1, jsonDecodeOneOfChecks ) )
+        , ( Fn.Json.Decode.map, ( 2, jsonDecodeMapChecks ) )
+        , ( Fn.Json.Decode.map2, ( 3, jsonDecodeMapNChecks ) )
+        , ( Fn.Json.Decode.map3, ( 4, jsonDecodeMapNChecks ) )
+        , ( Fn.Json.Decode.map4, ( 5, jsonDecodeMapNChecks ) )
+        , ( Fn.Json.Decode.map5, ( 6, jsonDecodeMapNChecks ) )
+        , ( Fn.Json.Decode.map6, ( 7, jsonDecodeMapNChecks ) )
+        , ( Fn.Json.Decode.map7, ( 8, jsonDecodeMapNChecks ) )
+        , ( Fn.Json.Decode.map8, ( 9, jsonDecodeMapNChecks ) )
+        , ( Fn.Json.Decode.andThen, ( 2, jsonDecodeAndThenChecks ) )
+        , ( Fn.Html.Attributes.classList, ( 1, htmlAttributesClassListChecks ) )
+        , ( Fn.Parser.oneOf, ( 1, parserOneOfChecks ) )
+        , ( Fn.Parser.Advanced.oneOf, ( 1, parserAdvancedOneOfChecks ) )
+        , ( Fn.Random.uniform, ( 2, randomUniformChecks ) )
+        , ( Fn.Random.weighted, ( 2, randomWeightedChecks ) )
+        , ( Fn.Random.list, ( 2, randomListChecks ) )
+        , ( Fn.Random.map, ( 2, randomMapChecks ) )
+        , ( Fn.Random.andThen, ( 2, randomAndThenChecks ) )
         ]
 
 
@@ -3780,15 +3780,18 @@ comparisonError bool checkInfo =
 -- BASICS FUNCTIONS
 
 
-basicsIdentityChecks : CheckInfo -> Maybe (Error {})
-basicsIdentityChecks checkInfo =
-    Just
-        (Rule.errorWithFix
-            { message = "`identity` should be removed"
-            , details = [ "`identity` can be a useful function to be passed as arguments to other functions, but calling it manually with an argument is the same thing as writing the argument on its own." ]
-            }
-            checkInfo.fnRange
-            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg })
+basicsIdentityChecks : IntoFnCheck
+basicsIdentityChecks =
+    intoFnCheckOnlyCall
+        (\checkInfo ->
+            Just
+                (Rule.errorWithFix
+                    { message = "`identity` should be removed"
+                    , details = [ "`identity` can be a useful function to be passed as arguments to other functions, but calling it manually with an argument is the same thing as writing the argument on its own." ]
+                    }
+                    checkInfo.fnRange
+                    (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg })
+                )
         )
 
 
@@ -3821,55 +3824,59 @@ basicsIdentityCompositionChecks checkInfo =
         Nothing
 
 
-basicsAlwaysChecks : CheckInfo -> Maybe (Error {})
-basicsAlwaysChecks checkInfo =
-    case secondArg checkInfo of
-        Just (Node secondArgRange _) ->
-            Just
-                (Rule.errorWithFix
-                    { message = "Expression can be replaced by the first argument given to `always`"
-                    , details = [ "The second argument will be ignored because of the `always` call." ]
-                    }
-                    checkInfo.fnRange
-                    (replaceBySubExpressionFix
-                        (Range.combine [ checkInfo.fnRange, Node.range checkInfo.firstArg, secondArgRange ])
-                        checkInfo.firstArg
-                    )
-                )
+basicsAlwaysChecks : IntoFnCheck
+basicsAlwaysChecks =
+    { call =
+        \checkInfo ->
+            case secondArg checkInfo of
+                Just (Node secondArgRange _) ->
+                    Just
+                        (Rule.errorWithFix
+                            { message = "Expression can be replaced by the first argument given to `always`"
+                            , details = [ "The second argument will be ignored because of the `always` call." ]
+                            }
+                            checkInfo.fnRange
+                            (replaceBySubExpressionFix
+                                (Range.combine [ checkInfo.fnRange, Node.range checkInfo.firstArg, secondArgRange ])
+                                checkInfo.firstArg
+                            )
+                        )
 
-        Nothing ->
-            Nothing
+                Nothing ->
+                    Nothing
+    , composition =
+        \checkInfo ->
+            case checkInfo.later.args of
+                _ :: [] ->
+                    Just
+                        { info =
+                            { message = "Function composed with always will be ignored"
+                            , details = [ "`always` will swallow the function composed into it." ]
+                            }
+                        , fix =
+                            [ Fix.removeRange checkInfo.earlier.removeRange ]
+                        }
+
+                _ ->
+                    Nothing
+    }
 
 
-basicsAlwaysCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-basicsAlwaysCompositionChecks checkInfo =
-    case checkInfo.later.args of
-        _ :: [] ->
-            Just
-                { info =
-                    { message = "Function composed with always will be ignored"
-                    , details = [ "`always` will swallow the function composed into it." ]
-                    }
-                , fix =
-                    [ Fix.removeRange checkInfo.earlier.removeRange ]
-                }
-
-        _ ->
-            Nothing
-
-
-basicsNegateChecks : CheckInfo -> Maybe (Error {})
+basicsNegateChecks : IntoFnCheck
 basicsNegateChecks =
-    toggleCallChecks
+    { call = toggleCallChecks, composition = toggleCompositionChecks }
 
 
-basicsNotChecks : CheckInfo -> Maybe (Error {})
+basicsNotChecks : IntoFnCheck
 basicsNotChecks =
-    firstThatConstructsJust
-        [ notOnKnownBoolCheck
-        , toggleCallChecks
-        , isNotOnBooleanOperatorCheck
-        ]
+    { call =
+        firstThatConstructsJust
+            [ notOnKnownBoolCheck
+            , toggleCallChecks
+            , isNotOnBooleanOperatorCheck
+            ]
+    , composition = toggleCompositionChecks
+    }
 
 
 notOnKnownBoolCheck : CheckInfo -> Maybe (Error {})
@@ -3956,32 +3963,38 @@ isNegatableOperator op =
             Nothing
 
 
-basicsToFloatChecks : CheckInfo -> Maybe (Error {})
-basicsToFloatChecks checkInfo =
-    case Evaluate.getInt checkInfo checkInfo.firstArg of
-        Just _ ->
-            Just
-                (Rule.errorWithFix
-                    { message = "Unnecessary " ++ qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on a literal number"
-                    , details =
-                        [ "A literal integer is considered a number which means it can be used as both an Int and a Float and there is no need to explicitly convert it to a Float."
-                        , "You can replace this function call by the literal number."
-                        ]
-                    }
-                    checkInfo.fnRange
-                    (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg })
-                )
+basicsToFloatChecks : IntoFnCheck
+basicsToFloatChecks =
+    intoFnCheckOnlyCall
+        (\checkInfo ->
+            case Evaluate.getInt checkInfo checkInfo.firstArg of
+                Just _ ->
+                    Just
+                        (Rule.errorWithFix
+                            { message = "Unnecessary " ++ qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " on a literal number"
+                            , details =
+                                [ "A literal integer is considered a number which means it can be used as both an Int and a Float and there is no need to explicitly convert it to a Float."
+                                , "You can replace this function call by the literal number."
+                                ]
+                            }
+                            checkInfo.fnRange
+                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg })
+                        )
 
-        Nothing ->
-            Nothing
+                Nothing ->
+                    Nothing
+        )
 
 
-intToIntChecks : CheckInfo -> Maybe (Error {})
+intToIntChecks : IntoFnCheck
 intToIntChecks =
-    firstThatConstructsJust
-        [ unnecessaryConversionToIntOnIntCheck
-        , onCallToInverseReturnsItsArgumentCheck Fn.Basics.toFloat
-        ]
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryConversionToIntOnIntCheck
+            , onCallToInverseReturnsItsArgumentCheck Fn.Basics.toFloat
+            ]
+    , composition = inversesCompositionCheck Fn.Basics.toFloat
+    }
 
 
 unnecessaryConversionToIntOnIntCheck : CheckInfo -> Maybe (Error {})
@@ -4171,146 +4184,147 @@ listConditions operatorToLookFor redundantConditionResolution expressionNode =
 -- TUPLE FUNCTIONS
 
 
-tuplePairChecks : CheckInfo -> Maybe (Error {})
-tuplePairChecks checkInfo =
-    case checkInfo.argsAfterFirst of
-        tuplePairCallSecondArg :: _ ->
-            let
-                firstRange : Range
-                firstRange =
-                    Node.range checkInfo.firstArg
+tuplePairChecks : IntoFnCheck
+tuplePairChecks =
+    intoFnCheckOnlyCall
+        (\checkInfo ->
+            case checkInfo.argsAfterFirst of
+                tuplePairCallSecondArg :: _ ->
+                    let
+                        firstRange : Range
+                        firstRange =
+                            Node.range checkInfo.firstArg
 
-                secondRange : Range
-                secondRange =
-                    Node.range tuplePairCallSecondArg
-            in
-            case Range.compareLocations firstRange.end secondRange.start of
-                LT ->
-                    Just
-                        (Rule.errorWithFix
-                            { message = "Fully constructed " ++ qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " can be replaced by tuple literal"
-                            , details = [ "You can replace this call by a tuple literal ( _, _ ). Consistently using ( _, _ ) to create a tuple is more idiomatic in elm." ]
-                            }
-                            checkInfo.fnRange
-                            (if checkInfo.parentRange.start.row /= checkInfo.parentRange.end.row then
-                                [ Fix.replaceRangeBy { start = checkInfo.parentRange.start, end = firstRange.start }
-                                    ("(\n" ++ String.repeat (firstRange.start.column - 1) " ")
-                                , Fix.replaceRangeBy { start = firstRange.end, end = secondRange.start }
-                                    ("\n"
-                                        ++ String.repeat (checkInfo.parentRange.start.column - 1) " "
-                                        ++ ",\n"
-                                        ++ String.repeat (secondRange.start.column - 1) " "
+                        secondRange : Range
+                        secondRange =
+                            Node.range tuplePairCallSecondArg
+                    in
+                    case Range.compareLocations firstRange.end secondRange.start of
+                        LT ->
+                            Just
+                                (Rule.errorWithFix
+                                    { message = "Fully constructed " ++ qualifiedToString (qualify checkInfo.fn defaultQualifyResources) ++ " can be replaced by tuple literal"
+                                    , details = [ "You can replace this call by a tuple literal ( _, _ ). Consistently using ( _, _ ) to create a tuple is more idiomatic in elm." ]
+                                    }
+                                    checkInfo.fnRange
+                                    (if checkInfo.parentRange.start.row /= checkInfo.parentRange.end.row then
+                                        [ Fix.replaceRangeBy { start = checkInfo.parentRange.start, end = firstRange.start }
+                                            ("(\n" ++ String.repeat (firstRange.start.column - 1) " ")
+                                        , Fix.replaceRangeBy { start = firstRange.end, end = secondRange.start }
+                                            ("\n"
+                                                ++ String.repeat (checkInfo.parentRange.start.column - 1) " "
+                                                ++ ",\n"
+                                                ++ String.repeat (secondRange.start.column - 1) " "
+                                            )
+                                        , Fix.replaceRangeBy { start = secondRange.end, end = checkInfo.parentRange.end }
+                                            ("\n"
+                                                ++ String.repeat (checkInfo.parentRange.start.column - 1) " "
+                                                ++ ")"
+                                            )
+                                        ]
+
+                                     else
+                                        [ Fix.replaceRangeBy { start = checkInfo.parentRange.start, end = firstRange.start } "( "
+                                        , Fix.replaceRangeBy { start = firstRange.end, end = secondRange.start } ", "
+                                        , Fix.replaceRangeBy { start = secondRange.end, end = checkInfo.parentRange.end } " )"
+                                        ]
                                     )
-                                , Fix.replaceRangeBy { start = secondRange.end, end = checkInfo.parentRange.end }
-                                    ("\n"
-                                        ++ String.repeat (checkInfo.parentRange.start.column - 1) " "
-                                        ++ ")"
-                                    )
-                                ]
+                                )
 
-                             else
-                                [ Fix.replaceRangeBy { start = checkInfo.parentRange.start, end = firstRange.start } "( "
-                                , Fix.replaceRangeBy { start = firstRange.end, end = secondRange.start } ", "
-                                , Fix.replaceRangeBy { start = secondRange.end, end = checkInfo.parentRange.end } " )"
-                                ]
-                            )
-                        )
+                        EQ ->
+                            Nothing
 
-                EQ ->
+                        GT ->
+                            Nothing
+
+                [] ->
                     Nothing
-
-                GT ->
-                    Nothing
-
-        [] ->
-            Nothing
+        )
 
 
-tupleFirstChecks : CheckInfo -> Maybe (Error {})
+tupleFirstChecks : IntoFnCheck
 tupleFirstChecks =
-    firstThatConstructsJust
-        [ tuplePartChecks
-            { part = TupleFirst
-            , description = "first"
-            , mapUnrelatedFn = Fn.Tuple.mapSecond
-            , mapFn = Fn.Tuple.mapFirst
-            }
-        , callFromCanBeCombinedCheck
-            { fromFn = Fn.List.partition, combinedFn = Fn.List.filter }
-        , callFromCanBeCombinedCheck
-            { fromFn = Fn.Set.partition, combinedFn = Fn.Set.filter }
-        , callFromCanBeCombinedCheck
-            { fromFn = Fn.Dict.partition, combinedFn = Fn.Dict.filter }
-        ]
-
-
-tupleFirstCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-tupleFirstCompositionChecks =
-    firstThatConstructsJust
-        [ tuplePartCompositionChecks
-            { part = TupleFirst
-            , description = "first"
-            , mapUnrelatedFn = Fn.Tuple.mapSecond
-            , mapFn = Fn.Tuple.mapFirst
-            }
-        , \checkInfo ->
-            case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
-                ( ( [ "Tuple" ], "pair" ), first :: [] ) ->
-                    Just
-                        { info =
-                            { message = qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in that first part"
-                            , details = [ "You can replace this call by always with the first argument given to " ++ qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ "." ]
+    { call =
+        firstThatConstructsJust
+            [ tuplePartChecks
+                { part = TupleFirst
+                , description = "first"
+                , mapUnrelatedFn = Fn.Tuple.mapSecond
+                , mapFn = Fn.Tuple.mapFirst
+                }
+            , callFromCanBeCombinedCheck
+                { fromFn = Fn.List.partition, combinedFn = Fn.List.filter }
+            , callFromCanBeCombinedCheck
+                { fromFn = Fn.Set.partition, combinedFn = Fn.Set.filter }
+            , callFromCanBeCombinedCheck
+                { fromFn = Fn.Dict.partition, combinedFn = Fn.Dict.filter }
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ tuplePartCompositionChecks
+                { part = TupleFirst
+                , description = "first"
+                , mapUnrelatedFn = Fn.Tuple.mapSecond
+                , mapFn = Fn.Tuple.mapFirst
+                }
+            , \checkInfo ->
+                case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
+                    ( ( [ "Tuple" ], "pair" ), first :: [] ) ->
+                        Just
+                            { info =
+                                { message = qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in that first part"
+                                , details = [ "You can replace this call by always with the first argument given to " ++ qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ "." ]
+                                }
+                            , fix =
+                                replaceBySubExpressionFix checkInfo.earlier.range first
+                                    ++ [ Fix.insertAt checkInfo.earlier.range.start
+                                            (qualifiedToString (qualify Fn.Basics.always checkInfo) ++ " ")
+                                       , Fix.removeRange checkInfo.later.removeRange
+                                       ]
                             }
-                        , fix =
-                            replaceBySubExpressionFix checkInfo.earlier.range first
-                                ++ [ Fix.insertAt checkInfo.earlier.range.start
-                                        (qualifiedToString (qualify Fn.Basics.always checkInfo) ++ " ")
-                                   , Fix.removeRange checkInfo.later.removeRange
-                                   ]
-                        }
 
-                _ ->
-                    Nothing
-        , compositionFromCanBeCombinedCheck
-            { fromFn = Fn.List.partition, combinedFn = Fn.List.filter }
-        , compositionFromCanBeCombinedCheck
-            { fromFn = Fn.Set.partition, combinedFn = Fn.Set.filter }
-        , compositionFromCanBeCombinedCheck
-            { fromFn = Fn.Dict.partition, combinedFn = Fn.Dict.filter }
-        ]
+                    _ ->
+                        Nothing
+            , compositionFromCanBeCombinedCheck
+                { fromFn = Fn.List.partition, combinedFn = Fn.List.filter }
+            , compositionFromCanBeCombinedCheck
+                { fromFn = Fn.Set.partition, combinedFn = Fn.Set.filter }
+            , compositionFromCanBeCombinedCheck
+                { fromFn = Fn.Dict.partition, combinedFn = Fn.Dict.filter }
+            ]
+    }
 
 
-tupleSecondChecks : CheckInfo -> Maybe (Error {})
+tupleSecondChecks : IntoFnCheck
 tupleSecondChecks =
-    tuplePartChecks
-        { part = TupleSecond
-        , description = "second"
-        , mapFn = Fn.Tuple.mapSecond
-        , mapUnrelatedFn = Fn.Tuple.mapFirst
-        }
-
-
-tupleSecondCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-tupleSecondCompositionChecks =
-    firstThatConstructsJust
-        [ tuplePartCompositionChecks
+    { call =
+        tuplePartChecks
             { part = TupleSecond
             , description = "second"
             , mapFn = Fn.Tuple.mapSecond
             , mapUnrelatedFn = Fn.Tuple.mapFirst
             }
-        , \checkInfo ->
-            case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
-                ( ( [ "Tuple" ], "pair" ), _ :: [] ) ->
-                    Just
-                        (compositionAlwaysReturnsIncomingError
-                            (qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in the incoming second part")
-                            checkInfo
-                        )
+    , composition =
+        firstThatConstructsJust
+            [ tuplePartCompositionChecks
+                { part = TupleSecond
+                , description = "second"
+                , mapFn = Fn.Tuple.mapSecond
+                , mapUnrelatedFn = Fn.Tuple.mapFirst
+                }
+            , \checkInfo ->
+                case ( checkInfo.earlier.fn, checkInfo.earlier.args ) of
+                    ( ( [ "Tuple" ], "pair" ), _ :: [] ) ->
+                        Just
+                            (compositionAlwaysReturnsIncomingError
+                                (qualifiedToString (qualify checkInfo.earlier.fn defaultQualifyResources) ++ " with a first part, then " ++ qualifiedToString (qualify checkInfo.later.fn defaultQualifyResources) ++ " will always result in the incoming second part")
+                                checkInfo
+                            )
 
-                _ ->
-                    Nothing
-        ]
+                    _ ->
+                        Nothing
+            ]
+    }
 
 
 type TuplePart
@@ -4452,251 +4466,280 @@ tuplePartCompositionChecks partConfig =
 -- STRING FUNCTIONS
 
 
-stringToListChecks : CheckInfo -> Maybe (Error {})
-stringToListChecks =
-    onCallToInverseReturnsItsArgumentCheck Fn.String.fromList
-
-
-stringToListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-stringToListCompositionChecks =
-    inversesCompositionCheck Fn.String.fromList
-
-
-stringFromListChecks : CheckInfo -> Maybe (Error {})
+stringFromListChecks : IntoFnCheck
 stringFromListChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection
-        , wrapperFromListSingletonChecks stringCollection
-        , onCallToInverseReturnsItsArgumentCheck Fn.String.toList
-        ]
+    { call =
+        firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection
+            , wrapperFromListSingletonChecks stringCollection
+            , onCallToInverseReturnsItsArgumentCheck Fn.String.toList
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ wrapperFromListSingletonCompositionChecks stringCollection
+            , inversesCompositionCheck Fn.String.toList
+            ]
+    }
 
 
-stringFromListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-stringFromListCompositionChecks =
-    firstThatConstructsJust
-        [ wrapperFromListSingletonCompositionChecks stringCollection
-        , inversesCompositionCheck Fn.String.toList
-        ]
+stringIsEmptyChecks : IntoFnCheck
+stringIsEmptyChecks =
+    intoFnCheckOnlyCall (collectionIsEmptyChecks stringCollection)
 
 
-stringConcatChecks : CheckInfo -> Maybe (Error {})
-stringConcatChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection
-        , callFromCanBeCombinedCheck { fromFn = Fn.List.repeat, combinedFn = Fn.String.repeat }
-        , callFromCanBeCombinedCheck { fromFn = Fn.List.intersperse, combinedFn = Fn.String.join }
-        ]
+stringLengthChecks : IntoFnCheck
+stringLengthChecks =
+    intoFnCheckOnlyCall (collectionSizeChecks stringCollection)
 
 
-stringConcatCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-stringConcatCompositionChecks =
-    firstThatConstructsJust
-        [ compositionFromCanBeCombinedCheck { fromFn = Fn.List.repeat, combinedFn = Fn.String.repeat }
-        , compositionFromCanBeCombinedCheck { fromFn = Fn.List.intersperse, combinedFn = Fn.String.join }
-        ]
+stringSliceChecks : IntoFnCheck
+stringSliceChecks =
+    intoFnCheckOnlyCall (collectionSliceChecks stringCollection)
 
 
-stringWordsChecks : CheckInfo -> Maybe (Error {})
-stringWordsChecks =
-    callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } stringCollection
-
-
-stringLinesChecks : CheckInfo -> Maybe (Error {})
-stringLinesChecks =
-    callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } stringCollection
-
-
-stringReverseChecks : CheckInfo -> Maybe (Error {})
+stringReverseChecks : IntoFnCheck
 stringReverseChecks =
-    firstThatConstructsJust
-        [ emptiableReverseChecks stringCollection
-        , unnecessaryCallOnWrappedCheck stringCollection
-        ]
+    { call =
+        firstThatConstructsJust
+            [ emptiableReverseChecks stringCollection
+            , unnecessaryCallOnWrappedCheck stringCollection
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ unnecessaryCompositionAfterWrapCheck stringCollection
+            , toggleCompositionChecks
+            ]
+    }
 
 
-stringReverseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-stringReverseCompositionChecks =
-    firstThatConstructsJust
-        [ unnecessaryCompositionAfterWrapCheck stringCollection
-        , toggleCompositionChecks
-        ]
-
-
-stringLeftChecks : CheckInfo -> Maybe (Error {})
+stringLeftChecks : IntoFnCheck
 stringLeftChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck stringCollection
-        , \checkInfo ->
-            case Evaluate.getInt checkInfo checkInfo.firstArg of
-                Just length ->
-                    callWithNonPositiveIntCanBeReplacedByCheck
-                        { int = length
-                        , intDescription = "length"
-                        , replacement = stringCollection.empty.asString
-                        }
-                        checkInfo
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck stringCollection
+            , \checkInfo ->
+                case Evaluate.getInt checkInfo checkInfo.firstArg of
+                    Just length ->
+                        callWithNonPositiveIntCanBeReplacedByCheck
+                            { int = length
+                            , intDescription = "length"
+                            , replacement = stringCollection.empty.asString
+                            }
+                            checkInfo
 
-                Nothing ->
-                    Nothing
-        ]
+                    Nothing ->
+                        Nothing
+            ]
+        )
 
 
-stringRightChecks : CheckInfo -> Maybe (Error {})
+stringRightChecks : IntoFnCheck
 stringRightChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck stringCollection
-        , \checkInfo ->
-            case Evaluate.getInt checkInfo checkInfo.firstArg of
-                Just length ->
-                    callWithNonPositiveIntCanBeReplacedByCheck
-                        { int = length
-                        , intDescription = "length"
-                        , replacement = stringCollection.empty.asString
-                        }
-                        checkInfo
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck stringCollection
+            , \checkInfo ->
+                case Evaluate.getInt checkInfo checkInfo.firstArg of
+                    Just length ->
+                        callWithNonPositiveIntCanBeReplacedByCheck
+                            { int = length
+                            , intDescription = "length"
+                            , replacement = stringCollection.empty.asString
+                            }
+                            checkInfo
 
-                Nothing ->
-                    Nothing
-        ]
-
-
-stringJoinChecks : CheckInfo -> Maybe (Error {})
-stringJoinChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection
-        , flatIntersperseWithEmptySeparatorIsEquivalentToFnCheck stringCollection Fn.String.concat
-        ]
+                    Nothing ->
+                        Nothing
+            ]
+        )
 
 
-stringRepeatChecks : CheckInfo -> Maybe (Error {})
-stringRepeatChecks =
-    emptiableFlatRepeatChecks stringCollection
-
-
-stringReplaceChecks : CheckInfo -> Maybe (Error {})
+stringReplaceChecks : IntoFnCheck
 stringReplaceChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck stringCollection
-        , \checkInfo ->
-            case secondArg checkInfo of
-                Just replacementArg ->
-                    firstThatConstructsJust
-                        [ \() ->
-                            Maybe.andThen
-                                (\stringArg ->
-                                    case ( checkInfo.firstArg, stringArg ) of
-                                        ( Node _ (Expression.Literal toReplace), Node _ (Expression.Literal third) ) ->
-                                            if not (String.contains "\u{000D}" toReplace) && not (String.contains toReplace third) then
-                                                Just
-                                                    (Rule.errorWithFix
-                                                        { message = "String.replace with a pattern not present in the given string will result in the given string"
-                                                        , details = [ "You can replace this call by the given string itself." ]
-                                                        }
-                                                        checkInfo.fnRange
-                                                        (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range stringArg })
-                                                    )
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck stringCollection
+            , \checkInfo ->
+                case secondArg checkInfo of
+                    Just replacementArg ->
+                        firstThatConstructsJust
+                            [ \() ->
+                                Maybe.andThen
+                                    (\stringArg ->
+                                        case ( checkInfo.firstArg, stringArg ) of
+                                            ( Node _ (Expression.Literal toReplace), Node _ (Expression.Literal third) ) ->
+                                                if not (String.contains "\u{000D}" toReplace) && not (String.contains toReplace third) then
+                                                    Just
+                                                        (Rule.errorWithFix
+                                                            { message = "String.replace with a pattern not present in the given string will result in the given string"
+                                                            , details = [ "You can replace this call by the given string itself." ]
+                                                            }
+                                                            checkInfo.fnRange
+                                                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range stringArg })
+                                                        )
 
-                                            else
+                                                else
+                                                    Nothing
+
+                                            _ ->
                                                 Nothing
+                                    )
+                                    (thirdArg checkInfo)
+                            , \() ->
+                                case Normalize.compare checkInfo checkInfo.firstArg replacementArg of
+                                    Normalize.ConfirmedEquality ->
+                                        Just
+                                            (alwaysReturnsLastArgError
+                                                (qualifiedToString checkInfo.fn ++ " where the pattern to replace and the replacement are equal")
+                                                stringCollection
+                                                checkInfo
+                                            )
 
-                                        _ ->
-                                            Nothing
-                                )
-                                (thirdArg checkInfo)
-                        , \() ->
-                            case Normalize.compare checkInfo checkInfo.firstArg replacementArg of
-                                Normalize.ConfirmedEquality ->
-                                    Just
-                                        (alwaysReturnsLastArgError
-                                            (qualifiedToString checkInfo.fn ++ " where the pattern to replace and the replacement are equal")
-                                            stringCollection
-                                            checkInfo
-                                        )
+                                    _ ->
+                                        Nothing
+                            ]
+                            ()
 
-                                _ ->
-                                    Nothing
-                        ]
-                        ()
-
-                Nothing ->
-                    Nothing
-        ]
+                    Nothing ->
+                        Nothing
+            ]
+        )
 
 
-stringFoldlChecks : CheckInfo -> Maybe (Error {})
+stringAppendChecks : IntoFnCheck
+stringAppendChecks =
+    intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } stringCollection)
+
+
+stringConcatChecks : IntoFnCheck
+stringConcatChecks =
+    { call =
+        firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection
+            , callFromCanBeCombinedCheck { fromFn = Fn.List.repeat, combinedFn = Fn.String.repeat }
+            , callFromCanBeCombinedCheck { fromFn = Fn.List.intersperse, combinedFn = Fn.String.join }
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ compositionFromCanBeCombinedCheck { fromFn = Fn.List.repeat, combinedFn = Fn.String.repeat }
+            , compositionFromCanBeCombinedCheck { fromFn = Fn.List.intersperse, combinedFn = Fn.String.join }
+            ]
+    }
+
+
+stringJoinChecks : IntoFnCheck
+stringJoinChecks =
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = stringCollection.empty.asString } listCollection
+            , flatIntersperseWithEmptySeparatorIsEquivalentToFnCheck stringCollection Fn.String.concat
+            ]
+        )
+
+
+stringRepeatChecks : IntoFnCheck
+stringRepeatChecks =
+    intoFnCheckOnlyCall (emptiableFlatRepeatChecks stringCollection)
+
+
+stringWordsChecks : IntoFnCheck
+stringWordsChecks =
+    intoFnCheckOnlyCall
+        (callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } stringCollection)
+
+
+stringLinesChecks : IntoFnCheck
+stringLinesChecks =
+    intoFnCheckOnlyCall
+        (callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } stringCollection)
+
+
+stringToListChecks : IntoFnCheck
+stringToListChecks =
+    { call = onCallToInverseReturnsItsArgumentCheck Fn.String.fromList
+    , composition = inversesCompositionCheck Fn.String.fromList
+    }
+
+
+stringFoldlChecks : IntoFnCheck
 stringFoldlChecks =
-    emptiableFoldChecks stringCollection
+    intoFnCheckOnlyCall (emptiableFoldChecks stringCollection)
 
 
-stringFoldrChecks : CheckInfo -> Maybe (Error {})
+stringFoldrChecks : IntoFnCheck
 stringFoldrChecks =
-    emptiableFoldChecks stringCollection
+    intoFnCheckOnlyCall (emptiableFoldChecks stringCollection)
 
 
 
 -- MAYBE FUNCTIONS
 
 
-maybeMapChecks : CheckInfo -> Maybe (Error {})
+maybeMapChecks : IntoFnCheck
 maybeMapChecks =
-    firstThatConstructsJust
-        [ emptiableMapChecks maybeWithJustAsWrap
-        , mapOnWrappedChecks maybeWithJustAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ emptiableMapChecks maybeWithJustAsWrap
+            , mapOnWrappedChecks maybeWithJustAsWrap
+            ]
+    , composition = mapAfterWrapCompositionChecks maybeWithJustAsWrap
+    }
 
 
-maybeMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-maybeMapCompositionChecks =
-    mapAfterWrapCompositionChecks maybeWithJustAsWrap
-
-
-maybeMapNChecks : CheckInfo -> Maybe (Error {})
+maybeMapNChecks : IntoFnCheck
 maybeMapNChecks =
-    firstThatConstructsJust
-        [ wrapperMapNChecks maybeWithJustAsWrap
-        , emptiableMapNChecks maybeWithJustAsWrap
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ wrapperMapNChecks maybeWithJustAsWrap
+            , emptiableMapNChecks maybeWithJustAsWrap
+            ]
+        )
 
 
-maybeAndThenChecks : CheckInfo -> Maybe (Error {})
+maybeAndThenChecks : IntoFnCheck
 maybeAndThenChecks =
-    firstThatConstructsJust
-        [ wrapperFlatMapChecks maybeWithJustAsWrap
-        , emptiableFlatMapChecks maybeWithJustAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ wrapperFlatMapChecks maybeWithJustAsWrap
+            , emptiableFlatMapChecks maybeWithJustAsWrap
+            ]
+    , composition =
+        wrapperFlatMapCompositionChecks maybeWithJustAsWrap
+    }
 
 
-maybeAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-maybeAndThenCompositionChecks checkInfo =
-    wrapperFlatMapCompositionChecks maybeWithJustAsWrap checkInfo
+maybeWithDefaultChecks : IntoFnCheck
+maybeWithDefaultChecks =
+    { call = withDefaultChecks maybeWithJustAsWrap, composition = wrapperWithDefaultChecks maybeWithJustAsWrap }
 
 
 
 -- RESULT FUNCTIONS
 
 
-resultMapChecks : CheckInfo -> Maybe (Error {})
+resultMapChecks : IntoFnCheck
 resultMapChecks =
-    firstThatConstructsJust
-        [ emptiableMapChecks resultWithOkAsWrap
-        , mapOnWrappedChecks resultWithOkAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ emptiableMapChecks resultWithOkAsWrap
+            , mapOnWrappedChecks resultWithOkAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ mapAfterWrapCompositionChecks resultWithOkAsWrap
+            , unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
+            ]
+    }
 
 
-resultMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-resultMapCompositionChecks =
-    firstThatConstructsJust
-        [ mapAfterWrapCompositionChecks resultWithOkAsWrap
-        , unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
-        ]
-
-
-resultMapNChecks : CheckInfo -> Maybe (Error {})
+resultMapNChecks : IntoFnCheck
 resultMapNChecks =
-    firstThatConstructsJust
-        [ wrapperMapNChecks resultWithOkAsWrap
-        , mapNOrFirstEmptyConstructionChecks resultWithOkAsWrap
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ wrapperMapNChecks resultWithOkAsWrap
+            , mapNOrFirstEmptyConstructionChecks resultWithOkAsWrap
+            ]
+        )
 
 
 mapWrapErrorInfo :
@@ -4714,191 +4757,207 @@ mapWrapErrorInfo mapFn wrapper =
     }
 
 
-resultMapErrorChecks : CheckInfo -> Maybe (Error {})
+resultMapErrorChecks : IntoFnCheck
 resultMapErrorChecks =
-    firstThatConstructsJust
-        [ emptiableMapChecks resultWithErrAsWrap
-        , mapOnWrappedChecks resultWithErrAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ emptiableMapChecks resultWithErrAsWrap
+            , mapOnWrappedChecks resultWithErrAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ mapAfterWrapCompositionChecks resultWithErrAsWrap
+            , unnecessaryCompositionAfterEmptyCheck resultWithErrAsWrap
+            ]
+    }
 
 
-resultMapErrorCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-resultMapErrorCompositionChecks =
-    firstThatConstructsJust
-        [ mapAfterWrapCompositionChecks resultWithErrAsWrap
-        , unnecessaryCompositionAfterEmptyCheck resultWithErrAsWrap
-        ]
-
-
-resultAndThenChecks : CheckInfo -> Maybe (Error {})
+resultAndThenChecks : IntoFnCheck
 resultAndThenChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck resultWithOkAsWrap
-        , wrapperFlatMapChecks resultWithOkAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck resultWithOkAsWrap
+            , wrapperFlatMapChecks resultWithOkAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
+            , wrapperFlatMapCompositionChecks resultWithOkAsWrap
+            ]
+    }
 
 
-resultAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-resultAndThenCompositionChecks =
-    firstThatConstructsJust
-        [ unnecessaryCompositionAfterEmptyCheck resultWithOkAsWrap
-        , wrapperFlatMapCompositionChecks resultWithOkAsWrap
-        ]
+resultWithDefaultChecks : IntoFnCheck
+resultWithDefaultChecks =
+    { call = withDefaultChecks resultWithOkAsWrap
+    , composition = wrapperWithDefaultChecks resultWithOkAsWrap
+    }
 
 
-resultToMaybeCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-resultToMaybeCompositionChecks =
-    firstThatConstructsJust
-        [ onWrapAlwaysReturnsJustIncomingCompositionCheck resultWithOkAsWrap
-        , \checkInfo ->
-            case checkInfo.earlier.fn of
-                ( [ "Result" ], "Err" ) ->
-                    Just
-                        { info =
-                            { message = qualifiedToString Fn.Result.toMaybe ++ " on an error will result in Nothing"
-                            , details = [ "You can replace this call by always Nothing." ]
+resultToMaybeChecks : IntoFnCheck
+resultToMaybeChecks =
+    { call = unwrapToMaybeChecks resultWithOkAsWrap
+    , composition =
+        firstThatConstructsJust
+            [ onWrapAlwaysReturnsJustIncomingCompositionCheck resultWithOkAsWrap
+            , \checkInfo ->
+                case checkInfo.earlier.fn of
+                    ( [ "Result" ], "Err" ) ->
+                        Just
+                            { info =
+                                { message = qualifiedToString Fn.Result.toMaybe ++ " on an error will result in Nothing"
+                                , details = [ "You can replace this call by always Nothing." ]
+                                }
+                            , fix =
+                                compositionReplaceByFix
+                                    (qualifiedToString (qualify Fn.Basics.always checkInfo)
+                                        ++ " "
+                                        ++ qualifiedToString (qualify Fn.Maybe.nothingVariant checkInfo)
+                                    )
+                                    checkInfo
                             }
-                        , fix =
-                            compositionReplaceByFix
-                                (qualifiedToString (qualify Fn.Basics.always checkInfo)
-                                    ++ " "
-                                    ++ qualifiedToString (qualify Fn.Maybe.nothingVariant checkInfo)
-                                )
-                                checkInfo
-                        }
 
-                _ ->
-                    Nothing
-        ]
+                    _ ->
+                        Nothing
+            ]
+    }
 
 
-resultFromMaybeChecks : CheckInfo -> Maybe (Error {})
+resultFromMaybeChecks : IntoFnCheck
 resultFromMaybeChecks =
-    fromMaybeChecks
-        { onNothingFn = Fn.Result.errVariant, onJustFn = Fn.Result.okVariant }
+    { call =
+        fromMaybeChecks
+            { onNothingFn = Fn.Result.errVariant, onJustFn = Fn.Result.okVariant }
+    , composition = wrapperFromMaybeCompositionChecks resultWithOkAsWrap
+    }
 
 
 
 -- LIST FUNCTIONS
 
 
-listConcatChecks : CheckInfo -> Maybe (Error {})
+listAppendChecks : IntoFnCheck
+listAppendChecks =
+    intoFnCheckOnlyCall
+        (collectionUnionChecks { leftElementsStayOnTheLeft = True } listCollection)
+
+
+listConcatChecks : IntoFnCheck
 listConcatChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck listCollection
-        , callOnWrapReturnsItsValueCheck listCollection
-        , \checkInfo ->
-            callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn)
-                ( listCollection, listCollection )
-                checkInfo
-        , \checkInfo ->
-            case fromListGetLiteral listCollection checkInfo.lookupTable checkInfo.firstArg of
-                Just listLiteral ->
-                    firstThatConstructsJust
-                        [ \() ->
-                            case traverse AstHelpers.getListLiteral listLiteral.elements of
-                                Just _ ->
-                                    Just
-                                        (Rule.errorWithFix
-                                            { message = "Expression could be simplified to be a single List"
-                                            , details = [ "Try moving all the elements into a single list." ]
-                                            }
-                                            checkInfo.fnRange
-                                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg }
-                                                ++ List.concatMap removeBoundariesFix listLiteral.elements
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck listCollection
+            , callOnWrapReturnsItsValueCheck listCollection
+            , \checkInfo ->
+                callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn)
+                    ( listCollection, listCollection )
+                    checkInfo
+            , \checkInfo ->
+                case fromListGetLiteral listCollection checkInfo.lookupTable checkInfo.firstArg of
+                    Just listLiteral ->
+                        firstThatConstructsJust
+                            [ \() ->
+                                case traverse AstHelpers.getListLiteral listLiteral.elements of
+                                    Just _ ->
+                                        Just
+                                            (Rule.errorWithFix
+                                                { message = "Expression could be simplified to be a single List"
+                                                , details = [ "Try moving all the elements into a single list." ]
+                                                }
+                                                checkInfo.fnRange
+                                                (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range checkInfo.firstArg }
+                                                    ++ List.concatMap removeBoundariesFix listLiteral.elements
+                                                )
                                             )
-                                        )
 
-                                Nothing ->
-                                    Nothing
-                        , \() ->
-                            case mergeConsecutiveFromListLiteralsFix listCollection checkInfo listLiteral.elements of
-                                firstFix :: fixesAfterFirst ->
-                                    Just
-                                        (Rule.errorWithFix
-                                            { message = "Consecutive literal lists can be merged"
-                                            , details = [ "Try moving all the elements from consecutive list literals so that they form a single list." ]
-                                            }
-                                            checkInfo.fnRange
-                                            (firstFix :: fixesAfterFirst)
-                                        )
+                                    Nothing ->
+                                        Nothing
+                            , \() ->
+                                case mergeConsecutiveFromListLiteralsFix listCollection checkInfo listLiteral.elements of
+                                    firstFix :: fixesAfterFirst ->
+                                        Just
+                                            (Rule.errorWithFix
+                                                { message = "Consecutive literal lists can be merged"
+                                                , details = [ "Try moving all the elements from consecutive list literals so that they form a single list." ]
+                                                }
+                                                checkInfo.fnRange
+                                                (firstFix :: fixesAfterFirst)
+                                            )
 
-                                [] ->
-                                    Nothing
-                        ]
-                        ()
+                                    [] ->
+                                        Nothing
+                            ]
+                            ()
 
-                Nothing ->
-                    Nothing
-        , callFromCanBeCombinedCheck
-            { fromFn = Fn.List.map, combinedFn = Fn.List.concatMap }
-        ]
-
-
-listConcatCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listConcatCompositionChecks =
-    firstThatConstructsJust
-        [ compositionFromCanBeCombinedCheck
-            { fromFn = Fn.List.map, combinedFn = Fn.List.concatMap }
-        , onWrapAlwaysReturnsIncomingCompositionCheck listCollection
-        ]
+                    Nothing ->
+                        Nothing
+            , callFromCanBeCombinedCheck
+                { fromFn = Fn.List.map, combinedFn = Fn.List.concatMap }
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ compositionFromCanBeCombinedCheck
+                { fromFn = Fn.List.map, combinedFn = Fn.List.concatMap }
+            , onWrapAlwaysReturnsIncomingCompositionCheck listCollection
+            ]
+    }
 
 
-listConcatMapChecks : CheckInfo -> Maybe (Error {})
+listConcatMapChecks : IntoFnCheck
 listConcatMapChecks =
-    firstThatConstructsJust
-        [ operationWithIdentityIsEquivalentToFnCheck Fn.List.concat
-        , emptiableFlatMapChecks listCollection
-        , wrapperFlatMapChecks listCollection
-        ]
+    { call =
+        firstThatConstructsJust
+            [ operationWithIdentityIsEquivalentToFnCheck Fn.List.concat
+            , emptiableFlatMapChecks listCollection
+            , wrapperFlatMapChecks listCollection
+            ]
+    , composition = wrapperFlatMapCompositionChecks listCollection
+    }
 
 
-listConcatMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listConcatMapCompositionChecks =
-    wrapperFlatMapCompositionChecks listCollection
-
-
-listIndexedMapChecks : CheckInfo -> Maybe (Error {})
+listIndexedMapChecks : IntoFnCheck
 listIndexedMapChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck listCollection
-        , operationWithExtraArgChecks { operationWithoutExtraArg = Fn.List.map }
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck listCollection
+            , operationWithExtraArgChecks { operationWithoutExtraArg = Fn.List.map }
+            ]
+        )
 
 
-listIntersperseChecks : CheckInfo -> Maybe (Error {})
+listIntersperseChecks : IntoFnCheck
 listIntersperseChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
-        ]
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck listCollection
+            , unnecessaryCallOnWrappedCheck listCollection
+            ]
+    , composition = unnecessaryCompositionAfterWrapCheck listCollection
+    }
 
 
-listIntersperseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listIntersperseCompositionChecks =
-    unnecessaryCompositionAfterWrapCheck listCollection
-
-
-listHeadChecks : CheckInfo -> Maybe (Error {})
+listHeadChecks : IntoFnCheck
 listHeadChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection
-        , \checkInfo ->
-            Maybe.map
-                (\listArgHead ->
-                    Rule.errorWithFix
-                        { message = qualifiedToString checkInfo.fn ++ " on a list with a first element will result in Just that element"
-                        , details = [ "You can replace this call by Just the first list element." ]
-                        }
-                        checkInfo.fnRange
-                        (replaceBySubExpressionFix (Node.range checkInfo.firstArg) listArgHead
-                            ++ [ Fix.replaceRangeBy checkInfo.fnRange
-                                    (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo))
-                               ]
-                        )
-                )
-                (getListHead checkInfo.lookupTable checkInfo.firstArg)
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection
+            , \checkInfo ->
+                Maybe.map
+                    (\listArgHead ->
+                        Rule.errorWithFix
+                            { message = qualifiedToString checkInfo.fn ++ " on a list with a first element will result in Just that element"
+                            , details = [ "You can replace this call by Just the first list element." ]
+                            }
+                            checkInfo.fnRange
+                            (replaceBySubExpressionFix (Node.range checkInfo.firstArg) listArgHead
+                                ++ [ Fix.replaceRangeBy checkInfo.fnRange
+                                        (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo))
+                                   ]
+                            )
+                    )
+                    (getListHead checkInfo.lookupTable checkInfo.firstArg)
+            ]
+        )
 
 
 getListHead : ModuleNameLookupTable -> Node Expression -> Maybe (Node Expression)
@@ -4933,57 +4992,72 @@ listTailExistsError replaceListArgByTailFix checkInfo =
         )
 
 
-listTailChecks : CheckInfo -> Maybe (Error {})
+listTailChecks : IntoFnCheck
 listTailChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection
-        , \checkInfo ->
-            case Node.value (AstHelpers.removeParens checkInfo.firstArg) of
-                Expression.ListExpr ((Node headRange _) :: (Node tailFirstRange _) :: _) ->
-                    Just
-                        (listTailExistsError
-                            [ Fix.removeRange { start = headRange.start, end = tailFirstRange.start }
-                            ]
-                            checkInfo
-                        )
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection
+            , \checkInfo ->
+                case Node.value (AstHelpers.removeParens checkInfo.firstArg) of
+                    Expression.ListExpr ((Node headRange _) :: (Node tailFirstRange _) :: _) ->
+                        Just
+                            (listTailExistsError
+                                [ Fix.removeRange { start = headRange.start, end = tailFirstRange.start }
+                                ]
+                                checkInfo
+                            )
 
-                Expression.OperatorApplication "::" _ _ tail ->
-                    Just
-                        (listTailExistsError
-                            (replaceBySubExpressionFix (Node.range checkInfo.firstArg) tail)
-                            checkInfo
-                        )
+                    Expression.OperatorApplication "::" _ _ tail ->
+                        Just
+                            (listTailExistsError
+                                (replaceBySubExpressionFix (Node.range checkInfo.firstArg) tail)
+                                checkInfo
+                            )
 
-                _ ->
-                    Nothing
-        , \checkInfo ->
-            case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.firstArg of
-                Just _ ->
-                    Just
-                        (Rule.errorWithFix
-                            { message = qualifiedToString checkInfo.fn ++ " on a singleton list will result in Just []"
-                            , details = [ "You can replace this call by Just []." ]
-                            }
-                            checkInfo.fnRange
-                            [ Fix.replaceRangeBy (Node.range checkInfo.firstArg) "[]"
-                            , Fix.replaceRangeBy checkInfo.fnRange
-                                (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo))
-                            ]
-                        )
+                    _ ->
+                        Nothing
+            , \checkInfo ->
+                case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.firstArg of
+                    Just _ ->
+                        Just
+                            (Rule.errorWithFix
+                                { message = qualifiedToString checkInfo.fn ++ " on a singleton list will result in Just []"
+                                , details = [ "You can replace this call by Just []." ]
+                                }
+                                checkInfo.fnRange
+                                [ Fix.replaceRangeBy (Node.range checkInfo.firstArg) "[]"
+                                , Fix.replaceRangeBy checkInfo.fnRange
+                                    (qualifiedToString (qualify Fn.Maybe.justVariant checkInfo))
+                                ]
+                            )
 
-                Nothing ->
-                    Nothing
-        ]
+                    Nothing ->
+                        Nothing
+            ]
+        )
 
 
-listMapChecks : CheckInfo -> Maybe (Error {})
+listMapChecks : IntoFnCheck
 listMapChecks =
-    firstThatConstructsJust
-        [ emptiableMapChecks listCollection
-        , listMapOnSingletonCheck
-        , dictToListMapChecks
-        , arrayToIndexedListToListMapChecks
-        ]
+    { call =
+        firstThatConstructsJust
+            [ emptiableMapChecks listCollection
+            , listMapOnSingletonCheck
+            , dictToListMapChecks
+            , arrayToIndexedListToListMapChecks
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ mapAfterWrapCompositionChecks listCollection
+            , dictToListIntoListMapCompositionCheck
+            , arrayToIndexedListMapCompositionCheck
+            ]
+    }
+
+
+listMapNChecks : IntoFnCheck
+listMapNChecks =
+    intoFnCheckOnlyCall (emptiableMapNChecks listCollection)
 
 
 listMapOnSingletonCheck : CheckInfo -> Maybe (Error {})
@@ -5156,15 +5230,6 @@ arrayToIndexedListToListMapChecks listMapCheckInfo =
             Nothing
 
 
-listMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listMapCompositionChecks =
-    firstThatConstructsJust
-        [ mapAfterWrapCompositionChecks listCollection
-        , dictToListIntoListMapCompositionCheck
-        , arrayToIndexedListMapCompositionCheck
-        ]
-
-
 dictToListIntoListMapCompositionCheck : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 dictToListIntoListMapCompositionCheck checkInfo =
     case
@@ -5218,83 +5283,101 @@ arrayToIndexedListMapCompositionCheck checkInfo =
             Nothing
 
 
-listMemberChecks : CheckInfo -> Maybe (Error {})
+listMemberChecks : IntoFnCheck
 listMemberChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck
-            { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
-            listCollection
-        , knownMemberChecks listCollection
-        , wrapperMemberChecks listCollection
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ callOnEmptyReturnsCheck
+                { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
+                listCollection
+            , knownMemberChecks listCollection
+            , wrapperMemberChecks listCollection
+            ]
+        )
 
 
-listSumChecks : CheckInfo -> Maybe (Error {})
+listSumChecks : IntoFnCheck
 listSumChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = \_ -> "0" } listCollection
-        , callOnWrapReturnsItsValueCheck listCollection
-        , \checkInfo ->
-            callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn)
-                ( listCollection, numberForAddProperties )
-                checkInfo
-        , \checkInfo ->
-            if checkInfo.expectNaN then
-                callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
+    { call =
+        firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = \_ -> "0" } listCollection
+            , callOnWrapReturnsItsValueCheck listCollection
+            , \checkInfo ->
+                callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn)
                     ( listCollection, numberForAddProperties )
                     checkInfo
+            , \checkInfo ->
+                if checkInfo.expectNaN then
+                    callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
+                        ( listCollection, numberForAddProperties )
+                        checkInfo
 
-            else
-                Nothing
-        ]
+                else
+                    Nothing
+            ]
+    , composition = sumCompositionChecks listCollection
+    }
 
 
-listProductChecks : CheckInfo -> Maybe (Error {})
+listProductChecks : IntoFnCheck
 listProductChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = \_ -> "1" } listCollection
-        , callOnWrapReturnsItsValueCheck listCollection
-        , \checkInfo ->
-            callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn)
-                ( listCollection, numberForMultiplyProperties )
-                checkInfo
-        , \checkInfo ->
-            if checkInfo.expectNaN then
-                callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
+    { call =
+        firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = \_ -> "1" } listCollection
+            , callOnWrapReturnsItsValueCheck listCollection
+            , \checkInfo ->
+                callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn)
                     ( listCollection, numberForMultiplyProperties )
                     checkInfo
+            , \checkInfo ->
+                if checkInfo.expectNaN then
+                    callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
+                        ( listCollection, numberForMultiplyProperties )
+                        checkInfo
 
-            else
-                callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
-                    ( listCollection, numberNotExpectingNaNForMultiplyProperties )
-                    checkInfo
-        ]
+                else
+                    callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
+                        ( listCollection, numberNotExpectingNaNForMultiplyProperties )
+                        checkInfo
+            ]
+    , composition = productCompositionChecks listCollection
+    }
 
 
-listMinimumChecks : CheckInfo -> Maybe (Error {})
+listMinimumChecks : IntoFnCheck
 listMinimumChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection
-        , callOnWrapReturnsJustItsValue listCollection
-        ]
+    { call =
+        firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection
+            , callOnWrapReturnsJustItsValue listCollection
+            ]
+    , composition = minimumCompositionChecks listCollection
+    }
 
 
-listMaximumChecks : CheckInfo -> Maybe (Error {})
+listMaximumChecks : IntoFnCheck
 listMaximumChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection
-        , callOnWrapReturnsJustItsValue listCollection
-        ]
+    { call =
+        firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = maybeWithJustAsWrap.empty.asString } listCollection
+            , callOnWrapReturnsJustItsValue listCollection
+            ]
+    , composition = maximumCompositionChecks listCollection
+    }
 
 
-listFoldlChecks : CheckInfo -> Maybe (Error {})
+listFoldlChecks : IntoFnCheck
 listFoldlChecks =
-    listFoldAnyDirectionChecks
+    { call = listFoldAnyDirectionChecks
+    , composition = foldAndSetToListCompositionChecks
+    }
 
 
-listFoldrChecks : CheckInfo -> Maybe (Error {})
+listFoldrChecks : IntoFnCheck
 listFoldrChecks =
-    listFoldAnyDirectionChecks
+    { call = listFoldAnyDirectionChecks
+    , composition = foldAndSetToListCompositionChecks
+    }
 
 
 listFoldAnyDirectionChecks : CheckInfo -> Maybe (Error {})
@@ -5469,16 +5552,6 @@ listFoldAnyDirectionChecks =
         ]
 
 
-listFoldlCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listFoldlCompositionChecks =
-    foldAndSetToListCompositionChecks
-
-
-listFoldrCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listFoldrCompositionChecks =
-    foldAndSetToListCompositionChecks
-
-
 foldAndSetToListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
 foldAndSetToListCompositionChecks checkInfo =
     case checkInfo.earlier.fn of
@@ -5499,307 +5572,353 @@ foldAndSetToListCompositionChecks checkInfo =
             Nothing
 
 
-listAllChecks : CheckInfo -> Maybe (Error {})
+listIsEmptyChecks : IntoFnCheck
+listIsEmptyChecks =
+    intoFnCheckOnlyCall (collectionIsEmptyChecks listCollection)
+
+
+listLengthChecks : IntoFnCheck
+listLengthChecks =
+    intoFnCheckOnlyCall (collectionSizeChecks listCollection)
+
+
+listAllChecks : IntoFnCheck
 listAllChecks =
-    firstThatConstructsJust
-        [ emptiableAllChecks listCollection
-        , collectionAllChecks listCollection
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ emptiableAllChecks listCollection
+            , collectionAllChecks listCollection
+            ]
+        )
 
 
-listAnyChecks : CheckInfo -> Maybe (Error {})
+listAnyChecks : IntoFnCheck
 listAnyChecks =
-    firstThatConstructsJust
-        [ emptiableAnyChecks listCollection
-        , collectionAnyChecks listCollection
-        , operationWithEqualsConstantIsEquivalentToFnWithThatConstantCheck Fn.List.member
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ emptiableAnyChecks listCollection
+            , collectionAnyChecks listCollection
+            , operationWithEqualsConstantIsEquivalentToFnWithThatConstantCheck Fn.List.member
+            ]
+        )
 
 
-listFilterMapChecks : CheckInfo -> Maybe (Error {})
+listFilterChecks : IntoFnCheck
+listFilterChecks =
+    intoFnCheckOnlyCall (emptiableKeepWhenChecks listCollection)
+
+
+listPartitionChecks : IntoFnCheck
+listPartitionChecks =
+    intoFnCheckOnlyCall (collectionPartitionChecks listCollection)
+
+
+listFilterMapChecks : IntoFnCheck
 listFilterMapChecks =
-    firstThatConstructsJust
-        [ emptiableWrapperFilterMapChecks listCollection
-        , \checkInfo ->
-            if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
-                firstThatConstructsJust
-                    [ \() ->
-                        callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn ++ " with an identity function")
-                            ( listCollection, maybeWithJustAsWrap )
-                            checkInfo
-                    , \() ->
-                        case secondArg checkInfo of
-                            Just listArg ->
-                                case AstHelpers.getListLiteral listArg of
-                                    Just list ->
-                                        case
-                                            traverse
-                                                (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant checkInfo.lookupTable)
-                                                list
-                                        of
-                                            Just justCalls ->
-                                                Just
-                                                    (Rule.errorWithFix
-                                                        { message = "Unnecessary use of " ++ qualifiedToString checkInfo.fn ++ " identity"
-                                                        , details = [ "All of the elements in the list are `Just`s, which can be simplified by removing all of the `Just`s." ]
-                                                        }
-                                                        checkInfo.fnRange
-                                                        (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range listArg }
-                                                            ++ List.concatMap
-                                                                (\just -> keepOnlyFix { parentRange = just.nodeRange, keep = Node.range just.firstArg })
-                                                                justCalls
+    { call =
+        firstThatConstructsJust
+            [ emptiableWrapperFilterMapChecks listCollection
+            , \checkInfo ->
+                if AstHelpers.isIdentity checkInfo.lookupTable checkInfo.firstArg then
+                    firstThatConstructsJust
+                        [ \() ->
+                            callOnFromListWithIrrelevantEmptyElement (qualifiedToString checkInfo.fn ++ " with an identity function")
+                                ( listCollection, maybeWithJustAsWrap )
+                                checkInfo
+                        , \() ->
+                            case secondArg checkInfo of
+                                Just listArg ->
+                                    case AstHelpers.getListLiteral listArg of
+                                        Just list ->
+                                            case
+                                                traverse
+                                                    (AstHelpers.getSpecificFnCall Fn.Maybe.justVariant checkInfo.lookupTable)
+                                                    list
+                                            of
+                                                Just justCalls ->
+                                                    Just
+                                                        (Rule.errorWithFix
+                                                            { message = "Unnecessary use of " ++ qualifiedToString checkInfo.fn ++ " identity"
+                                                            , details = [ "All of the elements in the list are `Just`s, which can be simplified by removing all of the `Just`s." ]
+                                                            }
+                                                            checkInfo.fnRange
+                                                            (keepOnlyFix { parentRange = checkInfo.parentRange, keep = Node.range listArg }
+                                                                ++ List.concatMap
+                                                                    (\just -> keepOnlyFix { parentRange = just.nodeRange, keep = Node.range just.firstArg })
+                                                                    justCalls
+                                                            )
                                                         )
-                                                    )
 
-                                            Nothing ->
-                                                Nothing
+                                                Nothing ->
+                                                    Nothing
 
-                                    Nothing ->
-                                        Nothing
+                                        Nothing ->
+                                            Nothing
 
-                            Nothing ->
-                                Nothing
-                    ]
-                    ()
+                                Nothing ->
+                                    Nothing
+                        ]
+                        ()
 
-            else
-                Nothing
-        ]
-
-
-listFilterMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listFilterMapCompositionChecks =
-    mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks listCollection
-
-
-listRangeChecks : CheckInfo -> Maybe (Error {})
-listRangeChecks =
-    emptiableRangeChecks listCollection
-
-
-listRepeatChecks : CheckInfo -> Maybe (Error {})
-listRepeatChecks =
-    firstThatConstructsJust
-        [ emptiableRepeatChecks listCollection
-        , wrapperRepeatChecks listCollection
-        ]
-
-
-listReverseChecks : CheckInfo -> Maybe (Error {})
-listReverseChecks =
-    firstThatConstructsJust
-        [ emptiableReverseChecks listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
-        ]
-
-
-listReverseCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listReverseCompositionChecks =
-    firstThatConstructsJust
-        [ unnecessaryCompositionAfterWrapCheck listCollection
-        , toggleCompositionChecks
-        ]
-
-
-listSortChecks : CheckInfo -> Maybe (Error {})
-listSortChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
-        , operationDoesNotChangeResultOfOperationCheck
-        ]
-
-
-listSortCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listSortCompositionChecks =
-    operationDoesNotChangeResultOfOperationCompositionCheck
-
-
-listSortByChecks : CheckInfo -> Maybe (Error {})
-listSortByChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
-        , \checkInfo ->
-            case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
-                Just _ ->
-                    Just
-                        (alwaysReturnsLastArgError
-                            (qualifiedToString checkInfo.fn ++ " with a function that always returns the same constant")
-                            listCollection
-                            checkInfo
-                        )
-
-                Nothing ->
+                else
                     Nothing
-        , operationWithIdentityIsEquivalentToFnCheck Fn.List.sort
-        , operationDoesNotChangeResultOfOperationCheck
-        ]
+            ]
+    , composition =
+        mapToOperationWithIdentityCanBeCombinedToOperationCompositionChecks listCollection
+    }
 
 
-listSortByCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-listSortByCompositionChecks =
-    operationDoesNotChangeResultOfOperationCompositionCheck
+listRangeChecks : IntoFnCheck
+listRangeChecks =
+    intoFnCheckOnlyCall (emptiableRangeChecks listCollection)
 
 
-listSortWithChecks : CheckInfo -> Maybe (Error {})
-listSortWithChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck listCollection
-        , unnecessaryCallOnWrappedCheck listCollection
-        , \checkInfo ->
-            let
-                alwaysAlwaysOrder : Maybe Order
-                alwaysAlwaysOrder =
-                    AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg
-                        |> Maybe.andThen (AstHelpers.getAlwaysResult checkInfo.lookupTable)
-                        |> Maybe.andThen (AstHelpers.getOrder checkInfo.lookupTable)
-            in
-            case alwaysAlwaysOrder of
-                Just order ->
-                    let
-                        fixToIdentity : Error {}
-                        fixToIdentity =
-                            alwaysReturnsLastArgError
-                                (qualifiedToString checkInfo.fn ++ " with a comparison that always returns " ++ AstHelpers.orderToString order)
+listRepeatChecks : IntoFnCheck
+listRepeatChecks =
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ emptiableRepeatChecks listCollection
+            , wrapperRepeatChecks listCollection
+            ]
+        )
+
+
+listReverseChecks : IntoFnCheck
+listReverseChecks =
+    { call =
+        firstThatConstructsJust
+            [ emptiableReverseChecks listCollection
+            , unnecessaryCallOnWrappedCheck listCollection
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ unnecessaryCompositionAfterWrapCheck listCollection
+            , toggleCompositionChecks
+            ]
+    }
+
+
+listSortChecks : IntoFnCheck
+listSortChecks =
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck listCollection
+            , unnecessaryCallOnWrappedCheck listCollection
+            , operationDoesNotChangeResultOfOperationCheck
+            ]
+    , composition =
+        operationDoesNotChangeResultOfOperationCompositionCheck
+    }
+
+
+listSortByChecks : IntoFnCheck
+listSortByChecks =
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck listCollection
+            , unnecessaryCallOnWrappedCheck listCollection
+            , \checkInfo ->
+                case AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg of
+                    Just _ ->
+                        Just
+                            (alwaysReturnsLastArgError
+                                (qualifiedToString checkInfo.fn ++ " with a function that always returns the same constant")
                                 listCollection
                                 checkInfo
-                    in
-                    case order of
-                        LT ->
-                            Just
-                                (operationWithFirstArgIsEquivalentToFnError
-                                    { firstArgDescription = "a comparison that always returns LT"
-                                    , replacementFn = Fn.List.reverse
-                                    }
-                                    checkInfo
-                                )
+                            )
 
-                        EQ ->
-                            Just fixToIdentity
-
-                        GT ->
-                            Just fixToIdentity
-
-                Nothing ->
-                    Nothing
-        ]
+                    Nothing ->
+                        Nothing
+            , operationWithIdentityIsEquivalentToFnCheck Fn.List.sort
+            , operationDoesNotChangeResultOfOperationCheck
+            ]
+    , composition =
+        operationDoesNotChangeResultOfOperationCompositionCheck
+    }
 
 
-listTakeChecks : CheckInfo -> Maybe (Error {})
-listTakeChecks =
-    firstThatConstructsJust
-        [ \checkInfo ->
-            case Evaluate.getInt checkInfo checkInfo.firstArg of
-                Just length ->
-                    callWithNonPositiveIntCanBeReplacedByCheck
-                        { int = length
-                        , intDescription = "length"
-                        , replacement = listCollection.empty.asString
-                        }
-                        checkInfo
-
-                Nothing ->
-                    Nothing
-        , unnecessaryCallOnEmptyCheck listCollection
-        ]
-
-
-listDropChecks : CheckInfo -> Maybe (Error {})
-listDropChecks =
-    firstThatConstructsJust
-        [ \checkInfo ->
-            Evaluate.getInt checkInfo checkInfo.firstArg
-                |> Maybe.andThen
-                    (\count ->
-                        firstThatConstructsJust
-                            [ \() ->
-                                callWithNonPositiveIntCheckErrorSituation
-                                    { int = count, intDescription = "count", fn = checkInfo.fn }
-                                    |> Maybe.map
-                                        (\situation -> alwaysReturnsLastArgError situation listCollection checkInfo)
-                            , \() -> dropOnSmallerCollectionCheck { dropCount = count } listCollection checkInfo
-                            , \() ->
-                                dropOnLargerConstructionFromListLiteralWillRemoveTheseElementsCheck { dropCount = count }
+listSortWithChecks : IntoFnCheck
+listSortWithChecks =
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck listCollection
+            , unnecessaryCallOnWrappedCheck listCollection
+            , \checkInfo ->
+                let
+                    alwaysAlwaysOrder : Maybe Order
+                    alwaysAlwaysOrder =
+                        AstHelpers.getAlwaysResult checkInfo.lookupTable checkInfo.firstArg
+                            |> Maybe.andThen (AstHelpers.getAlwaysResult checkInfo.lookupTable)
+                            |> Maybe.andThen (AstHelpers.getOrder checkInfo.lookupTable)
+                in
+                case alwaysAlwaysOrder of
+                    Just order ->
+                        let
+                            fixToIdentity : Error {}
+                            fixToIdentity =
+                                alwaysReturnsLastArgError
+                                    (qualifiedToString checkInfo.fn ++ " with a comparison that always returns " ++ AstHelpers.orderToString order)
                                     listCollection
                                     checkInfo
-                            ]
-                            ()
-                    )
-        , unnecessaryCallOnEmptyCheck listCollection
-        ]
+                        in
+                        case order of
+                            LT ->
+                                Just
+                                    (operationWithFirstArgIsEquivalentToFnError
+                                        { firstArgDescription = "a comparison that always returns LT"
+                                        , replacementFn = Fn.List.reverse
+                                        }
+                                        checkInfo
+                                    )
+
+                            EQ ->
+                                Just fixToIdentity
+
+                            GT ->
+                                Just fixToIdentity
+
+                    Nothing ->
+                        Nothing
+            ]
+        )
 
 
-listUnzipChecks : CheckInfo -> Maybe (Error {})
+listTakeChecks : IntoFnCheck
+listTakeChecks =
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ \checkInfo ->
+                case Evaluate.getInt checkInfo checkInfo.firstArg of
+                    Just length ->
+                        callWithNonPositiveIntCanBeReplacedByCheck
+                            { int = length
+                            , intDescription = "length"
+                            , replacement = listCollection.empty.asString
+                            }
+                            checkInfo
+
+                    Nothing ->
+                        Nothing
+            , unnecessaryCallOnEmptyCheck listCollection
+            ]
+        )
+
+
+listDropChecks : IntoFnCheck
+listDropChecks =
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ \checkInfo ->
+                Evaluate.getInt checkInfo checkInfo.firstArg
+                    |> Maybe.andThen
+                        (\count ->
+                            firstThatConstructsJust
+                                [ \() ->
+                                    callWithNonPositiveIntCheckErrorSituation
+                                        { int = count, intDescription = "count", fn = checkInfo.fn }
+                                        |> Maybe.map
+                                            (\situation -> alwaysReturnsLastArgError situation listCollection checkInfo)
+                                , \() -> dropOnSmallerCollectionCheck { dropCount = count } listCollection checkInfo
+                                , \() ->
+                                    dropOnLargerConstructionFromListLiteralWillRemoveTheseElementsCheck { dropCount = count }
+                                        listCollection
+                                        checkInfo
+                                ]
+                                ()
+                        )
+            , unnecessaryCallOnEmptyCheck listCollection
+            ]
+        )
+
+
+listUnzipChecks : IntoFnCheck
 listUnzipChecks =
-    callOnEmptyReturnsCheck { resultAsString = \_ -> "( [], [] )" } listCollection
+    intoFnCheckOnlyCall
+        (callOnEmptyReturnsCheck { resultAsString = \_ -> "( [], [] )" } listCollection)
 
 
 
 -- ARRAY FUNCTIONS
 
 
-arrayToListChecks : CheckInfo -> Maybe (Error {})
+arrayToListChecks : IntoFnCheck
 arrayToListChecks =
-    firstThatConstructsJust
-        [ callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } arrayCollection
-        , onCallToInverseReturnsItsArgumentCheck Fn.Array.fromList
-        , callFromCanBeCombinedCheck
-            { fromFn = Fn.Array.repeat, combinedFn = Fn.List.repeat }
-        ]
+    { call =
+        firstThatConstructsJust
+            [ callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } arrayCollection
+            , onCallToInverseReturnsItsArgumentCheck Fn.Array.fromList
+            , callFromCanBeCombinedCheck
+                { fromFn = Fn.Array.repeat, combinedFn = Fn.List.repeat }
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ inversesCompositionCheck Fn.Array.fromList
+            , compositionFromCanBeCombinedCheck
+                { fromFn = Fn.Array.repeat, combinedFn = Fn.List.repeat }
+            ]
+    }
 
 
-arrayToListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-arrayToListCompositionChecks =
-    firstThatConstructsJust
-        [ inversesCompositionCheck Fn.Array.fromList
-        , compositionFromCanBeCombinedCheck
-            { fromFn = Fn.Array.repeat, combinedFn = Fn.List.repeat }
-        ]
-
-
-arrayToIndexedListChecks : CheckInfo -> Maybe (Error {})
+arrayToIndexedListChecks : IntoFnCheck
 arrayToIndexedListChecks =
-    callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } arrayCollection
+    intoFnCheckOnlyCall
+        (callOnEmptyReturnsCheck { resultAsString = listCollection.empty.asString } arrayCollection)
 
 
-arrayFromListChecks : CheckInfo -> Maybe (Error {})
+arrayFromListChecks : IntoFnCheck
 arrayFromListChecks =
-    firstThatConstructsJust
-        [ collectionFromListChecks arrayCollection
-        , onCallToInverseReturnsItsArgumentCheck Fn.Array.toList
-        ]
+    { call =
+        firstThatConstructsJust
+            [ collectionFromListChecks arrayCollection
+            , onCallToInverseReturnsItsArgumentCheck Fn.Array.toList
+            ]
+    , composition = inversesCompositionCheck Fn.Array.toList
+    }
 
 
-arrayFromListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-arrayFromListCompositionChecks =
-    inversesCompositionCheck Fn.Array.toList
-
-
-arrayRepeatChecks : CheckInfo -> Maybe (Error {})
+arrayRepeatChecks : IntoFnCheck
 arrayRepeatChecks =
-    emptiableRepeatChecks arrayCollection
+    intoFnCheckOnlyCall (emptiableRepeatChecks arrayCollection)
 
 
-arrayInitializeChecks : CheckInfo -> Maybe (Error {})
+arrayInitializeChecks : IntoFnCheck
 arrayInitializeChecks =
-    emptiableRepeatChecks arrayCollection
+    intoFnCheckOnlyCall (emptiableRepeatChecks arrayCollection)
 
 
-arrayIndexedMapChecks : CheckInfo -> Maybe (Error {})
+arrayMapChecks : IntoFnCheck
+arrayMapChecks =
+    intoFnCheckOnlyCall (emptiableMapChecks arrayCollection)
+
+
+arrayIndexedMapChecks : IntoFnCheck
 arrayIndexedMapChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck arrayCollection
-        , operationWithExtraArgChecks { operationWithoutExtraArg = Fn.Array.map }
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck arrayCollection
+            , operationWithExtraArgChecks { operationWithoutExtraArg = Fn.Array.map }
+            ]
+        )
 
 
-arrayLengthChecks : CheckInfo -> Maybe (Error {})
+arrayIsEmptyChecks : IntoFnCheck
+arrayIsEmptyChecks =
+    intoFnCheckOnlyCall (collectionIsEmptyChecks arrayCollection)
+
+
+arrayLengthChecks : IntoFnCheck
 arrayLengthChecks =
-    firstThatConstructsJust
-        [ collectionSizeChecks arrayCollection
-        , arrayLengthOnArrayRepeatOrInitializeChecks
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ collectionSizeChecks arrayCollection
+            , arrayLengthOnArrayRepeatOrInitializeChecks
+            ]
+        )
+
+
+arrayGetChecks : IntoFnCheck
+arrayGetChecks =
+    intoFnCheckOnlyCall (getChecks arrayCollection)
 
 
 arrayLengthOnArrayRepeatOrInitializeChecks : CheckInfo -> Maybe (Error {})
@@ -5839,176 +5958,323 @@ arrayLengthOnArrayRepeatOrInitializeChecks checkInfo =
             Nothing
 
 
-arrayFoldlChecks : CheckInfo -> Maybe (Error {})
+arraySetChecks : IntoFnCheck
+arraySetChecks =
+    intoFnCheckOnlyCall (setChecks arrayCollection)
+
+
+arraySliceChecks : IntoFnCheck
+arraySliceChecks =
+    intoFnCheckOnlyCall (collectionSliceChecks arrayCollection)
+
+
+arrayFilterChecks : IntoFnCheck
+arrayFilterChecks =
+    intoFnCheckOnlyCall (emptiableKeepWhenChecks arrayCollection)
+
+
+arrayAppendChecks : IntoFnCheck
+arrayAppendChecks =
+    intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } arrayCollection)
+
+
+arrayFoldlChecks : IntoFnCheck
 arrayFoldlChecks =
-    emptiableFoldChecks arrayCollection
+    intoFnCheckOnlyCall (emptiableFoldChecks arrayCollection)
 
 
-arrayFoldrChecks : CheckInfo -> Maybe (Error {})
+arrayFoldrChecks : IntoFnCheck
 arrayFoldrChecks =
-    emptiableFoldChecks arrayCollection
+    intoFnCheckOnlyCall (emptiableFoldChecks arrayCollection)
 
 
 
 -- SET FUNCTIONS
 
 
-setFromListChecks : CheckInfo -> Maybe (Error {})
+setFromListChecks : IntoFnCheck
 setFromListChecks =
-    firstThatConstructsJust
-        [ collectionFromListChecks setCollection
-        , wrapperFromListSingletonChecks setCollection
-        , onCallToInverseReturnsItsArgumentCheck Fn.Set.toList
-        ]
+    { call =
+        firstThatConstructsJust
+            [ collectionFromListChecks setCollection
+            , wrapperFromListSingletonChecks setCollection
+            , onCallToInverseReturnsItsArgumentCheck Fn.Set.toList
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ wrapperFromListSingletonCompositionChecks setCollection
+            , inversesCompositionCheck Fn.Set.toList
+            ]
+    }
 
 
-setFromListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-setFromListCompositionChecks =
-    firstThatConstructsJust
-        [ wrapperFromListSingletonCompositionChecks setCollection
-        , inversesCompositionCheck Fn.Set.toList
-        ]
+setIsEmptyChecks : IntoFnCheck
+setIsEmptyChecks =
+    intoFnCheckOnlyCall (collectionIsEmptyChecks setCollection)
 
 
-setFoldlChecks : CheckInfo -> Maybe (Error {})
+setSizeChecks : IntoFnCheck
+setSizeChecks =
+    intoFnCheckOnlyCall (collectionSizeChecks setCollection)
+
+
+setMemberChecks : IntoFnCheck
+setMemberChecks =
+    intoFnCheckOnlyCall (collectionMemberChecks setCollection)
+
+
+setInsertChecks : IntoFnCheck
+setInsertChecks =
+    intoFnCheckOnlyCall (collectionInsertChecks setCollection)
+
+
+setRemoveChecks : IntoFnCheck
+setRemoveChecks =
+    intoFnCheckOnlyCall (collectionRemoveChecks setCollection)
+
+
+setFilterChecks : IntoFnCheck
+setFilterChecks =
+    intoFnCheckOnlyCall (emptiableKeepWhenChecks setCollection)
+
+
+setPartitionChecks : IntoFnCheck
+setPartitionChecks =
+    intoFnCheckOnlyCall (collectionPartitionChecks setCollection)
+
+
+setIntersectChecks : IntoFnCheck
+setIntersectChecks =
+    intoFnCheckOnlyCall (collectionIntersectChecks setCollection)
+
+
+setDiffChecks : IntoFnCheck
+setDiffChecks =
+    intoFnCheckOnlyCall (collectionDiffChecks setCollection)
+
+
+setUnionChecks : IntoFnCheck
+setUnionChecks =
+    intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } setCollection)
+
+
+setMapChecks : IntoFnCheck
+setMapChecks =
+    intoFnCheckOnlyCall (emptiableMapChecks setCollection)
+
+
+setToListChecks : IntoFnCheck
+setToListChecks =
+    intoFnCheckOnlyCall (emptiableToListChecks setCollection)
+
+
+setFoldlChecks : IntoFnCheck
 setFoldlChecks =
-    emptiableFoldChecks setCollection
+    intoFnCheckOnlyCall (emptiableFoldChecks setCollection)
 
 
-setFoldrChecks : CheckInfo -> Maybe (Error {})
+setFoldrChecks : IntoFnCheck
 setFoldrChecks =
-    emptiableFoldChecks setCollection
+    intoFnCheckOnlyCall (emptiableFoldChecks setCollection)
 
 
 
 -- DICT FUNCTIONS
 
 
-dictFromListChecks : CheckInfo -> Maybe (Error {})
+dictFromListChecks : IntoFnCheck
 dictFromListChecks =
-    firstThatConstructsJust
-        [ collectionFromListChecks dictCollection
-        , onCallToInverseReturnsItsArgumentCheck Fn.Dict.toList
-        ]
+    { call =
+        firstThatConstructsJust
+            [ collectionFromListChecks dictCollection
+            , onCallToInverseReturnsItsArgumentCheck Fn.Dict.toList
+            ]
+    , composition =
+        inversesCompositionCheck Fn.Dict.toList
+    }
 
 
-dictFromListCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-dictFromListCompositionChecks =
-    inversesCompositionCheck Fn.Dict.toList
+dictIsEmptyChecks : IntoFnCheck
+dictIsEmptyChecks =
+    intoFnCheckOnlyCall (collectionIsEmptyChecks dictCollection)
 
 
-dictFilterChecks : CheckInfo -> Maybe (Error {})
+dictSizeChecks : IntoFnCheck
+dictSizeChecks =
+    intoFnCheckOnlyCall (collectionSizeChecks dictCollection)
+
+
+dictMemberChecks : IntoFnCheck
+dictMemberChecks =
+    intoFnCheckOnlyCall (collectionMemberChecks dictCollection)
+
+
+dictRemoveChecks : IntoFnCheck
+dictRemoveChecks =
+    intoFnCheckOnlyCall (collectionRemoveChecks dictCollection)
+
+
+dictFilterChecks : IntoFnCheck
 dictFilterChecks =
-    emptiableKeepWhenWithExtraArgChecks dictCollection
+    intoFnCheckOnlyCall (emptiableKeepWhenWithExtraArgChecks dictCollection)
 
 
-dictPartitionChecks : CheckInfo -> Maybe (Error {})
+dictPartitionChecks : IntoFnCheck
 dictPartitionChecks =
-    emptiablePartitionWithExtraArgChecks dictCollection
+    intoFnCheckOnlyCall (emptiablePartitionWithExtraArgChecks dictCollection)
 
 
-dictMapChecks : CheckInfo -> Maybe (Error {})
+dictMapChecks : IntoFnCheck
 dictMapChecks =
-    emptiableMapWithExtraArgChecks dictCollection
+    intoFnCheckOnlyCall (emptiableMapWithExtraArgChecks dictCollection)
 
 
-dictFoldlChecks : CheckInfo -> Maybe (Error {})
+dictIntersectChecks : IntoFnCheck
+dictIntersectChecks =
+    intoFnCheckOnlyCall (collectionIntersectChecks dictCollection)
+
+
+dictDiffChecks : IntoFnCheck
+dictDiffChecks =
+    intoFnCheckOnlyCall (collectionDiffChecks dictCollection)
+
+
+dictUnionChecks : IntoFnCheck
+dictUnionChecks =
+    intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = False } dictCollection)
+
+
+dictToListChecks : IntoFnCheck
+dictToListChecks =
+    intoFnCheckOnlyCall (emptiableToListChecks dictCollection)
+
+
+dictFoldlChecks : IntoFnCheck
 dictFoldlChecks =
-    emptiableFoldWithExtraArgChecks dictCollection
+    intoFnCheckOnlyCall (emptiableFoldWithExtraArgChecks dictCollection)
 
 
-dictFoldrChecks : CheckInfo -> Maybe (Error {})
+dictFoldrChecks : IntoFnCheck
 dictFoldrChecks =
-    emptiableFoldWithExtraArgChecks dictCollection
+    intoFnCheckOnlyCall (emptiableFoldWithExtraArgChecks dictCollection)
+
+
+
+-- PLATFORM.CMD FUNCTIONS
+
+
+platformCmdBatchChecks : IntoFnCheck
+platformCmdBatchChecks =
+    { call = emptiableWrapperFlatFromListChecks cmdCollection
+    , composition = wrapperFlatFromListCompositionChecks
+    }
+
+
+platformCmdMapChecks : IntoFnCheck
+platformCmdMapChecks =
+    intoFnCheckOnlyCall (emptiableMapChecks cmdCollection)
+
+
+
+-- PLATFORM.SUB FUNCTIONS
+
+
+platformSubBatchChecks : IntoFnCheck
+platformSubBatchChecks =
+    { call = emptiableWrapperFlatFromListChecks subCollection
+    , composition = wrapperFlatFromListCompositionChecks
+    }
+
+
+platformSubChecks : IntoFnCheck
+platformSubChecks =
+    intoFnCheckOnlyCall (emptiableMapChecks subCollection)
 
 
 
 -- TASK FUNCTIONS
 
 
-taskMapChecks : CheckInfo -> Maybe (Error {})
+taskMapChecks : IntoFnCheck
 taskMapChecks =
-    firstThatConstructsJust
-        [ emptiableMapChecks taskWithSucceedAsWrap
-        , mapOnWrappedChecks taskWithSucceedAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ emptiableMapChecks taskWithSucceedAsWrap
+            , mapOnWrappedChecks taskWithSucceedAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ mapAfterWrapCompositionChecks taskWithSucceedAsWrap
+            , unnecessaryCompositionAfterEmptyCheck taskWithSucceedAsWrap
+            ]
+    }
 
 
-taskMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-taskMapCompositionChecks =
-    firstThatConstructsJust
-        [ mapAfterWrapCompositionChecks taskWithSucceedAsWrap
-        , unnecessaryCompositionAfterEmptyCheck taskWithSucceedAsWrap
-        ]
-
-
-taskMapNChecks : CheckInfo -> Maybe (Error {})
+taskMapNChecks : IntoFnCheck
 taskMapNChecks =
-    firstThatConstructsJust
-        [ wrapperMapNChecks taskWithSucceedAsWrap
-        , mapNOrFirstEmptyConstructionChecks taskWithSucceedAsWrap
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ wrapperMapNChecks taskWithSucceedAsWrap
+            , mapNOrFirstEmptyConstructionChecks taskWithSucceedAsWrap
+            ]
+        )
 
 
-taskAndThenChecks : CheckInfo -> Maybe (Error {})
+taskAndThenChecks : IntoFnCheck
 taskAndThenChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck taskWithSucceedAsWrap
-        , wrapperFlatMapChecks taskWithSucceedAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck taskWithSucceedAsWrap
+            , wrapperFlatMapChecks taskWithSucceedAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ unnecessaryCompositionAfterEmptyCheck taskWithSucceedAsWrap
+            , wrapperFlatMapCompositionChecks taskWithSucceedAsWrap
+            ]
+    }
 
 
-taskAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-taskAndThenCompositionChecks =
-    firstThatConstructsJust
-        [ unnecessaryCompositionAfterEmptyCheck taskWithSucceedAsWrap
-        , wrapperFlatMapCompositionChecks taskWithSucceedAsWrap
-        ]
-
-
-taskMapErrorChecks : CheckInfo -> Maybe (Error {})
+taskMapErrorChecks : IntoFnCheck
 taskMapErrorChecks =
-    firstThatConstructsJust
-        [ emptiableMapChecks taskWithFailAsWrap
-        , mapOnWrappedChecks taskWithFailAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ emptiableMapChecks taskWithFailAsWrap
+            , mapOnWrappedChecks taskWithFailAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ mapAfterWrapCompositionChecks taskWithFailAsWrap
+            , unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap
+            ]
+    }
 
 
-taskMapErrorCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-taskMapErrorCompositionChecks =
-    firstThatConstructsJust
-        [ mapAfterWrapCompositionChecks taskWithFailAsWrap
-        , unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap
-        ]
-
-
-taskOnErrorChecks : CheckInfo -> Maybe (Error {})
+taskOnErrorChecks : IntoFnCheck
 taskOnErrorChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck taskWithFailAsWrap
-        , wrapperFlatMapChecks taskWithFailAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck taskWithFailAsWrap
+            , wrapperFlatMapChecks taskWithFailAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap
+            , wrapperFlatMapCompositionChecks taskWithFailAsWrap
+            ]
+    }
 
 
-taskOnErrorCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-taskOnErrorCompositionChecks =
-    firstThatConstructsJust
-        [ unnecessaryCompositionAfterEmptyCheck taskWithFailAsWrap
-        , wrapperFlatMapCompositionChecks taskWithFailAsWrap
-        ]
-
-
-taskSequenceChecks : CheckInfo -> Maybe (Error {})
+taskSequenceChecks : IntoFnCheck
 taskSequenceChecks =
-    firstThatConstructsJust
-        [ listOfWrapperSequenceChecks taskWithSucceedAsWrap
-        , sequenceOrFirstEmptyChecks ( listCollection, taskWithSucceedAsWrap )
-        ]
-
-
-taskSequenceCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-taskSequenceCompositionChecks =
-    afterWrapIsEquivalentToMapWrapCheck ( listCollection, taskWithSucceedAsWrap )
+    { call =
+        firstThatConstructsJust
+            [ listOfWrapperSequenceChecks taskWithSucceedAsWrap
+            , sequenceOrFirstEmptyChecks ( listCollection, taskWithSucceedAsWrap )
+            ]
+    , composition =
+        afterWrapIsEquivalentToMapWrapCheck ( listCollection, taskWithSucceedAsWrap )
+    }
 
 
 
@@ -6030,180 +6296,203 @@ htmlAttributesClassListFalseElementError checkInfo =
     }
 
 
-htmlAttributesClassListChecks : CheckInfo -> Maybe (Error {})
+htmlAttributesClassListChecks : IntoFnCheck
 htmlAttributesClassListChecks =
-    firstThatConstructsJust
-        [ \checkInfo ->
-            case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.firstArg of
-                Just single ->
-                    case AstHelpers.getTuple2Literal single.element of
-                        Just tuple ->
-                            case AstHelpers.getBool checkInfo.lookupTable tuple.second of
-                                Just bool ->
-                                    if bool then
-                                        let
-                                            replacementFn : ( ModuleName, String )
-                                            replacementFn =
-                                                Fn.Html.Attributes.class
-                                        in
-                                        Just
-                                            (Rule.errorWithFix
-                                                { message = qualifiedToString checkInfo.fn ++ " with a single tuple paired with True can be replaced with " ++ qualifiedToString replacementFn
-                                                , details = [ "You can replace this call by " ++ qualifiedToString replacementFn ++ " with the String from the single tuple list element." ]
-                                                }
-                                                checkInfo.fnRange
-                                                (replaceBySubExpressionFix (Node.range checkInfo.firstArg) tuple.first
-                                                    ++ [ Fix.replaceRangeBy checkInfo.fnRange
-                                                            (qualifiedToString (qualify replacementFn checkInfo))
-                                                       ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ \checkInfo ->
+                case AstHelpers.getListSingleton checkInfo.lookupTable checkInfo.firstArg of
+                    Just single ->
+                        case AstHelpers.getTuple2Literal single.element of
+                            Just tuple ->
+                                case AstHelpers.getBool checkInfo.lookupTable tuple.second of
+                                    Just bool ->
+                                        if bool then
+                                            let
+                                                replacementFn : ( ModuleName, String )
+                                                replacementFn =
+                                                    Fn.Html.Attributes.class
+                                            in
+                                            Just
+                                                (Rule.errorWithFix
+                                                    { message = qualifiedToString checkInfo.fn ++ " with a single tuple paired with True can be replaced with " ++ qualifiedToString replacementFn
+                                                    , details = [ "You can replace this call by " ++ qualifiedToString replacementFn ++ " with the String from the single tuple list element." ]
+                                                    }
+                                                    checkInfo.fnRange
+                                                    (replaceBySubExpressionFix (Node.range checkInfo.firstArg) tuple.first
+                                                        ++ [ Fix.replaceRangeBy checkInfo.fnRange
+                                                                (qualifiedToString (qualify replacementFn checkInfo))
+                                                           ]
+                                                    )
                                                 )
-                                            )
 
-                                    else
-                                        Just
-                                            (Rule.errorWithFix (htmlAttributesClassListFalseElementError checkInfo)
-                                                checkInfo.fnRange
-                                                [ Fix.replaceRangeBy (Node.range checkInfo.firstArg) "[]" ]
-                                            )
+                                        else
+                                            Just
+                                                (Rule.errorWithFix (htmlAttributesClassListFalseElementError checkInfo)
+                                                    checkInfo.fnRange
+                                                    [ Fix.replaceRangeBy (Node.range checkInfo.firstArg) "[]" ]
+                                                )
 
-                                Nothing ->
-                                    Nothing
+                                    Nothing ->
+                                        Nothing
 
-                        Nothing ->
-                            Nothing
+                            Nothing ->
+                                Nothing
 
-                Nothing ->
-                    Nothing
-        , \checkInfo ->
-            case AstHelpers.getListLiteral checkInfo.firstArg of
-                Just (tuple0 :: tuple1 :: tuple2Up) ->
-                    case findMapNeighboring (\el -> getTupleWithSpecificSecondBoolExpressionNode False checkInfo.lookupTable el) (tuple0 :: tuple1 :: tuple2Up) of
-                        Just classPart ->
-                            Just
-                                (Rule.errorWithFix (htmlAttributesClassListFalseElementError checkInfo)
-                                    checkInfo.fnRange
-                                    (listLiteralRemoveElementFix classPart)
-                                )
-
-                        Nothing ->
-                            Nothing
-
-                _ ->
-                    Nothing
-        , \checkInfo ->
-            case AstHelpers.getCollapsedCons checkInfo.firstArg of
-                Just classParts ->
-                    case findMapNeighboring (\el -> getTupleWithSpecificSecondBoolExpressionNode False checkInfo.lookupTable el) classParts.consed of
-                        Just classPart ->
-                            Just
-                                (Rule.errorWithFix (htmlAttributesClassListFalseElementError checkInfo)
-                                    checkInfo.fnRange
-                                    (collapsedConsRemoveElementFix
-                                        { toRemove = classPart
-                                        , tailRange = Node.range classParts.tail
-                                        }
+                    Nothing ->
+                        Nothing
+            , \checkInfo ->
+                case AstHelpers.getListLiteral checkInfo.firstArg of
+                    Just (tuple0 :: tuple1 :: tuple2Up) ->
+                        case findMapNeighboring (\el -> getTupleWithSpecificSecondBoolExpressionNode False checkInfo.lookupTable el) (tuple0 :: tuple1 :: tuple2Up) of
+                            Just classPart ->
+                                Just
+                                    (Rule.errorWithFix (htmlAttributesClassListFalseElementError checkInfo)
+                                        checkInfo.fnRange
+                                        (listLiteralRemoveElementFix classPart)
                                     )
-                                )
 
-                        Nothing ->
-                            Nothing
+                            Nothing ->
+                                Nothing
 
-                Nothing ->
-                    Nothing
-        ]
+                    _ ->
+                        Nothing
+            , \checkInfo ->
+                case AstHelpers.getCollapsedCons checkInfo.firstArg of
+                    Just classParts ->
+                        case findMapNeighboring (\el -> getTupleWithSpecificSecondBoolExpressionNode False checkInfo.lookupTable el) classParts.consed of
+                            Just classPart ->
+                                Just
+                                    (Rule.errorWithFix (htmlAttributesClassListFalseElementError checkInfo)
+                                        checkInfo.fnRange
+                                        (collapsedConsRemoveElementFix
+                                            { toRemove = classPart
+                                            , tailRange = Node.range classParts.tail
+                                            }
+                                        )
+                                    )
+
+                            Nothing ->
+                                Nothing
+
+                    Nothing ->
+                        Nothing
+            ]
+        )
 
 
 
 -- JSON.DECODE FUNCTIONS
 
 
-jsonDecodeMapChecks : CheckInfo -> Maybe (Error {})
+jsonDecodeMapChecks : IntoFnCheck
 jsonDecodeMapChecks =
-    firstThatConstructsJust
-        [ emptiableMapChecks jsonDecoderWithSucceedAsWrap
-        , mapOnWrappedChecks jsonDecoderWithSucceedAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ emptiableMapChecks jsonDecoderWithSucceedAsWrap
+            , mapOnWrappedChecks jsonDecoderWithSucceedAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ mapAfterWrapCompositionChecks jsonDecoderWithSucceedAsWrap
+            , unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap
+            ]
+    }
 
 
-jsonDecodeMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-jsonDecodeMapCompositionChecks =
-    firstThatConstructsJust
-        [ mapAfterWrapCompositionChecks jsonDecoderWithSucceedAsWrap
-        , unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap
-        ]
-
-
-jsonDecodeMapNChecks : CheckInfo -> Maybe (Error {})
+jsonDecodeMapNChecks : IntoFnCheck
 jsonDecodeMapNChecks =
-    firstThatConstructsJust
-        [ wrapperMapNChecks jsonDecoderWithSucceedAsWrap
-        , mapNOrFirstEmptyConstructionChecks jsonDecoderWithSucceedAsWrap
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ wrapperMapNChecks jsonDecoderWithSucceedAsWrap
+            , mapNOrFirstEmptyConstructionChecks jsonDecoderWithSucceedAsWrap
+            ]
+        )
 
 
-jsonDecodeAndThenChecks : CheckInfo -> Maybe (Error {})
+jsonDecodeAndThenChecks : IntoFnCheck
 jsonDecodeAndThenChecks =
-    firstThatConstructsJust
-        [ unnecessaryCallOnEmptyCheck jsonDecoderWithSucceedAsWrap
-        , wrapperFlatMapChecks jsonDecoderWithSucceedAsWrap
-        ]
+    { call =
+        firstThatConstructsJust
+            [ unnecessaryCallOnEmptyCheck jsonDecoderWithSucceedAsWrap
+            , wrapperFlatMapChecks jsonDecoderWithSucceedAsWrap
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap
+            , wrapperFlatMapCompositionChecks jsonDecoderWithSucceedAsWrap
+            ]
+    }
 
 
-jsonDecodeAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-jsonDecodeAndThenCompositionChecks =
-    firstThatConstructsJust
-        [ unnecessaryCompositionAfterEmptyCheck jsonDecoderWithSucceedAsWrap
-        , wrapperFlatMapCompositionChecks jsonDecoderWithSucceedAsWrap
-        ]
+jsonDecodeOneOfChecks : IntoFnCheck
+jsonDecodeOneOfChecks =
+    intoFnCheckOnlyCall oneOfChecks
 
 
 
 -- RANDOM FUNCTIONS
 
 
-randomUniformChecks : CheckInfo -> Maybe (Error {})
+randomUniformChecks : IntoFnCheck
 randomUniformChecks =
-    oneOfConstantsWithOneAndRestListChecks randomGeneratorWrapper
+    intoFnCheckOnlyCall (oneOfConstantsWithOneAndRestListChecks randomGeneratorWrapper)
 
 
-randomWeightedChecks : CheckInfo -> Maybe (Error {})
+randomWeightedChecks : IntoFnCheck
 randomWeightedChecks =
-    oneOfWeightedConstantsWithOneAndRestChecks randomGeneratorWrapper
+    intoFnCheckOnlyCall (oneOfWeightedConstantsWithOneAndRestChecks randomGeneratorWrapper)
 
 
-randomListChecks : CheckInfo -> Maybe (Error {})
+randomListChecks : IntoFnCheck
 randomListChecks =
-    sequenceRepeatChecks randomGeneratorWrapper
+    intoFnCheckOnlyCall (sequenceRepeatChecks randomGeneratorWrapper)
 
 
-randomMapChecks : CheckInfo -> Maybe (Error {})
+randomMapChecks : IntoFnCheck
 randomMapChecks =
-    firstThatConstructsJust
-        [ mapIdentityChecks randomGeneratorWrapper
-        , mapOnWrappedChecks randomGeneratorWrapper
-        , nonEmptiableWrapperMapAlwaysChecks randomGeneratorWrapper
-        ]
+    { call =
+        firstThatConstructsJust
+            [ mapIdentityChecks randomGeneratorWrapper
+            , mapOnWrappedChecks randomGeneratorWrapper
+            , nonEmptiableWrapperMapAlwaysChecks randomGeneratorWrapper
+            ]
+    , composition =
+        firstThatConstructsJust
+            [ mapAfterWrapCompositionChecks randomGeneratorWrapper
+            , nonEmptiableWrapperMapAlwaysCompositionChecks randomGeneratorWrapper
+            ]
+    }
 
 
-randomMapCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-randomMapCompositionChecks =
-    firstThatConstructsJust
-        [ mapAfterWrapCompositionChecks randomGeneratorWrapper
-        , nonEmptiableWrapperMapAlwaysCompositionChecks randomGeneratorWrapper
-        ]
-
-
-randomAndThenChecks : CheckInfo -> Maybe (Error {})
+randomAndThenChecks : IntoFnCheck
 randomAndThenChecks =
-    firstThatConstructsJust
-        [ wrapperFlatMapChecks randomGeneratorWrapper
-        , nonEmptiableWrapperFlatMapAlwaysChecks randomGeneratorWrapper
-        ]
+    { call =
+        firstThatConstructsJust
+            [ wrapperFlatMapChecks randomGeneratorWrapper
+            , nonEmptiableWrapperFlatMapAlwaysChecks randomGeneratorWrapper
+            ]
+    , composition =
+        wrapperFlatMapCompositionChecks randomGeneratorWrapper
+    }
 
 
-randomAndThenCompositionChecks : CompositionIntoCheckInfo -> Maybe ErrorInfoAndFix
-randomAndThenCompositionChecks =
-    wrapperFlatMapCompositionChecks randomGeneratorWrapper
+
+-- PARSER FUNCTIONS
+
+
+parserOneOfChecks : IntoFnCheck
+parserOneOfChecks =
+    intoFnCheckOnlyCall oneOfChecks
+
+
+
+-- PARSER.ADVANCED FUNCTIONS
+
+
+parserAdvancedOneOfChecks : IntoFnCheck
+parserAdvancedOneOfChecks =
+    intoFnCheckOnlyCall oneOfChecks
 
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1865,8 +1865,8 @@ a = Dict.toList >> List.map Tuple.first
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this composition by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1883,8 +1883,8 @@ a = Dict.toList >> List.map (\\( part0, _ ) -> part0)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this composition by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1901,8 +1901,8 @@ a = List.map Tuple.first << Dict.toList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this composition by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1919,8 +1919,8 @@ a = Dict.toList >> List.map Tuple.second
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.second is the same as Dict.values"
-                            , details = [ "Using Dict.values directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.second can be combined into Dict.values"
+                            , details = [ "You can replace this composition by Dict.values with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1937,8 +1937,8 @@ a = Dict.toList >> List.map (\\( _, part1 ) -> part1)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.second is the same as Dict.values"
-                            , details = [ "Using Dict.values directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.second can be combined into Dict.values"
+                            , details = [ "You can replace this composition by Dict.values with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1955,8 +1955,8 @@ a = List.map Tuple.second << Dict.toList
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.second is the same as Dict.values"
-                            , details = [ "Using Dict.values directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.second can be combined into Dict.values"
+                            , details = [ "You can replace this composition by Dict.values with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -1964,7 +1964,7 @@ import Dict
 a = Dict.values
 """
                         ]
-        , test "should replace List.map Tuple.first (Dict.toList dict) by Dict.keys dict" <|
+        , test "should replace List.map Tuple.first (Dict.toList dict) by (Dict.keys dict)" <|
             \() ->
                 """module A exposing (..)
 import Dict
@@ -1973,16 +1973,16 @@ a = List.map Tuple.first (Dict.toList dict)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this call by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = Dict.keys dict
+a = (Dict.keys dict)
 """
                         ]
-        , test "should replace List.map Tuple.first (Dict.toList <| dict) by Dict.keys dict" <|
+        , test "should replace List.map Tuple.first (Dict.toList <| dict) by (Dict.keys <| dict)" <|
             \() ->
                 """module A exposing (..)
 import Dict
@@ -1991,16 +1991,16 @@ a = List.map Tuple.first (Dict.toList <| dict)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this call by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = Dict.keys dict
+a = (Dict.keys <| dict)
 """
                         ]
-        , test "should replace List.map Tuple.first (dict |> Dict.toList) by Dict.keys dict" <|
+        , test "should replace List.map Tuple.first (dict |> Dict.toList) by (dict |> Dict.keys)" <|
             \() ->
                 """module A exposing (..)
 import Dict
@@ -2009,16 +2009,16 @@ a = List.map Tuple.first (dict |> Dict.toList)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this call by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = Dict.keys dict
+a = (dict |> Dict.keys)
 """
                         ]
-        , test "should replace List.map Tuple.first <| Dict.toList dict by Dict.keys <| dict" <|
+        , test "should replace List.map Tuple.first <| Dict.toList dict by Dict.keys dict" <|
             \() ->
                 """module A exposing (..)
 import Dict
@@ -2027,16 +2027,16 @@ a = List.map Tuple.first <| Dict.toList dict
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this call by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = Dict.keys <| dict
+a = Dict.keys dict
 """
                         ]
-        , test "should replace List.map Tuple.first <| (Dict.toList <| dict) by Dict.keys <| dict" <|
+        , test "should replace List.map Tuple.first <| (Dict.toList <| dict) by (Dict.keys <| dict)" <|
             \() ->
                 """module A exposing (..)
 import Dict
@@ -2045,16 +2045,16 @@ a = List.map Tuple.first <| (Dict.toList <| dict)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this call by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = Dict.keys <| dict
+a = (Dict.keys <| dict)
 """
                         ]
-        , test "should replace List.map Tuple.first <| (dict |> Dict.toList) by Dict.keys <| dict" <|
+        , test "should replace List.map Tuple.first <| (dict |> Dict.toList) by (dict |> Dict.keys)" <|
             \() ->
                 """module A exposing (..)
 import Dict
@@ -2063,16 +2063,16 @@ a = List.map Tuple.first <| (dict |> Dict.toList)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this call by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = Dict.keys <| dict
+a = (dict |> Dict.keys)
 """
                         ]
-        , test "should replace Dict.toList dict |> List.map Tuple.first by dict |> Dict.keys" <|
+        , test "should replace Dict.toList dict |> List.map Tuple.first by Dict.keys dict" <|
             \() ->
                 """module A exposing (..)
 import Dict
@@ -2081,13 +2081,13 @@ a = Dict.toList dict |> List.map Tuple.first
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.toList, then List.map Tuple.first is the same as Dict.keys"
-                            , details = [ "Using Dict.keys directly is meant for this exact purpose and will also be faster." ]
+                            { message = "Dict.toList, then List.map with Tuple.first can be combined into Dict.keys"
+                            , details = [ "You can replace this call by Dict.keys with the same arguments given to Dict.toList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = dict |> Dict.keys
+a = Dict.keys dict
 """
                         ]
         , test "should replace array |> Array.toIndexedList |> List.map Tuple.second by array |> Array.toList" <|

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -2099,8 +2099,8 @@ a = array |> Array.toIndexedList |> List.map Tuple.second
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.toIndexedList, then List.map Tuple.second is the same as Array.toList"
-                            , details = [ "You can replace this call by Array.toList on the array given to Array.toIndexedList which is meant for this exact purpose and will also be faster." ]
+                            { message = "Array.toIndexedList, then List.map with Tuple.second can be combined into Array.toList"
+                            , details = [ "You can replace this call by Array.toList with the same arguments given to Array.toIndexedList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2117,8 +2117,8 @@ a = array |> Array.toIndexedList |> List.map (\\( _, part1 ) -> part1)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.toIndexedList, then List.map Tuple.second is the same as Array.toList"
-                            , details = [ "You can replace this call by Array.toList on the array given to Array.toIndexedList which is meant for this exact purpose and will also be faster." ]
+                            { message = "Array.toIndexedList, then List.map with Tuple.second can be combined into Array.toList"
+                            , details = [ "You can replace this call by Array.toList with the same arguments given to Array.toIndexedList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2135,8 +2135,8 @@ a = Array.toIndexedList >> List.map Tuple.second
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.toIndexedList, then List.map Tuple.second is the same as Array.toList"
-                            , details = [ "You can replace this composition by Array.toList which is meant for this exact purpose and will also be faster." ]
+                            { message = "Array.toIndexedList, then List.map with Tuple.second can be combined into Array.toList"
+                            , details = [ "You can replace this composition by Array.toList with the same arguments given to Array.toIndexedList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
@@ -2153,8 +2153,8 @@ a = Array.toIndexedList >> List.map (\\( _, part1 ) -> part1)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Array.toIndexedList, then List.map Tuple.second is the same as Array.toList"
-                            , details = [ "You can replace this composition by Array.toList which is meant for this exact purpose and will also be faster." ]
+                            { message = "Array.toIndexedList, then List.map with Tuple.second can be combined into Array.toList"
+                            , details = [ "You can replace this composition by Array.toList with the same arguments given to Array.toIndexedList which is meant for this exact purpose." ]
                             , under = "List.map"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)


### PR DESCRIPTION
Refactor based on the idea in #246 
- Convert all checks into combined "`IntoFnCheck`"s
- Introduce module-level `IntoFnCheck` declarations for each fn
- Go through each "use together / in combination with `...` / for the same thing as a ... check" and convert to a `IntoFnCheck`

Your idea works really well in making checks simpler and more reliable. Props for coming up with it!