### PR TITLE
Add flatMap (f << wrap) check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@
 - `List.drop -1 list` to `list`
 - `List.drop 3 [ a, b ]` to `[]` (same for lists with determined size like `List.singleton`)
 - `List.drop 2 [ a, b, c ]` to `[ c ]`
+- `Maybe.andThen (f << Just) maybe` to `Maybe.map f maybe` (same for `Result.andThen`, `List.concatMap`, `Task.andThen`, `Task.onError`, `Json.Decode.andThen`, `Random.andThen`)
 
 Bug fixes:
 - Fixed an issue where `Dict.intersect Dict.empty` would be fixed to `Dict.empty`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -12726,7 +12726,7 @@ constructsOrComposesInto constructWithOneValue lookupTable expressionNode =
                         compositionToLast.last
                             |> AstHelpers.getSpecificValueOrFn constructWithOneValue.fn lookupTable
                             |> Maybe.map
-                                (\constructor ->
+                                (\_ ->
                                     [ Fix.removeRange
                                         (andBetweenRange { included = Node.range compositionToLast.last, excluded = Node.range compositionToLast.earlier })
                                     ]


### PR DESCRIPTION
Implements a generic `flatMap` simplification listed for Maybe and Result in https://github.com/jfmengels/elm-review-simplify/issues/2
```elm
flatMap (f << wrap) wrapper --> map f wrapper
```
