### PR TITLE
List.length .isEmpty checks on Dict, Set and Array.toList (and more)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+The rule now simplifies:
+- `Array.length (Array.fromList list)` to `List.length list`
+- `List.length (Array.toList array)` to `Array.length array` (same for `Array.toIndexedList`)
+- `List.isEmpty (Array.toList array)` to `Array.isEmpty array` (same for `Array.toIndexedList`)
+- `List.length (Set.toList set)` to `Set.size set`
+- `List.isEmpty (Set.toList set)` to `Set.isEmpty set`
+- `List.length (Dict.toList dict)` to `Dict.size dict` (same for `Dict.values` and `Dict.keys`)
+- `List.isEmpty (Dict.toList dict)` to `Dict.isEmpty dict` (same for `Dict.values` and `Dict.keys`)
+
 ## [2.1.3] - 2023-10-23
 
 The rule now simplifies:

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5758,12 +5758,19 @@ arrayIsEmptyChecks =
 
 arrayLengthChecks : IntoFnCheck
 arrayLengthChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ collectionSizeChecks arrayCollection
-            , arrayLengthOnArrayRepeatOrInitializeChecks
-            ]
-        )
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall
+            (firstThatConstructsJust
+                [ collectionSizeChecks arrayCollection
+                , arrayLengthOnArrayRepeatOrInitializeChecks
+                ]
+            )
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Array.fromList
+            , combinedFn = Fn.List.length
+            }
+        ]
 
 
 arrayGetChecks : IntoFnCheck

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5453,6 +5453,11 @@ listLengthChecks =
             , earlierFn = Fn.Array.toList
             , combinedFn = Fn.Array.length
             }
+                , onSpecificFnCallCanBeCombinedCheck
+                    { args = []
+                    , earlierFn = Fn.Array.toIndexedList
+                    , combinedFn = Fn.Array.length
+                    }
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5414,6 +5414,11 @@ listLengthChecks =
             , earlierFn = Fn.Set.toList
             , combinedFn = Fn.Set.size
             }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Array.toList
+            , combinedFn = Fn.Array.length
+            }
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5392,7 +5392,29 @@ listIsEmptyChecks =
 
 listLengthChecks : IntoFnCheck
 listLengthChecks =
-    intoFnCheckOnlyCall (collectionSizeChecks listCollection)
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall (collectionSizeChecks listCollection)
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Dict.toList
+            , combinedFn = Fn.Dict.size
+            }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Dict.values
+            , combinedFn = Fn.Dict.size
+            }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Dict.keys
+            , combinedFn = Fn.Dict.size
+            }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Set.toList
+            , combinedFn = Fn.Set.size
+            }
+        ]
 
 
 listAllChecks : IntoFnCheck

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5102,15 +5102,17 @@ listMapOnSingletonCheck =
 
 listMemberChecks : IntoFnCheck
 listMemberChecks =
-    intoFnCheckOnlyCall
-        (firstThatConstructsJust
-            [ callOnEmptyReturnsCheck
-                { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
-                listCollection
-            , knownMemberChecks listCollection
-            , wrapperMemberChecks listCollection
-            ]
-        )
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall
+            (firstThatConstructsJust
+                [ callOnEmptyReturnsCheck
+                    { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
+                    listCollection
+                , knownMemberChecks listCollection
+                , wrapperMemberChecks listCollection
+                ]
+            )
+        ]
 
 
 listSumChecks : IntoFnCheck
@@ -5387,7 +5389,39 @@ listFoldAnyDirectionChecks =
 
 listIsEmptyChecks : IntoFnCheck
 listIsEmptyChecks =
-    intoFnCheckOnlyCall (collectionIsEmptyChecks listCollection)
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall (collectionIsEmptyChecks listCollection)
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Set.toList
+            , combinedFn = Fn.Set.isEmpty
+            }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Array.toList
+            , combinedFn = Fn.Array.isEmpty
+            }
+                , onSpecificFnCallCanBeCombinedCheck
+                    { args = []
+                    , earlierFn = Fn.Array.toIndexedList
+                    , combinedFn = Fn.Array.isEmpty
+                    }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Dict.toList
+            , combinedFn = Fn.Dict.isEmpty
+            }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Dict.values
+            , combinedFn = Fn.Dict.isEmpty
+            }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Dict.keys
+            , combinedFn = Fn.Dict.isEmpty
+            }
+        ]
 
 
 listLengthChecks : IntoFnCheck

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -5102,17 +5102,15 @@ listMapOnSingletonCheck =
 
 listMemberChecks : IntoFnCheck
 listMemberChecks =
-    intoFnChecksFirstThatConstructsError
-        [ intoFnCheckOnlyCall
-            (firstThatConstructsJust
-                [ callOnEmptyReturnsCheck
-                    { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
-                    listCollection
-                , knownMemberChecks listCollection
-                , wrapperMemberChecks listCollection
-                ]
-            )
-        ]
+    intoFnCheckOnlyCall
+        (firstThatConstructsJust
+            [ callOnEmptyReturnsCheck
+                { resultAsString = \res -> qualifiedToString (qualify Fn.Basics.falseVariant res) }
+                listCollection
+            , knownMemberChecks listCollection
+            , wrapperMemberChecks listCollection
+            ]
+        )
 
 
 listSumChecks : IntoFnCheck
@@ -5401,11 +5399,11 @@ listIsEmptyChecks =
             , earlierFn = Fn.Array.toList
             , combinedFn = Fn.Array.isEmpty
             }
-                , onSpecificFnCallCanBeCombinedCheck
-                    { args = []
-                    , earlierFn = Fn.Array.toIndexedList
-                    , combinedFn = Fn.Array.isEmpty
-                    }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Array.toIndexedList
+            , combinedFn = Fn.Array.isEmpty
+            }
         , onSpecificFnCallCanBeCombinedCheck
             { args = []
             , earlierFn = Fn.Dict.toList
@@ -5453,11 +5451,11 @@ listLengthChecks =
             , earlierFn = Fn.Array.toList
             , combinedFn = Fn.Array.length
             }
-                , onSpecificFnCallCanBeCombinedCheck
-                    { args = []
-                    , earlierFn = Fn.Array.toIndexedList
-                    , combinedFn = Fn.Array.length
-                    }
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.Array.toIndexedList
+            , combinedFn = Fn.Array.length
+            }
         ]
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -979,6 +979,17 @@ Destructuring using case expressions
     List.map Tuple.second (Array.toIndexedList array)
     --> Array.toList array
 
+    Array.length (Array.fromList list)
+    --> List.length list
+
+    -- The following simplification also works for Array.toIndexedList
+    List.length (Array.toList array)
+    --> Array.length array
+
+    -- The following simplification also works for Array.toIndexedList
+    List.isEmpty (Array.toList array)
+    --> Array.isEmpty array
+
 
 ### Sets
 
@@ -1061,6 +1072,12 @@ Destructuring using case expressions
 
     Set.foldl (\_ soFar -> soFar) initial set
     --> initial
+
+    List.length (Set.toList set)
+    --> Set.size set
+
+    List.isEmpty (Set.toList set)
+    --> Set.isEmpty set
 
 
 ### Dict
@@ -1146,6 +1163,14 @@ Destructuring using case expressions
 
     Dict.foldl (\_ soFar -> soFar) initial dict
     --> initial
+
+    -- The following simplification also works for Dict.keys, Dict.values
+    List.length (Dict.toList dict)
+    --> Dict.size dict
+
+    -- The following simplification also works for Dict.keys, Dict.values
+    List.isEmpty (Dict.toList dict)
+    --> Dict.isEmpty dict
 
 
 ### Cmd / Sub

--- a/tests/Simplify/ArrayTest.elm
+++ b/tests/Simplify/ArrayTest.elm
@@ -1723,6 +1723,24 @@ import Array
 a = max 0 n
 """
                         ]
+        , test "should replace Array.fromList list |> Array.length with List.length list" <|
+            \() ->
+                """module A exposing (..)
+import Array
+a = Array.fromList list |> Array.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.fromList, then Array.length can be combined into List.length"
+                            , details = [ "You can replace this call by List.length with the same arguments given to Array.fromList which is meant for this exact purpose." ]
+                            , under = "Array.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array
+a = List.length list
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -6269,7 +6269,7 @@ a = Dict.keys dict |> List.length
 a = Dict.size dict
 """
                         ]
-        , test "should replace List.length (Array.toList dict) with Dict.size" <|
+        , test "should replace List.length (Array.toList array) with Dict.size" <|
             \() ->
                 """module A exposing (..)
 a = Array.toList array |> List.length
@@ -6279,6 +6279,22 @@ a = Array.toList array |> List.length
                         [ Review.Test.error
                             { message = "Array.toList, then List.length can be combined into Array.length"
                             , details = [ "You can replace this call by Array.length with the same arguments given to Array.toList which is meant for this exact purpose." ]
+                            , under = "List.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Array.length array
+"""
+                        ]
+        , test "should replace List.length (Array.toIndexedList array) with Dict.size" <|
+            \() ->
+                """module A exposing (..)
+a = Array.toIndexedList array |> List.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.toIndexedList, then List.length can be combined into Array.length"
+                            , details = [ "You can replace this call by Array.length with the same arguments given to Array.toIndexedList which is meant for this exact purpose." ]
                             , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -6109,6 +6109,70 @@ a = List.length (List.range 3 7)
 a = 4
 """
                         ]
+        , test "should replace List.length (Set.fromList set) with Set.size" <|
+            \() ->
+                """module A exposing (..)
+a = Set.toList set |> List.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.toList, then List.length can be combined into Set.size"
+                            , details = [ "You can replace this call by Set.size with the same arguments given to Set.toList which is meant for this exact purpose." ]
+                            , under = "List.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Set.size set
+"""
+                        ]
+        , test "should replace List.length (Dict.fromList dict) with Dict.size" <|
+            \() ->
+                """module A exposing (..)
+a = Dict.toList dict |> List.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.toList, then List.length can be combined into Dict.size"
+                            , details = [ "You can replace this call by Dict.size with the same arguments given to Dict.toList which is meant for this exact purpose." ]
+                            , under = "List.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Dict.size dict
+"""
+                        ]
+        , test "should replace List.length (Dict.values dict) with Dict.size" <|
+            \() ->
+                """module A exposing (..)
+a = Dict.values dict |> List.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.values, then List.length can be combined into Dict.size"
+                            , details = [ "You can replace this call by Dict.size with the same arguments given to Dict.values which is meant for this exact purpose." ]
+                            , under = "List.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Dict.size dict
+"""
+                        ]
+        , test "should replace List.length (Dict.keys dict) with Dict.size" <|
+            \() ->
+                """module A exposing (..)
+a = Dict.keys dict |> List.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.keys, then List.length can be combined into Dict.size"
+                            , details = [ "You can replace this call by Dict.size with the same arguments given to Dict.keys which is meant for this exact purpose." ]
+                            , under = "List.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Dict.size dict
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -6173,6 +6173,22 @@ a = Dict.keys dict |> List.length
 a = Dict.size dict
 """
                         ]
+        , test "should replace List.length (Array.toList dict) with Dict.size" <|
+            \() ->
+                """module A exposing (..)
+a = Array.toList array |> List.length
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.toList, then List.length can be combined into Array.length"
+                            , details = [ "You can replace this call by Array.length with the same arguments given to Array.toList which is meant for this exact purpose." ]
+                            , under = "List.length"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Array.length array
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -3108,6 +3108,102 @@ a = List.isEmpty (b |> List.singleton)
 a = False
 """
                         ]
+        , test "should replace List.isEmpty (Set.toList set) by Set.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = Set.toList set |> List.isEmpty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.toList, then List.isEmpty can be combined into Set.isEmpty"
+                            , details = [ "You can replace this call by Set.isEmpty with the same arguments given to Set.toList which is meant for this exact purpose." ]
+                            , under = "List.isEmpty"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Set.isEmpty set
+"""
+                        ]
+        , test "should replace List.isEmpty (Dict.toList dict) by Dict.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = Dict.toList dict |> List.isEmpty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.toList, then List.isEmpty can be combined into Dict.isEmpty"
+                            , details = [ "You can replace this call by Dict.isEmpty with the same arguments given to Dict.toList which is meant for this exact purpose." ]
+                            , under = "List.isEmpty"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Dict.isEmpty dict
+"""
+                        ]
+        , test "should replace List.isEmpty (Dict.values dict) by Dict.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = Dict.values dict |> List.isEmpty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.values, then List.isEmpty can be combined into Dict.isEmpty"
+                            , details = [ "You can replace this call by Dict.isEmpty with the same arguments given to Dict.values which is meant for this exact purpose." ]
+                            , under = "List.isEmpty"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Dict.isEmpty dict
+"""
+                        ]
+        , test "should replace List.isEmpty (Dict.keys dict) by Dict.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = Dict.keys dict |> List.isEmpty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.keys, then List.isEmpty can be combined into Dict.isEmpty"
+                            , details = [ "You can replace this call by Dict.isEmpty with the same arguments given to Dict.keys which is meant for this exact purpose." ]
+                            , under = "List.isEmpty"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Dict.isEmpty dict
+"""
+                        ]
+        , test "should replace List.isEmpty (Array.toList array) by Array.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = Array.toList array |> List.isEmpty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.toList, then List.isEmpty can be combined into Array.isEmpty"
+                            , details = [ "You can replace this call by Array.isEmpty with the same arguments given to Array.toList which is meant for this exact purpose." ]
+                            , under = "List.isEmpty"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Array.isEmpty array
+"""
+                        ]
+        , test "should replace List.isEmpty (Array.toIndexedList array) by Dict.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = Array.toIndexedList array |> List.isEmpty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Array.toIndexedList, then List.isEmpty can be combined into Array.isEmpty"
+                            , details = [ "You can replace this call by Array.isEmpty with the same arguments given to Array.toIndexedList which is meant for this exact purpose." ]
+                            , under = "List.isEmpty"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = Array.isEmpty array
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -3108,9 +3108,10 @@ a = List.isEmpty (b |> List.singleton)
 a = False
 """
                         ]
-        , test "should replace List.isEmpty (Set.toList set) by Set.isEmpty" <|
+        , test "should replace Set.toList set |> List.isEmpty by Set.isEmpty" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = Set.toList set |> List.isEmpty
 """
                     |> Review.Test.run ruleWithDefaults
@@ -3121,12 +3122,14 @@ a = Set.toList set |> List.isEmpty
                             , under = "List.isEmpty"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = Set.isEmpty set
 """
                         ]
-        , test "should replace List.isEmpty (Dict.toList dict) by Dict.isEmpty" <|
+        , test "should replace Dict.toList dict |> List.isEmpty by Dict.isEmpty" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.toList dict |> List.isEmpty
 """
                     |> Review.Test.run ruleWithDefaults
@@ -3137,12 +3140,14 @@ a = Dict.toList dict |> List.isEmpty
                             , under = "List.isEmpty"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = Dict.isEmpty dict
 """
                         ]
-        , test "should replace List.isEmpty (Dict.values dict) by Dict.isEmpty" <|
+        , test "should replace Dict.values dict |> List.isEmpty by Dict.isEmpty" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.values dict |> List.isEmpty
 """
                     |> Review.Test.run ruleWithDefaults
@@ -3153,12 +3158,14 @@ a = Dict.values dict |> List.isEmpty
                             , under = "List.isEmpty"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = Dict.isEmpty dict
 """
                         ]
-        , test "should replace List.isEmpty (Dict.keys dict) by Dict.isEmpty" <|
+        , test "should replace Dict.keys dict |> List.isEmpty by Dict.isEmpty" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.keys dict |> List.isEmpty
 """
                     |> Review.Test.run ruleWithDefaults
@@ -3169,12 +3176,14 @@ a = Dict.keys dict |> List.isEmpty
                             , under = "List.isEmpty"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = Dict.isEmpty dict
 """
                         ]
-        , test "should replace List.isEmpty (Array.toList array) by Array.isEmpty" <|
+        , test "should replace Array.toList array |> List.isEmpty by Array.isEmpty" <|
             \() ->
                 """module A exposing (..)
+import Array
 a = Array.toList array |> List.isEmpty
 """
                     |> Review.Test.run ruleWithDefaults
@@ -3185,12 +3194,14 @@ a = Array.toList array |> List.isEmpty
                             , under = "List.isEmpty"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a = Array.isEmpty array
 """
                         ]
-        , test "should replace List.isEmpty (Array.toIndexedList array) by Dict.isEmpty" <|
+        , test "should replace Array.toIndexedList array |> List.isEmpty by Array.isEmpty" <|
             \() ->
                 """module A exposing (..)
+import Array
 a = Array.toIndexedList array |> List.isEmpty
 """
                     |> Review.Test.run ruleWithDefaults
@@ -3201,6 +3212,7 @@ a = Array.toIndexedList array |> List.isEmpty
                             , under = "List.isEmpty"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a = Array.isEmpty array
 """
                         ]
@@ -6205,9 +6217,10 @@ a = List.length (List.range 3 7)
 a = 4
 """
                         ]
-        , test "should replace List.length (Set.fromList set) with Set.size" <|
+        , test "should replace Set.toList set |> List.length with Set.size" <|
             \() ->
                 """module A exposing (..)
+import Set
 a = Set.toList set |> List.length
 """
                     |> Review.Test.run ruleWithDefaults
@@ -6218,12 +6231,14 @@ a = Set.toList set |> List.length
                             , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a = Set.size set
 """
                         ]
-        , test "should replace List.length (Dict.fromList dict) with Dict.size" <|
+        , test "should replace Dict.toList dict |> List.length with Dict.size" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.toList dict |> List.length
 """
                     |> Review.Test.run ruleWithDefaults
@@ -6234,12 +6249,14 @@ a = Dict.toList dict |> List.length
                             , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = Dict.size dict
 """
                         ]
-        , test "should replace List.length (Dict.values dict) with Dict.size" <|
+        , test "should replace Dict.values dict |> List.length with Dict.size" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.values dict |> List.length
 """
                     |> Review.Test.run ruleWithDefaults
@@ -6250,12 +6267,14 @@ a = Dict.values dict |> List.length
                             , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = Dict.size dict
 """
                         ]
-        , test "should replace List.length (Dict.keys dict) with Dict.size" <|
+        , test "should replace Dict.keys dict |> List.length with Dict.size" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a = Dict.keys dict |> List.length
 """
                     |> Review.Test.run ruleWithDefaults
@@ -6266,12 +6285,14 @@ a = Dict.keys dict |> List.length
                             , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a = Dict.size dict
 """
                         ]
-        , test "should replace List.length (Array.toList array) with Dict.size" <|
+        , test "should replace Array.toList array |> List.length with Dict.size" <|
             \() ->
                 """module A exposing (..)
+import Array
 a = Array.toList array |> List.length
 """
                     |> Review.Test.run ruleWithDefaults
@@ -6282,12 +6303,14 @@ a = Array.toList array |> List.length
                             , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a = Array.length array
 """
                         ]
-        , test "should replace List.length (Array.toIndexedList array) with Dict.size" <|
+        , test "should replace Array.toIndexedList array |> List.length with Array.length" <|
             \() ->
                 """module A exposing (..)
+import Array
 a = Array.toIndexedList array |> List.length
 """
                     |> Review.Test.run ruleWithDefaults
@@ -6298,6 +6321,7 @@ a = Array.toIndexedList array |> List.length
                             , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a = Array.length array
 """
                         ]


### PR DESCRIPTION
Simplifies uneccessary convertions from a Collection into List before a List.length / List.size, when you could just do 
Collection.size or Collection.isEmpty

Mentioned before in comment here: https://github.com/jfmengels/elm-review-simplify/issues/290#issuecomment-1975196945

Also adds one simplification for `Array.length (Array.fromList list)`

Simplifications:

## Array
```elm
-- The following simplification also works for Array.toIndexedList
List.length (Array.toList array)
--> Array.length array

-- The following simplification also works for Array.toIndexedList
List.isEmpty (Array.toList array)
--> Array.isEmpty array

Array.length (Array.fromList list)
--> List.length list
```

## Set
```elm
List.length (Set.toList set)
--> Set.size set

List.isEmpty (Set.toList set)
--> Set.isEmpty set
```

## Dict
```elm
-- The following simplification also works for Dict.keys, Dict.values
List.length (Dict.toList dict)
--> Dict.size dict

-- The following simplification also works for Dict.keys, Dict.values
List.isEmpty (Dict.toList dict)
--> Dict.isEmpty dict
```

