### PR TITLE
Replace union, intersect with the same args by the last arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `String.concat (List.intersperse str strings)` to `String.join str strings`
 - `Set.foldl/r f initial Set.empty` to `initial`
 - `Set.foldl/r (\_ soFar -> soFar) initial set` to `initial`
+- `Set.union set set` to `set`
 - `String.foldl/r f initial ""` to `initial`
 - `String.foldl/r (\_ soFar -> soFar) initial string` to `initial`
 - `Result.fromMaybe x (Just a)` to `Ok a`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `Set.foldl/r f initial Set.empty` to `initial`
 - `Set.foldl/r (\_ soFar -> soFar) initial set` to `initial`
 - `Set.union set set` to `set`
+- `Set.intersect set set` to `set`
 - `String.foldl/r f initial ""` to `initial`
 - `String.foldl/r (\_ soFar -> soFar) initial string` to `initial`
 - `Result.fromMaybe x (Just a)` to `Ok a`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - `Dict.remove k Dict.empty` to `Dict.empty`
 - `Dict.foldl f initial Dict.empty` to `initial` (same for `Dict.foldr`)
 - `Dict.foldl (\_ soFar -> soFar) initial dict` to `initial` (same for `Dict.foldr`)
+- `Dict.union dict dict` to `dict`
 - `Tuple.first (List.partition f list)` to `List.filter f list` (same for `Set.partition` and `Dict.partition`)
 - `List.sum [ a, 0, b ]` to `List.sum [ a, b ]`
 - `List.product [ a, 1, b ]` to `List.product [ a, b ]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - `Dict.foldl f initial Dict.empty` to `initial` (same for `Dict.foldr`)
 - `Dict.foldl (\_ soFar -> soFar) initial dict` to `initial` (same for `Dict.foldr`)
 - `Dict.union dict dict` to `dict`
+- `Dict.intersect dict dict` to `dict`
 - `Tuple.first (List.partition f list)` to `List.filter f list` (same for `Set.partition` and `Dict.partition`)
 - `List.sum [ a, 0, b ]` to `List.sum [ a, b ]`
 - `List.product [ a, 1, b ]` to `List.product [ a, b ]`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1006,6 +1006,9 @@ Destructuring using case expressions
     Set.union set Set.empty
     --> set
 
+    Set.union set set
+    --> set
+
     Set.union (Set.fromList [ a, b ]) (Set.fromList [ c, d ])
     --> Set.fromList [ a, b, c, d]
 
@@ -5818,7 +5821,10 @@ setDiffChecks =
 
 setUnionChecks : IntoFnCheck
 setUnionChecks =
-    intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } setCollection)
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } setCollection)
+        , whenArgumentsAreEqualReturnLastCheck
+        ]
 
 
 setMapChecks : IntoFnCheck

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1083,6 +1083,9 @@ Destructuring using case expressions
     Dict.intersect Dict.empty dict
     --> Dict.empty
 
+    Dict.intersect dict dict
+    --> dict
+
     Dict.diff Dict.empty dict
     --> Dict.empty
 
@@ -5896,7 +5899,10 @@ dictMapChecks =
 
 dictIntersectChecks : IntoFnCheck
 dictIntersectChecks =
-    collectionIntersectChecks dictCollection
+    intoFnChecksFirstThatConstructsError
+        [ collectionIntersectChecks dictCollection
+        , whenArgumentsAreEqualReturnLastCheck
+        ]
 
 
 dictDiffChecks : IntoFnCheck

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -997,6 +997,9 @@ Destructuring using case expressions
     Set.intersect Set.empty set
     --> Set.empty
 
+    Set.intersect set set
+    --> set
+
     Set.diff Set.empty set
     --> Set.empty
 
@@ -5814,7 +5817,10 @@ setPartitionChecks =
 
 setIntersectChecks : IntoFnCheck
 setIntersectChecks =
-    collectionIntersectChecks setCollection
+    intoFnChecksFirstThatConstructsError
+        [ collectionIntersectChecks setCollection
+        , whenArgumentsAreEqualReturnLastCheck
+        ]
 
 
 setDiffChecks : IntoFnCheck

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -10467,7 +10467,7 @@ withTwoEqualArgumentsReturnsLastCheck =
                         Normalize.ConfirmedEquality ->
                             Just
                                 (returnsArgError
-                                    (qualifiedToString checkInfo.fn ++ " where the first and second argument are equal")
+                                    (qualifiedToString checkInfo.fn ++ " with equal first and second arguments")
                                     { arg = secondArg_, argRepresents = "last argument" }
                                     checkInfo
                                 )

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5829,7 +5829,7 @@ setUnionChecks : IntoFnCheck
 setUnionChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = True } setCollection)
-        , whenArgumentsAreEqualReturnLastCheck
+        , withTwoEqualArgumentsReturnsLastCheck
         ]
 
 
@@ -5914,7 +5914,7 @@ dictUnionChecks : IntoFnCheck
 dictUnionChecks =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall (collectionUnionChecks { leftElementsStayOnTheLeft = False } dictCollection)
-        , whenArgumentsAreEqualReturnLastCheck
+        , withTwoEqualArgumentsReturnsLastCheck
         ]
 
 
@@ -10443,7 +10443,7 @@ operationDoesNotChangeResultOfOperationCheck =
     }
 
 
-{-| When a function is given two equal arguments it will return the last argument.
+{-| When a function's first 2 arguments are equal it will return the last argument.
 
     f a a
     --> a
@@ -10453,12 +10453,12 @@ Examples:
     Dict.union dict dict
     --> dict
 
-    Set.union set set
+    Set.intersect set set
     --> set
 
 -}
-whenArgumentsAreEqualReturnLastCheck : IntoFnCheck
-whenArgumentsAreEqualReturnLastCheck =
+withTwoEqualArgumentsReturnsLastCheck : IntoFnCheck
+withTwoEqualArgumentsReturnsLastCheck =
     intoFnCheckOnlyCall
         (\checkInfo ->
             case secondArg checkInfo of
@@ -11045,7 +11045,7 @@ collectionIntersectChecks collection =
                 else
                     Nothing
             )
-        , whenArgumentsAreEqualReturnLastCheck
+        , withTwoEqualArgumentsReturnsLastCheck
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5817,10 +5817,7 @@ setPartitionChecks =
 
 setIntersectChecks : IntoFnCheck
 setIntersectChecks =
-    intoFnChecksFirstThatConstructsError
-        [ collectionIntersectChecks setCollection
-        , whenArgumentsAreEqualReturnLastCheck
-        ]
+    collectionIntersectChecks setCollection
 
 
 setDiffChecks : IntoFnCheck
@@ -5905,10 +5902,7 @@ dictMapChecks =
 
 dictIntersectChecks : IntoFnCheck
 dictIntersectChecks =
-    intoFnChecksFirstThatConstructsError
-        [ collectionIntersectChecks dictCollection
-        , whenArgumentsAreEqualReturnLastCheck
-        ]
+    collectionIntersectChecks dictCollection
 
 
 dictDiffChecks : IntoFnCheck
@@ -11051,6 +11045,7 @@ collectionIntersectChecks collection =
                 else
                     Nothing
             )
+        , whenArgumentsAreEqualReturnLastCheck
         ]
 
 

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -1061,7 +1061,7 @@ a = Dict.intersect dict dict
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.intersect where the first and second argument are equal will always return the same given last argument"
+                            { message = "Dict.intersect with equal first and second arguments will always return the same given last argument"
                             , details = [ "You can replace this call by the last argument itself." ]
                             , under = "Dict.intersect"
                             }
@@ -1079,7 +1079,7 @@ a = value.field |> Dict.intersect (.field value)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.intersect where the first and second argument are equal will always return the same given last argument"
+                            { message = "Dict.intersect with equal first and second arguments will always return the same given last argument"
                             , details = [ "You can replace this call by the last argument itself." ]
                             , under = "Dict.intersect"
                             }
@@ -1447,7 +1447,7 @@ a = Dict.union dict dict
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union where the first and second argument are equal will always return the same given last argument"
+                            { message = "Dict.union with equal first and second arguments will always return the same given last argument"
                             , details = [ "You can replace this call by the last argument itself." ]
                             , under = "Dict.union"
                             }
@@ -1465,7 +1465,7 @@ a = value.field |> Dict.union (.field value)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union where the first and second argument are equal will always return the same given last argument"
+                            { message = "Dict.union with equal first and second arguments will always return the same given last argument"
                             , details = [ "You can replace this call by the last argument itself." ]
                             , under = "Dict.union"
                             }

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -1052,6 +1052,42 @@ import Dict
 a = Dict.empty
 """
                         ]
+        , test "should replace Dict.intersect dict dict by dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.intersect dict dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.intersect where the first and second argument are equal will always return the same given last argument"
+                            , details = [ "You can replace this call by the last argument itself." ]
+                            , under = "Dict.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict
+"""
+                        ]
+        , test "should replace value.field |> Dict.intersect (.field value) by value.field" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = value.field |> Dict.intersect (.field value)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.intersect where the first and second argument are equal will always return the same given last argument"
+                            , details = [ "You can replace this call by the last argument itself." ]
+                            , under = "Dict.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = value.field
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -1402,6 +1402,42 @@ import Dict
 a = (Dict.fromList [b,c,d,e])
 """
                         ]
+        , test "should replace Dict.union dict dict by dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.union dict dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union where the first and second argument are equal will always return the same given last argument"
+                            , details = [ "You can replace this call by the last argument itself." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict
+"""
+                        ]
+        , test "should replace value.field |> Dict.union (.field value) by value.field" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = value.field |> Dict.union (.field value)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union where the first and second argument are equal will always return the same given last argument"
+                            , details = [ "You can replace this call by the last argument itself." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = value.field
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -1509,6 +1509,42 @@ import Set
 a = Set.empty
 """
                         ]
+        , test "should replace Set.intersect set set by set" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.intersect set set
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.intersect where the first and second argument are equal will always return the same given last argument"
+                            , details = [ "You can replace this call by the last argument itself." ]
+                            , under = "Set.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = set
+"""
+                        ]
+        , test "should replace value.field |> Set.intersect (.field value) by value.field" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = value.field |> Set.intersect (.field value)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.intersect where the first and second argument are equal will always return the same given last argument"
+                            , details = [ "You can replace this call by the last argument itself." ]
+                            , under = "Set.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = value.field
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -1825,6 +1825,42 @@ import Set
 a = [ b, c , d, e ] |> Set.fromList
 """
                         ]
+        , test "should replace Set.union set set by set" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.union set set
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union where the first and second argument are equal will always return the same given last argument"
+                            , details = [ "You can replace this call by the last argument itself." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = set
+"""
+                        ]
+        , test "should replace value.field |> Set.union (.field value) by value.field" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = value.field |> Set.union (.field value)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union where the first and second argument are equal will always return the same given last argument"
+                            , details = [ "You can replace this call by the last argument itself." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = value.field
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -1518,7 +1518,7 @@ a = Set.intersect set set
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.intersect where the first and second argument are equal will always return the same given last argument"
+                            { message = "Set.intersect with equal first and second arguments will always return the same given last argument"
                             , details = [ "You can replace this call by the last argument itself." ]
                             , under = "Set.intersect"
                             }
@@ -1536,7 +1536,7 @@ a = value.field |> Set.intersect (.field value)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.intersect where the first and second argument are equal will always return the same given last argument"
+                            { message = "Set.intersect with equal first and second arguments will always return the same given last argument"
                             , details = [ "You can replace this call by the last argument itself." ]
                             , under = "Set.intersect"
                             }
@@ -1870,7 +1870,7 @@ a = Set.union set set
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union where the first and second argument are equal will always return the same given last argument"
+                            { message = "Set.union with equal first and second arguments will always return the same given last argument"
                             , details = [ "You can replace this call by the last argument itself." ]
                             , under = "Set.union"
                             }
@@ -1888,7 +1888,7 @@ a = value.field |> Set.union (.field value)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Set.union where the first and second argument are equal will always return the same given last argument"
+                            { message = "Set.union with equal first and second arguments will always return the same given last argument"
                             , details = [ "You can replace this call by the last argument itself." ]
                             , under = "Set.union"
                             }


### PR DESCRIPTION
Implements simplifications from #2:

```elm
Dict.union dict dict
--> dict

Dict.intersect dict dict
--> dict

Set.union set set
--> set

Set.intersect set set
--> set
```