### PR TITLE
Add ++ case for listGetElements

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6839,17 +6839,26 @@ listGetElements resources =
         , \expressionNode ->
             case AstHelpers.removeParens expressionNode of
                 Node _ (Expression.OperatorApplication "++" _ leftList rightList) ->
-                    case ( listGetElements resources leftList, listGetElements resources rightList ) of
-                        ( Just leftElements, Just rightElements ) ->
+                    case
+                        listGetElements resources leftList
+                            |> Maybe.map
+                                (\lefts ->
+                                    ( lefts
+                                    , if lefts.allKnown then
+                                        listGetElements resources rightList
+
+                                      else
+                                        Nothing
+                                    )
+                                )
+                    of
+                        Just ( leftElements, Just rightElements ) ->
                             Just { allKnown = leftElements.allKnown && rightElements.allKnown, known = leftElements.known ++ rightElements.known }
 
-                        ( Just leftElements, Nothing ) ->
+                        Just ( leftElements, Nothing ) ->
                             Just { known = leftElements.known, allKnown = False }
 
-                        ( Nothing, Just rightElements ) ->
-                            Just { known = rightElements.known, allKnown = False }
-
-                        ( Nothing, Nothing ) ->
+                        Nothing ->
                             Nothing
 
                 _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6849,7 +6849,7 @@ listGetElements resources =
                         ( Nothing, Just rightElements ) ->
                             Just { known = rightElements.known, allKnown = False }
 
-                        _ ->
+                        ( Nothing, Nothing ) ->
                             Nothing
 
                 _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -563,6 +563,9 @@ Destructuring using case expressions
     List.member a [ a, b, c ]
     --> True
 
+    List.member a ([a, b] ++ list)
+    --> True
+
     List.member a [ b ]
     --> a == b
 
@@ -984,6 +987,9 @@ Destructuring using case expressions
 
     Set.isEmpty Set.empty
     --> True
+
+    Set.isEmpty (Set.fromList ([a] ++ list)
+    --> False
 
     Set.member x Set.empty
     --> False

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6836,23 +6836,24 @@ listGetElements resources =
 
                 _ ->
                     Nothing
-         , \expressionNode ->
-                case AstHelpers.removeParens expressionNode of
-                    Node _ (Expression.OperatorApplication "++" _ leftList rightList) ->
-                        case (listGetElements resources leftList, listGetElements resources rightList) of
-                            (Just leftElements, Just rightElements) ->
-                                Just {allKnown = leftElements.allKnown && rightElements.allKnown, known = leftElements.known ++ rightElements.known}
+        , \expressionNode ->
+            case AstHelpers.removeParens expressionNode of
+                Node _ (Expression.OperatorApplication "++" _ leftList rightList) ->
+                    case ( listGetElements resources leftList, listGetElements resources rightList ) of
+                        ( Just leftElements, Just rightElements ) ->
+                            Just { allKnown = leftElements.allKnown && rightElements.allKnown, known = leftElements.known ++ rightElements.known }
 
-                            (Just leftElements, Nothing) ->
-                                 Just {known = leftElements.known, allKnown = False}
+                        ( Just leftElements, Nothing ) ->
+                            Just { known = leftElements.known, allKnown = False }
 
-                            (Nothing, Just rightElements) ->
-                                 Just {known = rightElements.known, allKnown = False}
+                        ( Nothing, Just rightElements ) ->
+                            Just { known = rightElements.known, allKnown = False }
 
-                            _ -> Nothing
+                        _ ->
+                            Nothing
 
-                    _ ->
-                        Nothing
+                _ ->
+                    Nothing
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6836,6 +6836,23 @@ listGetElements resources =
 
                 _ ->
                     Nothing
+         , \expressionNode ->
+                case AstHelpers.removeParens expressionNode of
+                    Node _ (Expression.OperatorApplication "++" _ leftList rightList) ->
+                        case (listGetElements resources leftList, listGetElements resources rightList) of
+                            (Just leftElements, Just rightElements) ->
+                                Just {allKnown = leftElements.allKnown && rightElements.allKnown, known = leftElements.known ++ rightElements.known}
+
+                            (Just leftElements, Nothing) ->
+                                 Just {known = leftElements.known, allKnown = False}
+
+                            (Nothing, Just rightElements) ->
+                                 Just {known = rightElements.known, allKnown = False}
+
+                            _ -> Nothing
+
+                    _ ->
+                        Nothing
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6853,7 +6853,7 @@ listGetElements resources =
                                 )
                     of
                         Just ( leftElements, Just rightElements ) ->
-                            Just { allKnown = leftElements.allKnown && rightElements.allKnown, known = leftElements.known ++ rightElements.known }
+                            Just { allKnown = rightElements.allKnown, known = leftElements.known ++ rightElements.known }
 
                         Just ( leftElements, Nothing ) ->
                             Just { known = leftElements.known, allKnown = False }

--- a/tests/Simplify/ArrayTest.elm
+++ b/tests/Simplify/ArrayTest.elm
@@ -2046,6 +2046,7 @@ d = Array.get n (Array.repeat m x)
 e = Array.get 0 (Array.repeat m x)
 f = Array.get 0 (Array.initialize m func)
 g = Array.get n (Array.initialize m func)
+h = Array.get 0 (Array.fromList (xs ++ [1]))
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1478,6 +1478,22 @@ a = List.member d [ b, c, d ]
 a = True
 """
                         ]
+        , test "should replace List.member c ([ a, b, c] ++ dToZ ] by True" <|
+            \() ->
+                """module A exposing (..)
+a = List.member d ([ b, c, d ] ++ eToZ)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.member on a list which contains the given element will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = True
+"""
+                        ]
         , test "should not report List.member d [ a, b, c ]" <|
             \() ->
                 """module A exposing (..)

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1318,7 +1318,7 @@ d = List.member g (List.filter f list)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should replace List.member a [] by Nothing" <|
+        , test "should replace List.member a [] by False" <|
             \() ->
                 """module A exposing (..)
 a = List.member a []

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1524,39 +1524,38 @@ a = List.member e (a :: b :: c :: eToZ)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-      , test "should replace List.member c ([a,b,c] ++ dToZ) by True" <|
-          \() ->
-            """module A exposing (..)
+        , test "should replace List.member c ([a,b,c] ++ dToZ) by True" <|
+            \() ->
+                """module A exposing (..)
 a = List.member c ([a,b,c] ++ dToZ)
 """
-                |> Review.Test.run ruleWithDefaults
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "List.member on a list which contains the given element will result in True"
-                        , details = [ "You can replace this call by True." ]
-                        , under = "List.member"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.member on a list which contains the given element will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = True
 """
-                    ]
-
-      , test "should replace List.member c (ab ++ (c::dToZ)) by True" <|
-          \() ->
-            """module A exposing (..)
+                        ]
+        , test "should replace List.member c (ab ++ (c::dToZ)) by True" <|
+            \() ->
+                """module A exposing (..)
 a = List.member c (ab ++ (c::dToZ))
 """
-                |> Review.Test.run ruleWithDefaults
-                |> Review.Test.expectErrors
-                    [ Review.Test.error
-                        { message = "List.member on a list which contains the given element will result in True"
-                        , details = [ "You can replace this call by True." ]
-                        , under = "List.member"
-                        }
-                        |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.member on a list which contains the given element will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 a = True
 """
-                    ]
+                        ]
         ]
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1517,45 +1517,13 @@ a = List.member d (b :: c :: d :: eToZ)
 a = True
 """
                         ]
-        , test "should not report List.member e (a :: b :: c :: dToZ)" <|
+        , test "should not report List.member d (a :: b :: c :: dToZ)" <|
             \() ->
                 """module A exposing (..)
-a = List.member e (a :: b :: c :: eToZ)
+a = List.member e (b :: c :: d :: eToZ)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
-        , test "should replace List.member c ([a,b,c] ++ dToZ) by True" <|
-            \() ->
-                """module A exposing (..)
-a = List.member c ([a,b,c] ++ dToZ)
-"""
-                    |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "List.member on a list which contains the given element will result in True"
-                            , details = [ "You can replace this call by True." ]
-                            , under = "List.member"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = True
-"""
-                        ]
-        , test "should replace List.member c (ab ++ (c::dToZ)) by True" <|
-            \() ->
-                """module A exposing (..)
-a = List.member c (ab ++ (c::dToZ))
-"""
-                    |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "List.member on a list which contains the given element will result in True"
-                            , details = [ "You can replace this call by True." ]
-                            , under = "List.member"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = True
-"""
-                        ]
         ]
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1517,13 +1517,46 @@ a = List.member d (b :: c :: d :: eToZ)
 a = True
 """
                         ]
-        , test "should not report List.member d (a :: b :: c :: dToZ)" <|
+        , test "should not report List.member e (a :: b :: c :: dToZ)" <|
             \() ->
                 """module A exposing (..)
-a = List.member e (b :: c :: d :: eToZ)
+a = List.member e (a :: b :: c :: eToZ)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+      , test "should replace List.member c ([a,b,c] ++ dToZ) by True" <|
+          \() ->
+            """module A exposing (..)
+a = List.member c ([a,b,c] ++ dToZ)
+"""
+                |> Review.Test.run ruleWithDefaults
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "List.member on a list which contains the given element will result in True"
+                        , details = [ "You can replace this call by True." ]
+                        , under = "List.member"
+                        }
+                        |> Review.Test.whenFixed """module A exposing (..)
+a = True
+"""
+                    ]
+
+      , test "should replace List.member c (ab ++ (c::dToZ)) by True" <|
+          \() ->
+            """module A exposing (..)
+a = List.member c (ab ++ (c::dToZ))
+"""
+                |> Review.Test.run ruleWithDefaults
+                |> Review.Test.expectErrors
+                    [ Review.Test.error
+                        { message = "List.member on a list which contains the given element will result in True"
+                        , details = [ "You can replace this call by True." ]
+                        , under = "List.member"
+                        }
+                        |> Review.Test.whenFixed """module A exposing (..)
+a = True
+"""
+                    ]
         ]
 
 

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -849,7 +849,7 @@ a = False
             \() ->
                 """module A exposing (..)
 import Set
-a = Set.isEmpty (Set.singleton x)
+a = Set.isEmpty (Set.fromList ([b,c] ++ rest))
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -845,6 +845,24 @@ import Set
 a = False
 """
                         ]
+        , test "should replace Set.isEmpty (Set.fromList ([a,b] ++ rest)) by False" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.isEmpty (Set.singleton x)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.isEmpty on this set will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "Set.isEmpty"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = False
+"""
+                        ]
         , test "should replace Set.singleton set |> Set.isEmpty by False" <|
             \() ->
                 """module A exposing (..)


### PR DESCRIPTION
Add case for `++` in `listGetElements`.

This enables simplifications such as
```elm
List.member b ([a,b] ++ rest)
--> True

Set.isEmpty (Set.fromList ([a,b] ++ rest))
--> False
```

## Examples in docs
I am not sure about which/how many cases I should add in the documentation for this change.
I added one for the two cases above, but there are many more that are now included.
Not sure how to generalize it.
Maybe the examples also are a bit complex, and this change doesn't really need any doc examples?

## Multiple fixes
This can lead to multiple fixes, at least when writing tests.
```elm
List.member a ([a,b] ++ [c,d])
--> True
and
--> List.member a ([a,b,c,d])
```

I guess this is unavoidable and also happens for a lot of other rules and that this is fine, but the solutions is probably just write tests that avoid this issue?