### PR TITLE
Add expectNan to Configuration documentation

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1418,7 +1418,7 @@ moduleVisitor config schema =
 -- CONFIGURATION
 
 
-{-| Configuration for this rule. Create a new one with [`defaults`](#defaults) and use [`ignoreCaseOfForTypes`](#ignoreCaseOfForTypes) to alter it.
+{-| Configuration for this rule. Create a new one with [`defaults`](#defaults) and use [`ignoreCaseOfForTypes`](#ignoreCaseOfForTypes) and [`expectNaN`](#expectNaN) to alter it.
 -}
 type Configuration
     = Configuration


### PR DESCRIPTION
Seems lik expectNan should also be mentioned, if I understand correctly.

It is mentioned below in the `defaults` documentation