### PR TITLE
prefer isEmpty functions to checking if length/size == 0 for Set, Dict, and List

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3874,11 +3874,17 @@ equalityChecks isEqual =
                                     [ Fix.replaceRangeBy
                                         fnRange
                                         replacement
-                                    , Range.combine
-                                        [ Node.range thatNode
-                                        , checkInfo.operatorRange
-                                        ]
-                                        |> Fix.removeRange
+                                    , Fix.removeRange <|
+                                        case Range.compare (Node.range thisNode) (Node.range thatNode) of
+                                            LT ->
+                                                { start = (Node.range thisNode).end
+                                                , end = (Node.range thatNode).end
+                                                }
+
+                                            _ ->
+                                                { start = (Node.range thatNode).start
+                                                , end = (Node.range thisNode).start
+                                                }
                                     ]
                                 )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3865,12 +3865,7 @@ equalityChecks isEqual =
                         Just { message, details, fnRange, replacement } ->
                             Just
                                 (Rule.errorWithFix { message = message, details = details }
-                                    (Range.combine
-                                        [ checkInfo.leftRange
-                                        , checkInfo.operatorRange
-                                        , checkInfo.rightRange
-                                        ]
-                                    )
+                                    fnRange
                                     [ Fix.replaceRangeBy
                                         fnRange
                                         replacement

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -864,6 +864,12 @@ Destructuring using case expressions
     List.unzip []
     --> ( [], [] )
 
+    List.length l == 0
+    --> List.isEmpty l
+
+    List.length l /= 0
+    --> (not << List.isEmpty) l
+
 
 ### Arrays
 
@@ -1091,6 +1097,12 @@ Destructuring using case expressions
     List.isEmpty (Set.toList set)
     --> Set.isEmpty set
 
+    Set.size set == 0
+    --> Set.isEmpty set
+
+    Set.size set /= 0
+    --> (not << Set.isEmpty) set
+
 
 ### Dict
 
@@ -1183,6 +1195,12 @@ Destructuring using case expressions
     -- The following simplification also works for Dict.keys, Dict.values
     List.isEmpty (Dict.toList dict)
     --> Dict.isEmpty dict
+
+    Set.size dict == 0
+    --> Set.isEmpty dict
+
+    Set.size dict /= 0
+    --> (not << Set.isEmpty) dict
 
 
 ### Cmd / Sub
@@ -3994,7 +4012,7 @@ compareWithZeroChecks checkInfo isEqual node =
                                     newName
 
                                 else
-                                    "(not " ++ newName ++ ")"
+                                    "(not << " ++ newName ++ ")"
                         in
                         Just
                             { message = "This can be replaced with a call to " ++ replacement

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4017,6 +4017,7 @@ compareWithZeroChecks checkInfo isEqual node =
                             newName =
                                 qualifiedToString (qualify newFn checkInfo)
 
+                            replacement : String
                             replacement =
                                 if isEqual then
                                     newName

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1005,8 +1005,11 @@ Destructuring using case expressions
     List.isEmpty (Array.toList array)
     --> Array.isEmpty array
 
-    a = List.length l == 0
-    --> a = List.isEmpty l
+    Array.length a == 0
+    --> Array.isEmpty a
+
+    Array.length a /= 0
+    --> (not << Array.isEmpty) a
 
 
 ### Sets
@@ -3990,6 +3993,7 @@ compareWithZeroChecks checkInfo isEqual node =
     [ ( Fn.List.isEmpty, Fn.List.length, "List" )
     , ( Fn.Dict.isEmpty, Fn.Dict.size, "Dict" )
     , ( Fn.Set.isEmpty, Fn.Set.size, "Set" )
+    , ( Fn.Array.isEmpty, Fn.Array.length, "Array" )
 
     -- , ( Fn.String.isEmpty, Fn.String.length, "String" ) is this the best replacement? Should it be == ""?
     ]

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3840,7 +3840,7 @@ equalityChecks isEqual =
             let
                 handle : Node Expression -> Node Expression -> Maybe (Error {})
                 handle thisNode thatNode =
-                    case compareWithZeroChecks checkInfo.lookupTable isEqual thisNode of
+                    case compareWithZeroChecks checkInfo isEqual thisNode of
                         Just { message, details, fnRange, replacement } ->
                             Just
                                 (Rule.errorWithFix { message = message, details = details }
@@ -3958,7 +3958,7 @@ equalityChecks isEqual =
 
 
 compareWithZeroChecks :
-    ModuleNameLookupTable
+    OperatorApplicationCheckInfo
     -> Bool
     -> Node Expression
     ->
@@ -3968,51 +3968,51 @@ compareWithZeroChecks :
             , fnRange : Range
             , replacement : String
             }
-compareWithZeroChecks lookupTable isEqual node =
-    let
-        maybeRangeAndNames =
-            [ ( "List.isEmpty", "List.length", Fn.List.length )
-            , ( "Dict.isEmpty", "Dict.size", Fn.Dict.size )
-            , ( "Set.isEmpty", "Set.size", Fn.Set.size )
+compareWithZeroChecks checkInfo isEqual node =
+    [ ( Fn.List.isEmpty, Fn.List.length, "List" )
+    , ( Fn.Dict.isEmpty, Fn.Dict.size, "Dict" )
+    , ( Fn.Set.isEmpty, Fn.Set.size, "Set" )
 
-            -- , ( "String.isEmpty", "String.length", Fn.String.length ) is this the best replacement? Should it be == ""?
-            ]
-                |> List.map (\( newName, oldName, fn ) -> ( newName, oldName, AstHelpers.getSpecificFnCall fn lookupTable node ))
-                |> List.filterMap
-                    (\( newName, oldName, maybeCall ) ->
-                        Maybe.map
-                            (\call ->
-                                { range = call.fnRange
-                                , newName = newName
-                                , oldName = oldName
-                                }
-                            )
-                            maybeCall
-                    )
-                |> List.head
-    in
-    case maybeRangeAndNames of
-        Just { range, oldName, newName } ->
-            let
-                replacement =
-                    if isEqual then
-                        newName
+    -- , ( Fn.String.isEmpty, Fn.String.length, "String" ) is this the best replacement? Should it be == ""?
+    ]
+        |> findMap
+            (\( newFn, oldFn, structName ) ->
+                case
+                    AstHelpers.getSpecificFnCall
+                        oldFn
+                        checkInfo.lookupTable
+                        node
+                of
+                    Just call ->
+                        let
+                            newName : String
+                            newName =
+                                qualifiedToString (qualify newFn checkInfo)
 
-                    else
-                        "(not " ++ newName ++ ")"
-            in
-            Just
-                { message = "This can be replaced with a call to " ++ replacement
-                , details =
-                    [ oldName ++ " takes as long to run as the list is long"
-                    , "whereas " ++ newName ++ " runs in constant time."
-                    ]
-                , fnRange = range
-                , replacement = replacement
-                }
+                            replacement =
+                                if isEqual then
+                                    newName
 
-        Nothing ->
-            Nothing
+                                else
+                                    "(not " ++ newName ++ ")"
+                        in
+                        Just
+                            { message = "This can be replaced with a call to " ++ replacement
+                            , details =
+                                [ "Whereas "
+                                    ++ qualifiedToString (qualify oldFn checkInfo)
+                                    ++ " takes as long to run as the number of elements in the "
+                                    ++ structName
+                                    ++ ","
+                                , newName ++ " runs in constant time."
+                                ]
+                            , fnRange = call.fnRange
+                            , replacement = replacement
+                            }
+
+                    Nothing ->
+                        Nothing
+            )
 
 
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -4032,8 +4032,9 @@ compareWithZeroChecks checkInfo isEqual node =
                                     ++ qualifiedToString (qualify oldFn checkInfo)
                                     ++ " takes as long to run as the number of elements in the "
                                     ++ structName
-                                    ++ ","
-                                , newName ++ " runs in constant time."
+                                    ++ ", "
+                                    ++ newName
+                                    ++ " runs in constant time."
                                 ]
                             , fnRange = call.fnRange
                             , replacement = replacement

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -1115,6 +1115,7 @@ setIsEmptyTests =
         [ test "should replace Set.size s == 0 with Set.isEmpty s" <|
             \() ->
                 """module A exposing (..)
+import Set
 a : Bool
 a = Set.size s == 0
 """
@@ -1128,16 +1129,37 @@ a = Set.size s == 0
                             , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a : Bool
 a = Set.isEmpty s
+"""
+                        ]
+        , test "should replace CoreSet.size s == 0 with isEmpty s" <|
+            \() ->
+                """module A exposing (..)
+import Set as CoreSet
+a : Bool
+a = CoreSet.size s == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to CoreSet.isEmpty"
+                            , details =
+                                [ "Whereas CoreSet.size takes as long to run as the number of elements in the Set, CoreSet.isEmpty runs in constant time."
+                                ]
+                            , under = "CoreSet.size"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set as CoreSet
+a : Bool
+a = CoreSet.isEmpty s
 """
                         ]
         , test "should replace size s == 0 with isEmpty s" <|
             \() ->
                 """module A exposing (..)
 import Set as CoreSet exposing (..)
-
-
 a : Bool
 a = size s == 0
 """
@@ -1152,8 +1174,6 @@ a = size s == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Set as CoreSet exposing (..)
-
-
 a : Bool
 a = isEmpty s
 """
@@ -1161,6 +1181,7 @@ a = isEmpty s
         , test "should replace 0 == Set.size s with Set.isEmpty s" <|
             \() ->
                 """module A exposing (..)
+import Set
 a : Bool
 a = 0 == Set.size s
 """
@@ -1174,6 +1195,7 @@ a = 0 == Set.size s
                             , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a : Bool
 a = Set.isEmpty s
 """
@@ -1181,6 +1203,7 @@ a = Set.isEmpty s
         , test "should replace (s |> Set.size) == 0 with Set.isEmpty s" <|
             \() ->
                 """module A exposing (..)
+import Set
 a : Bool
 a = (s |> Set.size) == 0
 """
@@ -1194,6 +1217,7 @@ a = (s |> Set.size) == 0
                             , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a : Bool
 a = (s |> Set.isEmpty)
 """
@@ -1201,6 +1225,7 @@ a = (s |> Set.isEmpty)
         , test "should replace 0 == ([] |> Set.size) with Set.isEmpty s" <|
             \() ->
                 """module A exposing (..)
+import Set
 a : Bool
 a = 0 == (s |> Set.size)
 """
@@ -1214,6 +1239,7 @@ a = 0 == (s |> Set.size)
                             , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a : Bool
 a = (s |> Set.isEmpty)
 """
@@ -1221,6 +1247,7 @@ a = (s |> Set.isEmpty)
         , test "should replace Set.size s /= 0 with (not << Set.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Set
 a : Bool
 a = Set.size s /= 0
 """
@@ -1234,6 +1261,7 @@ a = Set.size s /= 0
                             , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a : Bool
 a = (not << Set.isEmpty) s
 """
@@ -1241,6 +1269,7 @@ a = (not << Set.isEmpty) s
         , test "should replace 0 /= Set.size s with (not << Set.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Set
 a : Bool
 a = 0 /= Set.size s
 """
@@ -1254,6 +1283,7 @@ a = 0 /= Set.size s
                             , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a : Bool
 a = (not << Set.isEmpty) s
 """
@@ -1261,6 +1291,7 @@ a = (not << Set.isEmpty) s
         , test "should replace (s |> Set.size) /= 0 with (not << Set.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Set
 a : Bool
 a = (s |> Set.size) /= 0
 """
@@ -1274,6 +1305,7 @@ a = (s |> Set.size) /= 0
                             , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a : Bool
 a = (s |> (not << Set.isEmpty))
 """
@@ -1281,6 +1313,7 @@ a = (s |> (not << Set.isEmpty))
         , test "should replace 0 /= (s |> Set.size) with (not << Set.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Set
 a : Bool
 a = 0 /= (s |> Set.size)
 """
@@ -1294,6 +1327,7 @@ a = 0 /= (s |> Set.size)
                             , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Set
 a : Bool
 a = (s |> (not << Set.isEmpty))
 """
@@ -1307,6 +1341,7 @@ dictIsEmptyTests =
         [ test "should replace Dict.size d == 0 with Dict.isEmpty d" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a : Bool
 a = Dict.size d == 0
 """
@@ -1320,6 +1355,7 @@ a = Dict.size d == 0
                             , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a : Bool
 a = Dict.isEmpty d
 """
@@ -1353,6 +1389,7 @@ a = isEmpty d
         , test "should replace 0 == Dict.size d with Dict.isEmpty d" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a : Bool
 a = 0 == Dict.size d
 """
@@ -1366,6 +1403,7 @@ a = 0 == Dict.size d
                             , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a : Bool
 a = Dict.isEmpty d
 """
@@ -1373,6 +1411,7 @@ a = Dict.isEmpty d
         , test "should replace (d |> Dict.size) == 0 with Dict.isEmpty d" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a : Bool
 a = (d |> Dict.size) == 0
 """
@@ -1386,6 +1425,7 @@ a = (d |> Dict.size) == 0
                             , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a : Bool
 a = (d |> Dict.isEmpty)
 """
@@ -1393,6 +1433,7 @@ a = (d |> Dict.isEmpty)
         , test "should replace 0 == ([] |> Dict.size) with Dict.isEmpty d" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a : Bool
 a = 0 == (d |> Dict.size)
 """
@@ -1406,6 +1447,7 @@ a = 0 == (d |> Dict.size)
                             , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a : Bool
 a = (d |> Dict.isEmpty)
 """
@@ -1413,6 +1455,7 @@ a = (d |> Dict.isEmpty)
         , test "should replace Dict.size d /= 0 with (not << Dict.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a : Bool
 a = Dict.size d /= 0
 """
@@ -1426,6 +1469,7 @@ a = Dict.size d /= 0
                             , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a : Bool
 a = (not << Dict.isEmpty) d
 """
@@ -1433,6 +1477,7 @@ a = (not << Dict.isEmpty) d
         , test "should replace 0 /= Dict.size d with (not << Dict.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a : Bool
 a = 0 /= Dict.size d
 """
@@ -1446,6 +1491,7 @@ a = 0 /= Dict.size d
                             , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a : Bool
 a = (not << Dict.isEmpty) d
 """
@@ -1453,6 +1499,7 @@ a = (not << Dict.isEmpty) d
         , test "should replace (d |> Dict.size) /= 0 with (not << Dict.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a : Bool
 a = (d |> Dict.size) /= 0
 """
@@ -1466,6 +1513,7 @@ a = (d |> Dict.size) /= 0
                             , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a : Bool
 a = (d |> (not << Dict.isEmpty))
 """
@@ -1473,6 +1521,7 @@ a = (d |> (not << Dict.isEmpty))
         , test "should replace 0 /= (d |> Dict.size) with (not << Dict.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Dict
 a : Bool
 a = 0 /= (d |> Dict.size)
 """
@@ -1486,6 +1535,7 @@ a = 0 /= (d |> Dict.size)
                             , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Dict
 a : Bool
 a = (d |> (not << Dict.isEmpty))
 """
@@ -1495,10 +1545,11 @@ a = (d |> (not << Dict.isEmpty))
 
 arrayIsEmptyTests : Test
 arrayIsEmptyTests =
-    describe "Array.length should be Array.isEmpty"
+    describe "Array.length should be Arraya.isEmpty"
         [ test "should replace Array.length array == 0 with Array.isEmpty array" <|
             \() ->
                 """module A exposing (..)
+import Array
 a : Bool
 a = Array.length array == 0
 """
@@ -1512,6 +1563,7 @@ a = Array.length array == 0
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a : Bool
 a = Array.isEmpty array
 """
@@ -1545,6 +1597,7 @@ a = isEmpty array
         , test "should replace 0 == Array.length array with Array.isEmpty array" <|
             \() ->
                 """module A exposing (..)
+import Array
 a : Bool
 a = 0 == Array.length array
 """
@@ -1558,6 +1611,7 @@ a = 0 == Array.length array
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a : Bool
 a = Array.isEmpty array
 """
@@ -1565,6 +1619,7 @@ a = Array.isEmpty array
         , test "should replace (array |> Array.length) == 0 with Array.isEmpty array" <|
             \() ->
                 """module A exposing (..)
+import Array
 a : Bool
 a = (array |> Array.length) == 0
 """
@@ -1578,6 +1633,7 @@ a = (array |> Array.length) == 0
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a : Bool
 a = (array |> Array.isEmpty)
 """
@@ -1585,6 +1641,7 @@ a = (array |> Array.isEmpty)
         , test "should replace 0 == ([] |> Array.length) with Array.isEmpty array" <|
             \() ->
                 """module A exposing (..)
+import Array
 a : Bool
 a = 0 == (array |> Array.length)
 """
@@ -1598,6 +1655,7 @@ a = 0 == (array |> Array.length)
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a : Bool
 a = (array |> Array.isEmpty)
 """
@@ -1605,6 +1663,7 @@ a = (array |> Array.isEmpty)
         , test "should replace Array.length array /= 0 with (not << Array.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Array
 a : Bool
 a = Array.length array /= 0
 """
@@ -1618,6 +1677,7 @@ a = Array.length array /= 0
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a : Bool
 a = (not << Array.isEmpty) array
 """
@@ -1625,6 +1685,7 @@ a = (not << Array.isEmpty) array
         , test "should replace 0 /= Array.length array with (not << Array.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Array
 a : Bool
 a = 0 /= Array.length array
 """
@@ -1638,6 +1699,7 @@ a = 0 /= Array.length array
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a : Bool
 a = (not << Array.isEmpty) array
 """
@@ -1645,6 +1707,7 @@ a = (not << Array.isEmpty) array
         , test "should replace (array |> Array.length) /= 0 with (not << Array.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Array
 a : Bool
 a = (array |> Array.length) /= 0
 """
@@ -1658,6 +1721,7 @@ a = (array |> Array.length) /= 0
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a : Bool
 a = (array |> (not << Array.isEmpty))
 """
@@ -1665,6 +1729,7 @@ a = (array |> (not << Array.isEmpty))
         , test "should replace 0 /= (array |> Array.length) with (not << Array.isEmpty)" <|
             \() ->
                 """module A exposing (..)
+import Array
 a : Bool
 a = 0 /= (array |> Array.length)
 """
@@ -1678,6 +1743,7 @@ a = 0 /= (array |> Array.length)
                             , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
+import Array
 a : Bool
 a = (array |> (not << Array.isEmpty))
 """

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -936,15 +936,15 @@ a = ({ a = 1 }).a == ({ a = 1 }).b
 a = 1 == ({ a = 1 }).b
 """
                         ]
-        , listTests
-        , setTests
-        , dictTests
-        , arrayTests
+        , listIsEmptyTests
+        , setIsEmptyTests
+        , dictIsEmptyTests
+        , arrayIsEmptyTests
         ]
 
 
-listTests : Test
-listTests =
+listIsEmptyTests : Test
+listIsEmptyTests =
     describe "List.length should be List.isEmpty"
         [ test "should replace List.length l == 0 with List.isEmpty l" <|
             \() ->
@@ -1109,8 +1109,8 @@ a = (l |> (not << List.isEmpty))
         ]
 
 
-setTests : Test
-setTests =
+setIsEmptyTests : Test
+setIsEmptyTests =
     describe "Set.size should be Set.isEmpty"
         [ test "should replace Set.size s == 0 with Set.isEmpty s" <|
             \() ->
@@ -1301,9 +1301,9 @@ a = (s |> (not << Set.isEmpty))
         ]
 
 
-dictTests : Test
-dictTests =
-    describe "Dict.size should be Set.isEmpty"
+dictIsEmptyTests : Test
+dictIsEmptyTests =
+    describe "Dict.size should be Dict.isEmpty"
         [ test "should replace Dict.size d == 0 with Dict.isEmpty d" <|
             \() ->
                 """module A exposing (..)
@@ -1493,9 +1493,9 @@ a = (d |> (not << Dict.isEmpty))
         ]
 
 
-arrayTests : Test
-arrayTests =
-    describe "Array.length should be Set.isEmpty"
+arrayIsEmptyTests : Test
+arrayIsEmptyTests =
+    describe "Array.length should be Array.isEmpty"
         [ test "should replace Array.length array == 0 with Array.isEmpty array" <|
             \() ->
                 """module A exposing (..)

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -936,4 +936,585 @@ a = ({ a = 1 }).a == ({ a = 1 }).b
 a = 1 == ({ a = 1 }).b
 """
                         ]
+        , listTests
+        , setTests
+        , dictTests
+        ]
+
+
+listTests : Test
+listTests =
+    describe "List.length should be List.isEmpty"
+        [ test "should replace List.length l == 0 with List.isEmpty l" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = List.length l == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to List.isEmpty"
+                            , details =
+                                [ "List.length takes as long to run as the list is long"
+                                , "whereas List.isEmpty runs in constant time."
+                                ]
+                            , under = "List.length l == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = List.isEmpty l 
+"""
+                        ]
+        , test "should replace 0 == List.length l with List.isEmpty l" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 == List.length l
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to List.isEmpty"
+                            , details =
+                                [ "List.length takes as long to run as the list is long"
+                                , "whereas List.isEmpty runs in constant time."
+                                ]
+                            , under = "0 == List.length l"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  List.isEmpty l
+"""
+                        ]
+        , test "should replace (l |> List.length) == 0 with List.isEmpty l" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = (l |> List.length) == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to List.isEmpty"
+                            , details =
+                                [ "List.length takes as long to run as the list is long"
+                                , "whereas List.isEmpty runs in constant time."
+                                ]
+                            , under = "(l |> List.length) == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (l |> List.isEmpty) 
+"""
+                        ]
+        , test "should replace 0 == ([] |> List.length) with List.isEmpty l" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 == (l |> List.length)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to List.isEmpty"
+                            , details =
+                                [ "List.length takes as long to run as the list is long"
+                                , "whereas List.isEmpty runs in constant time."
+                                ]
+                            , under = "0 == (l |> List.length)"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (l |> List.isEmpty)
+"""
+                        ]
+        , test "should replace List.length l /= 0 with (not List.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = List.length l /= 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not List.isEmpty)"
+                            , details =
+                                [ "List.length takes as long to run as the list is long"
+                                , "whereas List.isEmpty runs in constant time."
+                                ]
+                            , under = "List.length l /= 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (not List.isEmpty) l 
+"""
+                        ]
+        , test "should replace 0 /= List.length l with (not List.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 /= List.length l
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not List.isEmpty)"
+                            , details =
+                                [ "List.length takes as long to run as the list is long"
+                                , "whereas List.isEmpty runs in constant time."
+                                ]
+                            , under = "0 /= List.length l"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (not List.isEmpty) l
+"""
+                        ]
+        , test "should replace (l |> List.length) /= 0 with (not List.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = (l |> List.length) /= 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not List.isEmpty)"
+                            , details =
+                                [ "List.length takes as long to run as the list is long"
+                                , "whereas List.isEmpty runs in constant time."
+                                ]
+                            , under = "(l |> List.length) /= 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (l |> (not List.isEmpty)) 
+"""
+                        ]
+        , test "should replace 0 /= (l |> List.length) with (not List.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 /= (l |> List.length)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not List.isEmpty)"
+                            , details =
+                                [ "List.length takes as long to run as the list is long"
+                                , "whereas List.isEmpty runs in constant time."
+                                ]
+                            , under = "0 /= (l |> List.length)"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (l |> (not List.isEmpty))
+"""
+                        ]
+        ]
+
+
+setTests : Test
+setTests =
+    describe "Set.size should be Set.isEmpty"
+        [ test "should replace Set.size s == 0 with Set.isEmpty s" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = Set.size s == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Set.isEmpty"
+                            , details =
+                                [ "Set.size takes as long to run as the list is long"
+                                , "whereas Set.isEmpty runs in constant time."
+                                ]
+                            , under = "Set.size s == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = Set.isEmpty s 
+"""
+                        ]
+        , Test.skip <|
+            test "should replace size s == 0 with isEmpty s" <|
+                \() ->
+                    """module A exposing (..)
+import Set as CoreSet exposing (..)
+
+
+a : Bool
+a = size s == 0
+"""
+                        |> Review.Test.run ruleWithDefaults
+                        |> Review.Test.expectErrors
+                            [ Review.Test.error
+                                { message = "This can be replaced with a call to Set.isEmpty"
+                                , details =
+                                    [ "Set.size takes as long to run as the list is long"
+                                    , "whereas Set.isEmpty runs in constant time."
+                                    ]
+                                , under = "size s == 0"
+                                }
+                                |> Review.Test.whenFixed """module A exposing (..)
+import Set as CoreSet exposing (..)
+
+
+a : Bool
+a = isEmpty s 
+"""
+                            ]
+        , test "should replace 0 == Set.size s with Set.isEmpty s" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 == Set.size s
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Set.isEmpty"
+                            , details =
+                                [ "Set.size takes as long to run as the list is long"
+                                , "whereas Set.isEmpty runs in constant time."
+                                ]
+                            , under = "0 == Set.size s"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  Set.isEmpty s
+"""
+                        ]
+        , test "should replace (s |> Set.size) == 0 with Set.isEmpty s" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = (s |> Set.size) == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Set.isEmpty"
+                            , details =
+                                [ "Set.size takes as long to run as the list is long"
+                                , "whereas Set.isEmpty runs in constant time."
+                                ]
+                            , under = "(s |> Set.size) == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (s |> Set.isEmpty) 
+"""
+                        ]
+        , test "should replace 0 == ([] |> Set.size) with Set.isEmpty s" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 == (s |> Set.size)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Set.isEmpty"
+                            , details =
+                                [ "Set.size takes as long to run as the list is long"
+                                , "whereas Set.isEmpty runs in constant time."
+                                ]
+                            , under = "0 == (s |> Set.size)"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (s |> Set.isEmpty)
+"""
+                        ]
+        , test "should replace Set.size s /= 0 with (not Set.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = Set.size s /= 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not Set.isEmpty)"
+                            , details =
+                                [ "Set.size takes as long to run as the list is long"
+                                , "whereas Set.isEmpty runs in constant time."
+                                ]
+                            , under = "Set.size s /= 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (not Set.isEmpty) s 
+"""
+                        ]
+        , test "should replace 0 /= Set.size s with (not Set.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 /= Set.size s
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not Set.isEmpty)"
+                            , details =
+                                [ "Set.size takes as long to run as the list is long"
+                                , "whereas Set.isEmpty runs in constant time."
+                                ]
+                            , under = "0 /= Set.size s"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (not Set.isEmpty) s
+"""
+                        ]
+        , test "should replace (s |> Set.size) /= 0 with (not Set.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = (s |> Set.size) /= 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not Set.isEmpty)"
+                            , details =
+                                [ "Set.size takes as long to run as the list is long"
+                                , "whereas Set.isEmpty runs in constant time."
+                                ]
+                            , under = "(s |> Set.size) /= 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (s |> (not Set.isEmpty)) 
+"""
+                        ]
+        , test "should replace 0 /= (s |> Set.size) with (not Set.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 /= (s |> Set.size)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not Set.isEmpty)"
+                            , details =
+                                [ "Set.size takes as long to run as the list is long"
+                                , "whereas Set.isEmpty runs in constant time."
+                                ]
+                            , under = "0 /= (s |> Set.size)"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (s |> (not Set.isEmpty))
+"""
+                        ]
+        ]
+
+
+dictTests : Test
+dictTests =
+    describe "Dict.size should be Set.isEmpty"
+        [ test "should replace Dict.size d == 0 with Dict.isEmpty d" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = Dict.size d == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Dict.isEmpty"
+                            , details =
+                                [ "Dict.size takes as long to run as the list is long"
+                                , "whereas Dict.isEmpty runs in constant time."
+                                ]
+                            , under = "Dict.size d == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = Dict.isEmpty d 
+"""
+                        ]
+        , Test.skip <|
+            test "should replace size d == 0 with isEmpty d" <|
+                \() ->
+                    """module A exposing (..)
+import Dict as CoreDict exposing (..)
+
+
+a : Bool
+a = size d == 0
+"""
+                        |> Review.Test.run ruleWithDefaults
+                        |> Review.Test.expectErrors
+                            [ Review.Test.error
+                                { message = "This can be replaced with a call to Dict.isEmpty"
+                                , details =
+                                    [ "Dict.size takes as long to run as the list is long"
+                                    , "whereas Dict.isEmpty runs in constant time."
+                                    ]
+                                , under = "size d == 0"
+                                }
+                                |> Review.Test.whenFixed """module A exposing (..)
+import Dict as CoreDict exposing (..)
+
+
+a : Bool
+a = isEmpty d 
+"""
+                            ]
+        , test "should replace 0 == Dict.size d with Dict.isEmpty d" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 == Dict.size d
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Dict.isEmpty"
+                            , details =
+                                [ "Dict.size takes as long to run as the list is long"
+                                , "whereas Dict.isEmpty runs in constant time."
+                                ]
+                            , under = "0 == Dict.size d"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  Dict.isEmpty d
+"""
+                        ]
+        , test "should replace (d |> Dict.size) == 0 with Dict.isEmpty d" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = (d |> Dict.size) == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Dict.isEmpty"
+                            , details =
+                                [ "Dict.size takes as long to run as the list is long"
+                                , "whereas Dict.isEmpty runs in constant time."
+                                ]
+                            , under = "(d |> Dict.size) == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (d |> Dict.isEmpty) 
+"""
+                        ]
+        , test "should replace 0 == ([] |> Dict.size) with Dict.isEmpty d" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 == (d |> Dict.size)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Dict.isEmpty"
+                            , details =
+                                [ "Dict.size takes as long to run as the list is long"
+                                , "whereas Dict.isEmpty runs in constant time."
+                                ]
+                            , under = "0 == (d |> Dict.size)"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (d |> Dict.isEmpty)
+"""
+                        ]
+        , test "should replace Dict.size d /= 0 with (not Dict.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = Dict.size d /= 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not Dict.isEmpty)"
+                            , details =
+                                [ "Dict.size takes as long to run as the list is long"
+                                , "whereas Dict.isEmpty runs in constant time."
+                                ]
+                            , under = "Dict.size d /= 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (not Dict.isEmpty) d 
+"""
+                        ]
+        , test "should replace 0 /= Dict.size d with (not Dict.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 /= Dict.size d
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not Dict.isEmpty)"
+                            , details =
+                                [ "Dict.size takes as long to run as the list is long"
+                                , "whereas Dict.isEmpty runs in constant time."
+                                ]
+                            , under = "0 /= Dict.size d"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (not Dict.isEmpty) d
+"""
+                        ]
+        , test "should replace (d |> Dict.size) /= 0 with (not Dict.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = (d |> Dict.size) /= 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not Dict.isEmpty)"
+                            , details =
+                                [ "Dict.size takes as long to run as the list is long"
+                                , "whereas Dict.isEmpty runs in constant time."
+                                ]
+                            , under = "(d |> Dict.size) /= 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (d |> (not Dict.isEmpty)) 
+"""
+                        ]
+        , test "should replace 0 /= (d |> Dict.size) with (not Dict.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 /= (d |> Dict.size)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not Dict.isEmpty)"
+                            , details =
+                                [ "Dict.size takes as long to run as the list is long"
+                                , "whereas Dict.isEmpty runs in constant time."
+                                ]
+                            , under = "0 /= (d |> Dict.size)"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (d |> (not Dict.isEmpty))
+"""
+                        ]
         ]

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -939,6 +939,7 @@ a = 1 == ({ a = 1 }).b
         , listTests
         , setTests
         , dictTests
+        , arrayTests
         ]
 
 
@@ -1513,6 +1514,207 @@ a = 0 /= (d |> Dict.size)
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
 a =  (d |> (not << Dict.isEmpty))
+"""
+                        ]
+        ]
+
+
+arrayTests : Test
+arrayTests =
+    describe "Array.length should be Set.isEmpty"
+        [ test "should replace Array.length array == 0 with Array.isEmpty array" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = Array.length array == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Array.isEmpty"
+                            , details =
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
+                                , "Array.isEmpty runs in constant time."
+                                ]
+                            , under = "Array.length array == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = Array.isEmpty array 
+"""
+                        ]
+        , test "should replace length array == 0 with isEmpty array" <|
+            \() ->
+                """module A exposing (..)
+import Array as SomethingElse exposing (..)
+
+
+a : Bool
+a = length array == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to isEmpty"
+                            , details =
+                                [ "Whereas length takes as long to run as the number of elements in the Array,"
+                                , "isEmpty runs in constant time."
+                                ]
+                            , under = "length array == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Array as SomethingElse exposing (..)
+
+
+a : Bool
+a = isEmpty array 
+"""
+                        ]
+        , test "should replace 0 == Array.length array with Array.isEmpty array" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 == Array.length array
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Array.isEmpty"
+                            , details =
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
+                                , "Array.isEmpty runs in constant time."
+                                ]
+                            , under = "0 == Array.length array"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  Array.isEmpty array
+"""
+                        ]
+        , test "should replace (array |> Array.length) == 0 with Array.isEmpty array" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = (array |> Array.length) == 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Array.isEmpty"
+                            , details =
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
+                                , "Array.isEmpty runs in constant time."
+                                ]
+                            , under = "(array |> Array.length) == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (array |> Array.isEmpty) 
+"""
+                        ]
+        , test "should replace 0 == ([] |> Array.length) with Array.isEmpty array" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 == (array |> Array.length)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to Array.isEmpty"
+                            , details =
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
+                                , "Array.isEmpty runs in constant time."
+                                ]
+                            , under = "0 == (array |> Array.length)"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (array |> Array.isEmpty)
+"""
+                        ]
+        , test "should replace Array.length array /= 0 with (not << Array.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = Array.length array /= 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not << Array.isEmpty)"
+                            , details =
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
+                                , "Array.isEmpty runs in constant time."
+                                ]
+                            , under = "Array.length array /= 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (not << Array.isEmpty) array 
+"""
+                        ]
+        , test "should replace 0 /= Array.length array with (not << Array.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 /= Array.length array
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not << Array.isEmpty)"
+                            , details =
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
+                                , "Array.isEmpty runs in constant time."
+                                ]
+                            , under = "0 /= Array.length array"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (not << Array.isEmpty) array
+"""
+                        ]
+        , test "should replace (array |> Array.length) /= 0 with (not << Array.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = (array |> Array.length) /= 0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not << Array.isEmpty)"
+                            , details =
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
+                                , "Array.isEmpty runs in constant time."
+                                ]
+                            , under = "(array |> Array.length) /= 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a = (array |> (not << Array.isEmpty)) 
+"""
+                        ]
+        , test "should replace 0 /= (array |> Array.length) with (not << Array.isEmpty)" <|
+            \() ->
+                """module A exposing (..)
+a : Bool
+a = 0 /= (array |> Array.length)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to (not << Array.isEmpty)"
+                            , details =
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
+                                , "Array.isEmpty runs in constant time."
+                                ]
+                            , under = "0 /= (array |> Array.length)"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a : Bool
+a =  (array |> (not << Array.isEmpty))
 """
                         ]
         ]

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -957,8 +957,7 @@ a = List.length l == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to List.isEmpty"
                             , details =
-                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
-                                , "List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
                             , under = "List.length l == 0"
                             }
@@ -978,8 +977,7 @@ a = 0 == List.length l
                         [ Review.Test.error
                             { message = "This can be replaced with a call to List.isEmpty"
                             , details =
-                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
-                                , "List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
                             , under = "0 == List.length l"
                             }
@@ -999,8 +997,7 @@ a = (l |> List.length) == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to List.isEmpty"
                             , details =
-                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
-                                , "List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
                             , under = "(l |> List.length) == 0"
                             }
@@ -1020,8 +1017,7 @@ a = 0 == (l |> List.length)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to List.isEmpty"
                             , details =
-                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
-                                , "List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
                             , under = "0 == (l |> List.length)"
                             }
@@ -1041,8 +1037,7 @@ a = List.length l /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << List.isEmpty)"
                             , details =
-                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
-                                , "List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
                             , under = "List.length l /= 0"
                             }
@@ -1062,8 +1057,7 @@ a = 0 /= List.length l
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << List.isEmpty)"
                             , details =
-                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
-                                , "List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= List.length l"
                             }
@@ -1083,8 +1077,7 @@ a = (l |> List.length) /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << List.isEmpty)"
                             , details =
-                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
-                                , "List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
                             , under = "(l |> List.length) /= 0"
                             }
@@ -1104,8 +1097,7 @@ a = 0 /= (l |> List.length)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << List.isEmpty)"
                             , details =
-                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
-                                , "List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= (l |> List.length)"
                             }
@@ -1131,8 +1123,7 @@ a = Set.size s == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Set.isEmpty"
                             , details =
-                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
-                                , "Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
                             , under = "Set.size s == 0"
                             }
@@ -1155,8 +1146,7 @@ a = size s == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to isEmpty"
                             , details =
-                                [ "Whereas size takes as long to run as the number of elements in the Set,"
-                                , "isEmpty runs in constant time."
+                                [ "Whereas size takes as long to run as the number of elements in the Set, isEmpty runs in constant time."
                                 ]
                             , under = "size s == 0"
                             }
@@ -1179,8 +1169,7 @@ a = 0 == Set.size s
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Set.isEmpty"
                             , details =
-                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
-                                , "Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
                             , under = "0 == Set.size s"
                             }
@@ -1200,8 +1189,7 @@ a = (s |> Set.size) == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Set.isEmpty"
                             , details =
-                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
-                                , "Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
                             , under = "(s |> Set.size) == 0"
                             }
@@ -1221,8 +1209,7 @@ a = 0 == (s |> Set.size)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Set.isEmpty"
                             , details =
-                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
-                                , "Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
                             , under = "0 == (s |> Set.size)"
                             }
@@ -1242,8 +1229,7 @@ a = Set.size s /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Set.isEmpty)"
                             , details =
-                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
-                                , "Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
                             , under = "Set.size s /= 0"
                             }
@@ -1263,8 +1249,7 @@ a = 0 /= Set.size s
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Set.isEmpty)"
                             , details =
-                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
-                                , "Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= Set.size s"
                             }
@@ -1284,8 +1269,7 @@ a = (s |> Set.size) /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Set.isEmpty)"
                             , details =
-                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
-                                , "Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
                             , under = "(s |> Set.size) /= 0"
                             }
@@ -1305,8 +1289,7 @@ a = 0 /= (s |> Set.size)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Set.isEmpty)"
                             , details =
-                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
-                                , "Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= (s |> Set.size)"
                             }
@@ -1332,8 +1315,7 @@ a = Dict.size d == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Dict.isEmpty"
                             , details =
-                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
-                                , "Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
                             , under = "Dict.size d == 0"
                             }
@@ -1356,8 +1338,7 @@ a = size d == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to isEmpty"
                             , details =
-                                [ "Whereas size takes as long to run as the number of elements in the Dict,"
-                                , "isEmpty runs in constant time."
+                                [ "Whereas size takes as long to run as the number of elements in the Dict, isEmpty runs in constant time."
                                 ]
                             , under = "size d == 0"
                             }
@@ -1380,8 +1361,7 @@ a = 0 == Dict.size d
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Dict.isEmpty"
                             , details =
-                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
-                                , "Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
                             , under = "0 == Dict.size d"
                             }
@@ -1401,8 +1381,7 @@ a = (d |> Dict.size) == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Dict.isEmpty"
                             , details =
-                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
-                                , "Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
                             , under = "(d |> Dict.size) == 0"
                             }
@@ -1422,8 +1401,7 @@ a = 0 == (d |> Dict.size)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Dict.isEmpty"
                             , details =
-                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
-                                , "Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
                             , under = "0 == (d |> Dict.size)"
                             }
@@ -1443,8 +1421,7 @@ a = Dict.size d /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Dict.isEmpty)"
                             , details =
-                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
-                                , "Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
                             , under = "Dict.size d /= 0"
                             }
@@ -1464,8 +1441,7 @@ a = 0 /= Dict.size d
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Dict.isEmpty)"
                             , details =
-                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
-                                , "Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= Dict.size d"
                             }
@@ -1485,8 +1461,7 @@ a = (d |> Dict.size) /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Dict.isEmpty)"
                             , details =
-                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
-                                , "Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
                             , under = "(d |> Dict.size) /= 0"
                             }
@@ -1506,8 +1481,7 @@ a = 0 /= (d |> Dict.size)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Dict.isEmpty)"
                             , details =
-                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
-                                , "Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= (d |> Dict.size)"
                             }
@@ -1533,8 +1507,7 @@ a = Array.length array == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Array.isEmpty"
                             , details =
-                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
-                                , "Array.isEmpty runs in constant time."
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
                             , under = "Array.length array == 0"
                             }
@@ -1557,8 +1530,7 @@ a = length array == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to isEmpty"
                             , details =
-                                [ "Whereas length takes as long to run as the number of elements in the Array,"
-                                , "isEmpty runs in constant time."
+                                [ "Whereas length takes as long to run as the number of elements in the Array, isEmpty runs in constant time."
                                 ]
                             , under = "length array == 0"
                             }
@@ -1581,8 +1553,7 @@ a = 0 == Array.length array
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Array.isEmpty"
                             , details =
-                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
-                                , "Array.isEmpty runs in constant time."
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
                             , under = "0 == Array.length array"
                             }
@@ -1602,8 +1573,7 @@ a = (array |> Array.length) == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Array.isEmpty"
                             , details =
-                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
-                                , "Array.isEmpty runs in constant time."
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
                             , under = "(array |> Array.length) == 0"
                             }
@@ -1623,8 +1593,7 @@ a = 0 == (array |> Array.length)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Array.isEmpty"
                             , details =
-                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
-                                , "Array.isEmpty runs in constant time."
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
                             , under = "0 == (array |> Array.length)"
                             }
@@ -1644,8 +1613,7 @@ a = Array.length array /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Array.isEmpty)"
                             , details =
-                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
-                                , "Array.isEmpty runs in constant time."
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
                             , under = "Array.length array /= 0"
                             }
@@ -1665,8 +1633,7 @@ a = 0 /= Array.length array
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Array.isEmpty)"
                             , details =
-                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
-                                , "Array.isEmpty runs in constant time."
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= Array.length array"
                             }
@@ -1686,8 +1653,7 @@ a = (array |> Array.length) /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Array.isEmpty)"
                             , details =
-                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
-                                , "Array.isEmpty runs in constant time."
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
                             , under = "(array |> Array.length) /= 0"
                             }
@@ -1707,8 +1673,7 @@ a = 0 /= (array |> Array.length)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not << Array.isEmpty)"
                             , details =
-                                [ "Whereas Array.length takes as long to run as the number of elements in the Array,"
-                                , "Array.isEmpty runs in constant time."
+                                [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= (array |> Array.length)"
                             }

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -964,7 +964,7 @@ a = List.length l == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = List.isEmpty l 
+a = List.isEmpty l
 """
                         ]
         , test "should replace 0 == List.length l with List.isEmpty l" <|
@@ -985,7 +985,7 @@ a = 0 == List.length l
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  List.isEmpty l
+a = List.isEmpty l
 """
                         ]
         , test "should replace (l |> List.length) == 0 with List.isEmpty l" <|
@@ -1006,7 +1006,7 @@ a = (l |> List.length) == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (l |> List.isEmpty) 
+a = (l |> List.isEmpty)
 """
                         ]
         , test "should replace 0 == ([] |> List.length) with List.isEmpty l" <|
@@ -1027,7 +1027,7 @@ a = 0 == (l |> List.length)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (l |> List.isEmpty)
+a = (l |> List.isEmpty)
 """
                         ]
         , test "should replace List.length l /= 0 with (not << List.isEmpty)" <|
@@ -1048,7 +1048,7 @@ a = List.length l /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (not << List.isEmpty) l 
+a = (not << List.isEmpty) l
 """
                         ]
         , test "should replace 0 /= List.length l with (not << List.isEmpty)" <|
@@ -1069,7 +1069,7 @@ a = 0 /= List.length l
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (not << List.isEmpty) l
+a = (not << List.isEmpty) l
 """
                         ]
         , test "should replace (l |> List.length) /= 0 with (not << List.isEmpty)" <|
@@ -1090,7 +1090,7 @@ a = (l |> List.length) /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (l |> (not << List.isEmpty)) 
+a = (l |> (not << List.isEmpty))
 """
                         ]
         , test "should replace 0 /= (l |> List.length) with (not << List.isEmpty)" <|
@@ -1111,7 +1111,7 @@ a = 0 /= (l |> List.length)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (l |> (not << List.isEmpty))
+a = (l |> (not << List.isEmpty))
 """
                         ]
         ]
@@ -1138,7 +1138,7 @@ a = Set.size s == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = Set.isEmpty s 
+a = Set.isEmpty s
 """
                         ]
         , test "should replace size s == 0 with isEmpty s" <|
@@ -1165,7 +1165,7 @@ import Set as CoreSet exposing (..)
 
 
 a : Bool
-a = isEmpty s 
+a = isEmpty s
 """
                         ]
         , test "should replace 0 == Set.size s with Set.isEmpty s" <|
@@ -1186,7 +1186,7 @@ a = 0 == Set.size s
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  Set.isEmpty s
+a = Set.isEmpty s
 """
                         ]
         , test "should replace (s |> Set.size) == 0 with Set.isEmpty s" <|
@@ -1207,7 +1207,7 @@ a = (s |> Set.size) == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (s |> Set.isEmpty) 
+a = (s |> Set.isEmpty)
 """
                         ]
         , test "should replace 0 == ([] |> Set.size) with Set.isEmpty s" <|
@@ -1228,7 +1228,7 @@ a = 0 == (s |> Set.size)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (s |> Set.isEmpty)
+a = (s |> Set.isEmpty)
 """
                         ]
         , test "should replace Set.size s /= 0 with (not << Set.isEmpty)" <|
@@ -1249,7 +1249,7 @@ a = Set.size s /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (not << Set.isEmpty) s 
+a = (not << Set.isEmpty) s
 """
                         ]
         , test "should replace 0 /= Set.size s with (not << Set.isEmpty)" <|
@@ -1270,7 +1270,7 @@ a = 0 /= Set.size s
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (not << Set.isEmpty) s
+a = (not << Set.isEmpty) s
 """
                         ]
         , test "should replace (s |> Set.size) /= 0 with (not << Set.isEmpty)" <|
@@ -1291,7 +1291,7 @@ a = (s |> Set.size) /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (s |> (not << Set.isEmpty)) 
+a = (s |> (not << Set.isEmpty))
 """
                         ]
         , test "should replace 0 /= (s |> Set.size) with (not << Set.isEmpty)" <|
@@ -1312,7 +1312,7 @@ a = 0 /= (s |> Set.size)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (s |> (not << Set.isEmpty))
+a = (s |> (not << Set.isEmpty))
 """
                         ]
         ]
@@ -1339,7 +1339,7 @@ a = Dict.size d == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = Dict.isEmpty d 
+a = Dict.isEmpty d
 """
                         ]
         , test "should replace size d == 0 with isEmpty d" <|
@@ -1366,7 +1366,7 @@ import Dict as CoreDict exposing (..)
 
 
 a : Bool
-a = isEmpty d 
+a = isEmpty d
 """
                         ]
         , test "should replace 0 == Dict.size d with Dict.isEmpty d" <|
@@ -1387,7 +1387,7 @@ a = 0 == Dict.size d
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  Dict.isEmpty d
+a = Dict.isEmpty d
 """
                         ]
         , test "should replace (d |> Dict.size) == 0 with Dict.isEmpty d" <|
@@ -1408,7 +1408,7 @@ a = (d |> Dict.size) == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (d |> Dict.isEmpty) 
+a = (d |> Dict.isEmpty)
 """
                         ]
         , test "should replace 0 == ([] |> Dict.size) with Dict.isEmpty d" <|
@@ -1429,7 +1429,7 @@ a = 0 == (d |> Dict.size)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (d |> Dict.isEmpty)
+a = (d |> Dict.isEmpty)
 """
                         ]
         , test "should replace Dict.size d /= 0 with (not << Dict.isEmpty)" <|
@@ -1450,7 +1450,7 @@ a = Dict.size d /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (not << Dict.isEmpty) d 
+a = (not << Dict.isEmpty) d
 """
                         ]
         , test "should replace 0 /= Dict.size d with (not << Dict.isEmpty)" <|
@@ -1471,7 +1471,7 @@ a = 0 /= Dict.size d
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (not << Dict.isEmpty) d
+a = (not << Dict.isEmpty) d
 """
                         ]
         , test "should replace (d |> Dict.size) /= 0 with (not << Dict.isEmpty)" <|
@@ -1492,7 +1492,7 @@ a = (d |> Dict.size) /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (d |> (not << Dict.isEmpty)) 
+a = (d |> (not << Dict.isEmpty))
 """
                         ]
         , test "should replace 0 /= (d |> Dict.size) with (not << Dict.isEmpty)" <|
@@ -1513,7 +1513,7 @@ a = 0 /= (d |> Dict.size)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (d |> (not << Dict.isEmpty))
+a = (d |> (not << Dict.isEmpty))
 """
                         ]
         ]
@@ -1540,7 +1540,7 @@ a = Array.length array == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = Array.isEmpty array 
+a = Array.isEmpty array
 """
                         ]
         , test "should replace length array == 0 with isEmpty array" <|
@@ -1567,7 +1567,7 @@ import Array as SomethingElse exposing (..)
 
 
 a : Bool
-a = isEmpty array 
+a = isEmpty array
 """
                         ]
         , test "should replace 0 == Array.length array with Array.isEmpty array" <|
@@ -1588,7 +1588,7 @@ a = 0 == Array.length array
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  Array.isEmpty array
+a = Array.isEmpty array
 """
                         ]
         , test "should replace (array |> Array.length) == 0 with Array.isEmpty array" <|
@@ -1609,7 +1609,7 @@ a = (array |> Array.length) == 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (array |> Array.isEmpty) 
+a = (array |> Array.isEmpty)
 """
                         ]
         , test "should replace 0 == ([] |> Array.length) with Array.isEmpty array" <|
@@ -1630,7 +1630,7 @@ a = 0 == (array |> Array.length)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (array |> Array.isEmpty)
+a = (array |> Array.isEmpty)
 """
                         ]
         , test "should replace Array.length array /= 0 with (not << Array.isEmpty)" <|
@@ -1651,7 +1651,7 @@ a = Array.length array /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (not << Array.isEmpty) array 
+a = (not << Array.isEmpty) array
 """
                         ]
         , test "should replace 0 /= Array.length array with (not << Array.isEmpty)" <|
@@ -1672,7 +1672,7 @@ a = 0 /= Array.length array
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (not << Array.isEmpty) array
+a = (not << Array.isEmpty) array
 """
                         ]
         , test "should replace (array |> Array.length) /= 0 with (not << Array.isEmpty)" <|
@@ -1693,7 +1693,7 @@ a = (array |> Array.length) /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (array |> (not << Array.isEmpty)) 
+a = (array |> (not << Array.isEmpty))
 """
                         ]
         , test "should replace 0 /= (array |> Array.length) with (not << Array.isEmpty)" <|
@@ -1714,7 +1714,7 @@ a = 0 /= (array |> Array.length)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (array |> (not << Array.isEmpty))
+a = (array |> (not << Array.isEmpty))
 """
                         ]
         ]

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -959,7 +959,7 @@ a = List.length l == 0
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
-                            , under = "List.length l == 0"
+                            , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -979,7 +979,7 @@ a = 0 == List.length l
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
-                            , under = "0 == List.length l"
+                            , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -999,7 +999,7 @@ a = (l |> List.length) == 0
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
-                            , under = "(l |> List.length) == 0"
+                            , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1019,7 +1019,7 @@ a = 0 == (l |> List.length)
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
-                            , under = "0 == (l |> List.length)"
+                            , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1039,7 +1039,7 @@ a = List.length l /= 0
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
-                            , under = "List.length l /= 0"
+                            , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1059,7 +1059,7 @@ a = 0 /= List.length l
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
-                            , under = "0 /= List.length l"
+                            , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1079,7 +1079,7 @@ a = (l |> List.length) /= 0
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
-                            , under = "(l |> List.length) /= 0"
+                            , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1099,7 +1099,7 @@ a = 0 /= (l |> List.length)
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List, List.isEmpty runs in constant time."
                                 ]
-                            , under = "0 /= (l |> List.length)"
+                            , under = "List.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1125,7 +1125,7 @@ a = Set.size s == 0
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
-                            , under = "Set.size s == 0"
+                            , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1148,7 +1148,7 @@ a = size s == 0
                             , details =
                                 [ "Whereas size takes as long to run as the number of elements in the Set, isEmpty runs in constant time."
                                 ]
-                            , under = "size s == 0"
+                            , under = "size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Set as CoreSet exposing (..)
@@ -1171,7 +1171,7 @@ a = 0 == Set.size s
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
-                            , under = "0 == Set.size s"
+                            , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1191,7 +1191,7 @@ a = (s |> Set.size) == 0
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
-                            , under = "(s |> Set.size) == 0"
+                            , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1211,7 +1211,7 @@ a = 0 == (s |> Set.size)
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
-                            , under = "0 == (s |> Set.size)"
+                            , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1231,7 +1231,7 @@ a = Set.size s /= 0
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
-                            , under = "Set.size s /= 0"
+                            , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1251,7 +1251,7 @@ a = 0 /= Set.size s
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
-                            , under = "0 /= Set.size s"
+                            , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1271,7 +1271,7 @@ a = (s |> Set.size) /= 0
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
-                            , under = "(s |> Set.size) /= 0"
+                            , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1291,7 +1291,7 @@ a = 0 /= (s |> Set.size)
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set, Set.isEmpty runs in constant time."
                                 ]
-                            , under = "0 /= (s |> Set.size)"
+                            , under = "Set.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1317,7 +1317,7 @@ a = Dict.size d == 0
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
-                            , under = "Dict.size d == 0"
+                            , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1340,7 +1340,7 @@ a = size d == 0
                             , details =
                                 [ "Whereas size takes as long to run as the number of elements in the Dict, isEmpty runs in constant time."
                                 ]
-                            , under = "size d == 0"
+                            , under = "size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict as CoreDict exposing (..)
@@ -1363,7 +1363,7 @@ a = 0 == Dict.size d
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
-                            , under = "0 == Dict.size d"
+                            , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1383,7 +1383,7 @@ a = (d |> Dict.size) == 0
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
-                            , under = "(d |> Dict.size) == 0"
+                            , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1403,7 +1403,7 @@ a = 0 == (d |> Dict.size)
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
-                            , under = "0 == (d |> Dict.size)"
+                            , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1423,7 +1423,7 @@ a = Dict.size d /= 0
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
-                            , under = "Dict.size d /= 0"
+                            , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1443,7 +1443,7 @@ a = 0 /= Dict.size d
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
-                            , under = "0 /= Dict.size d"
+                            , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1463,7 +1463,7 @@ a = (d |> Dict.size) /= 0
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
-                            , under = "(d |> Dict.size) /= 0"
+                            , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1483,7 +1483,7 @@ a = 0 /= (d |> Dict.size)
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict, Dict.isEmpty runs in constant time."
                                 ]
-                            , under = "0 /= (d |> Dict.size)"
+                            , under = "Dict.size"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1509,7 +1509,7 @@ a = Array.length array == 0
                             , details =
                                 [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
-                            , under = "Array.length array == 0"
+                            , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1532,7 +1532,7 @@ a = length array == 0
                             , details =
                                 [ "Whereas length takes as long to run as the number of elements in the Array, isEmpty runs in constant time."
                                 ]
-                            , under = "length array == 0"
+                            , under = "length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Array as SomethingElse exposing (..)
@@ -1555,7 +1555,7 @@ a = 0 == Array.length array
                             , details =
                                 [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
-                            , under = "0 == Array.length array"
+                            , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1575,7 +1575,7 @@ a = (array |> Array.length) == 0
                             , details =
                                 [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
-                            , under = "(array |> Array.length) == 0"
+                            , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1595,7 +1595,7 @@ a = 0 == (array |> Array.length)
                             , details =
                                 [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
-                            , under = "0 == (array |> Array.length)"
+                            , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1615,7 +1615,7 @@ a = Array.length array /= 0
                             , details =
                                 [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
-                            , under = "Array.length array /= 0"
+                            , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1635,7 +1635,7 @@ a = 0 /= Array.length array
                             , details =
                                 [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
-                            , under = "0 /= Array.length array"
+                            , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1655,7 +1655,7 @@ a = (array |> Array.length) /= 0
                             , details =
                                 [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
-                            , under = "(array |> Array.length) /= 0"
+                            , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
@@ -1675,7 +1675,7 @@ a = 0 /= (array |> Array.length)
                             , details =
                                 [ "Whereas Array.length takes as long to run as the number of elements in the Array, Array.isEmpty runs in constant time."
                                 ]
-                            , under = "0 /= (array |> Array.length)"
+                            , under = "Array.length"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -1029,7 +1029,7 @@ a : Bool
 a =  (l |> List.isEmpty)
 """
                         ]
-        , test "should replace List.length l /= 0 with (not List.isEmpty)" <|
+        , test "should replace List.length l /= 0 with (not << List.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1038,7 +1038,7 @@ a = List.length l /= 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not List.isEmpty)"
+                            { message = "This can be replaced with a call to (not << List.isEmpty)"
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List,"
                                 , "List.isEmpty runs in constant time."
@@ -1047,10 +1047,10 @@ a = List.length l /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (not List.isEmpty) l 
+a = (not << List.isEmpty) l 
 """
                         ]
-        , test "should replace 0 /= List.length l with (not List.isEmpty)" <|
+        , test "should replace 0 /= List.length l with (not << List.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1059,7 +1059,7 @@ a = 0 /= List.length l
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not List.isEmpty)"
+                            { message = "This can be replaced with a call to (not << List.isEmpty)"
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List,"
                                 , "List.isEmpty runs in constant time."
@@ -1068,10 +1068,10 @@ a = 0 /= List.length l
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (not List.isEmpty) l
+a =  (not << List.isEmpty) l
 """
                         ]
-        , test "should replace (l |> List.length) /= 0 with (not List.isEmpty)" <|
+        , test "should replace (l |> List.length) /= 0 with (not << List.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1080,7 +1080,7 @@ a = (l |> List.length) /= 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not List.isEmpty)"
+                            { message = "This can be replaced with a call to (not << List.isEmpty)"
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List,"
                                 , "List.isEmpty runs in constant time."
@@ -1089,10 +1089,10 @@ a = (l |> List.length) /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (l |> (not List.isEmpty)) 
+a = (l |> (not << List.isEmpty)) 
 """
                         ]
-        , test "should replace 0 /= (l |> List.length) with (not List.isEmpty)" <|
+        , test "should replace 0 /= (l |> List.length) with (not << List.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1101,7 +1101,7 @@ a = 0 /= (l |> List.length)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not List.isEmpty)"
+                            { message = "This can be replaced with a call to (not << List.isEmpty)"
                             , details =
                                 [ "Whereas List.length takes as long to run as the number of elements in the List,"
                                 , "List.isEmpty runs in constant time."
@@ -1110,7 +1110,7 @@ a = 0 /= (l |> List.length)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (l |> (not List.isEmpty))
+a =  (l |> (not << List.isEmpty))
 """
                         ]
         ]
@@ -1230,7 +1230,7 @@ a : Bool
 a =  (s |> Set.isEmpty)
 """
                         ]
-        , test "should replace Set.size s /= 0 with (not Set.isEmpty)" <|
+        , test "should replace Set.size s /= 0 with (not << Set.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1239,7 +1239,7 @@ a = Set.size s /= 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not Set.isEmpty)"
+                            { message = "This can be replaced with a call to (not << Set.isEmpty)"
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
                                 , "Set.isEmpty runs in constant time."
@@ -1248,10 +1248,10 @@ a = Set.size s /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (not Set.isEmpty) s 
+a = (not << Set.isEmpty) s 
 """
                         ]
-        , test "should replace 0 /= Set.size s with (not Set.isEmpty)" <|
+        , test "should replace 0 /= Set.size s with (not << Set.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1260,7 +1260,7 @@ a = 0 /= Set.size s
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not Set.isEmpty)"
+                            { message = "This can be replaced with a call to (not << Set.isEmpty)"
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
                                 , "Set.isEmpty runs in constant time."
@@ -1269,10 +1269,10 @@ a = 0 /= Set.size s
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (not Set.isEmpty) s
+a =  (not << Set.isEmpty) s
 """
                         ]
-        , test "should replace (s |> Set.size) /= 0 with (not Set.isEmpty)" <|
+        , test "should replace (s |> Set.size) /= 0 with (not << Set.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1281,7 +1281,7 @@ a = (s |> Set.size) /= 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not Set.isEmpty)"
+                            { message = "This can be replaced with a call to (not << Set.isEmpty)"
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
                                 , "Set.isEmpty runs in constant time."
@@ -1290,10 +1290,10 @@ a = (s |> Set.size) /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (s |> (not Set.isEmpty)) 
+a = (s |> (not << Set.isEmpty)) 
 """
                         ]
-        , test "should replace 0 /= (s |> Set.size) with (not Set.isEmpty)" <|
+        , test "should replace 0 /= (s |> Set.size) with (not << Set.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1302,7 +1302,7 @@ a = 0 /= (s |> Set.size)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not Set.isEmpty)"
+                            { message = "This can be replaced with a call to (not << Set.isEmpty)"
                             , details =
                                 [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
                                 , "Set.isEmpty runs in constant time."
@@ -1311,7 +1311,7 @@ a = 0 /= (s |> Set.size)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (s |> (not Set.isEmpty))
+a =  (s |> (not << Set.isEmpty))
 """
                         ]
         ]
@@ -1431,7 +1431,7 @@ a : Bool
 a =  (d |> Dict.isEmpty)
 """
                         ]
-        , test "should replace Dict.size d /= 0 with (not Dict.isEmpty)" <|
+        , test "should replace Dict.size d /= 0 with (not << Dict.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1440,7 +1440,7 @@ a = Dict.size d /= 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not Dict.isEmpty)"
+                            { message = "This can be replaced with a call to (not << Dict.isEmpty)"
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
                                 , "Dict.isEmpty runs in constant time."
@@ -1449,10 +1449,10 @@ a = Dict.size d /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (not Dict.isEmpty) d 
+a = (not << Dict.isEmpty) d 
 """
                         ]
-        , test "should replace 0 /= Dict.size d with (not Dict.isEmpty)" <|
+        , test "should replace 0 /= Dict.size d with (not << Dict.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1461,7 +1461,7 @@ a = 0 /= Dict.size d
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not Dict.isEmpty)"
+                            { message = "This can be replaced with a call to (not << Dict.isEmpty)"
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
                                 , "Dict.isEmpty runs in constant time."
@@ -1470,10 +1470,10 @@ a = 0 /= Dict.size d
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (not Dict.isEmpty) d
+a =  (not << Dict.isEmpty) d
 """
                         ]
-        , test "should replace (d |> Dict.size) /= 0 with (not Dict.isEmpty)" <|
+        , test "should replace (d |> Dict.size) /= 0 with (not << Dict.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1482,7 +1482,7 @@ a = (d |> Dict.size) /= 0
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not Dict.isEmpty)"
+                            { message = "This can be replaced with a call to (not << Dict.isEmpty)"
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
                                 , "Dict.isEmpty runs in constant time."
@@ -1491,10 +1491,10 @@ a = (d |> Dict.size) /= 0
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a = (d |> (not Dict.isEmpty)) 
+a = (d |> (not << Dict.isEmpty)) 
 """
                         ]
-        , test "should replace 0 /= (d |> Dict.size) with (not Dict.isEmpty)" <|
+        , test "should replace 0 /= (d |> Dict.size) with (not << Dict.isEmpty)" <|
             \() ->
                 """module A exposing (..)
 a : Bool
@@ -1503,7 +1503,7 @@ a = 0 /= (d |> Dict.size)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "This can be replaced with a call to (not Dict.isEmpty)"
+                            { message = "This can be replaced with a call to (not << Dict.isEmpty)"
                             , details =
                                 [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
                                 , "Dict.isEmpty runs in constant time."
@@ -1512,7 +1512,7 @@ a = 0 /= (d |> Dict.size)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a : Bool
-a =  (d |> (not Dict.isEmpty))
+a =  (d |> (not << Dict.isEmpty))
 """
                         ]
         ]

--- a/tests/Simplify/EqualTest.elm
+++ b/tests/Simplify/EqualTest.elm
@@ -956,8 +956,8 @@ a = List.length l == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to List.isEmpty"
                             , details =
-                                [ "List.length takes as long to run as the list is long"
-                                , "whereas List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
+                                , "List.isEmpty runs in constant time."
                                 ]
                             , under = "List.length l == 0"
                             }
@@ -977,8 +977,8 @@ a = 0 == List.length l
                         [ Review.Test.error
                             { message = "This can be replaced with a call to List.isEmpty"
                             , details =
-                                [ "List.length takes as long to run as the list is long"
-                                , "whereas List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
+                                , "List.isEmpty runs in constant time."
                                 ]
                             , under = "0 == List.length l"
                             }
@@ -998,8 +998,8 @@ a = (l |> List.length) == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to List.isEmpty"
                             , details =
-                                [ "List.length takes as long to run as the list is long"
-                                , "whereas List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
+                                , "List.isEmpty runs in constant time."
                                 ]
                             , under = "(l |> List.length) == 0"
                             }
@@ -1019,8 +1019,8 @@ a = 0 == (l |> List.length)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to List.isEmpty"
                             , details =
-                                [ "List.length takes as long to run as the list is long"
-                                , "whereas List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
+                                , "List.isEmpty runs in constant time."
                                 ]
                             , under = "0 == (l |> List.length)"
                             }
@@ -1040,8 +1040,8 @@ a = List.length l /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not List.isEmpty)"
                             , details =
-                                [ "List.length takes as long to run as the list is long"
-                                , "whereas List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
+                                , "List.isEmpty runs in constant time."
                                 ]
                             , under = "List.length l /= 0"
                             }
@@ -1061,8 +1061,8 @@ a = 0 /= List.length l
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not List.isEmpty)"
                             , details =
-                                [ "List.length takes as long to run as the list is long"
-                                , "whereas List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
+                                , "List.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= List.length l"
                             }
@@ -1082,8 +1082,8 @@ a = (l |> List.length) /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not List.isEmpty)"
                             , details =
-                                [ "List.length takes as long to run as the list is long"
-                                , "whereas List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
+                                , "List.isEmpty runs in constant time."
                                 ]
                             , under = "(l |> List.length) /= 0"
                             }
@@ -1103,8 +1103,8 @@ a = 0 /= (l |> List.length)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not List.isEmpty)"
                             , details =
-                                [ "List.length takes as long to run as the list is long"
-                                , "whereas List.isEmpty runs in constant time."
+                                [ "Whereas List.length takes as long to run as the number of elements in the List,"
+                                , "List.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= (l |> List.length)"
                             }
@@ -1130,8 +1130,8 @@ a = Set.size s == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Set.isEmpty"
                             , details =
-                                [ "Set.size takes as long to run as the list is long"
-                                , "whereas Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
+                                , "Set.isEmpty runs in constant time."
                                 ]
                             , under = "Set.size s == 0"
                             }
@@ -1140,34 +1140,33 @@ a : Bool
 a = Set.isEmpty s 
 """
                         ]
-        , Test.skip <|
-            test "should replace size s == 0 with isEmpty s" <|
-                \() ->
-                    """module A exposing (..)
+        , test "should replace size s == 0 with isEmpty s" <|
+            \() ->
+                """module A exposing (..)
 import Set as CoreSet exposing (..)
 
 
 a : Bool
 a = size s == 0
 """
-                        |> Review.Test.run ruleWithDefaults
-                        |> Review.Test.expectErrors
-                            [ Review.Test.error
-                                { message = "This can be replaced with a call to Set.isEmpty"
-                                , details =
-                                    [ "Set.size takes as long to run as the list is long"
-                                    , "whereas Set.isEmpty runs in constant time."
-                                    ]
-                                , under = "size s == 0"
-                                }
-                                |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to isEmpty"
+                            , details =
+                                [ "Whereas size takes as long to run as the number of elements in the Set,"
+                                , "isEmpty runs in constant time."
+                                ]
+                            , under = "size s == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 import Set as CoreSet exposing (..)
 
 
 a : Bool
 a = isEmpty s 
 """
-                            ]
+                        ]
         , test "should replace 0 == Set.size s with Set.isEmpty s" <|
             \() ->
                 """module A exposing (..)
@@ -1179,8 +1178,8 @@ a = 0 == Set.size s
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Set.isEmpty"
                             , details =
-                                [ "Set.size takes as long to run as the list is long"
-                                , "whereas Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
+                                , "Set.isEmpty runs in constant time."
                                 ]
                             , under = "0 == Set.size s"
                             }
@@ -1200,8 +1199,8 @@ a = (s |> Set.size) == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Set.isEmpty"
                             , details =
-                                [ "Set.size takes as long to run as the list is long"
-                                , "whereas Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
+                                , "Set.isEmpty runs in constant time."
                                 ]
                             , under = "(s |> Set.size) == 0"
                             }
@@ -1221,8 +1220,8 @@ a = 0 == (s |> Set.size)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Set.isEmpty"
                             , details =
-                                [ "Set.size takes as long to run as the list is long"
-                                , "whereas Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
+                                , "Set.isEmpty runs in constant time."
                                 ]
                             , under = "0 == (s |> Set.size)"
                             }
@@ -1242,8 +1241,8 @@ a = Set.size s /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not Set.isEmpty)"
                             , details =
-                                [ "Set.size takes as long to run as the list is long"
-                                , "whereas Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
+                                , "Set.isEmpty runs in constant time."
                                 ]
                             , under = "Set.size s /= 0"
                             }
@@ -1263,8 +1262,8 @@ a = 0 /= Set.size s
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not Set.isEmpty)"
                             , details =
-                                [ "Set.size takes as long to run as the list is long"
-                                , "whereas Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
+                                , "Set.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= Set.size s"
                             }
@@ -1284,8 +1283,8 @@ a = (s |> Set.size) /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not Set.isEmpty)"
                             , details =
-                                [ "Set.size takes as long to run as the list is long"
-                                , "whereas Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
+                                , "Set.isEmpty runs in constant time."
                                 ]
                             , under = "(s |> Set.size) /= 0"
                             }
@@ -1305,8 +1304,8 @@ a = 0 /= (s |> Set.size)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not Set.isEmpty)"
                             , details =
-                                [ "Set.size takes as long to run as the list is long"
-                                , "whereas Set.isEmpty runs in constant time."
+                                [ "Whereas Set.size takes as long to run as the number of elements in the Set,"
+                                , "Set.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= (s |> Set.size)"
                             }
@@ -1332,8 +1331,8 @@ a = Dict.size d == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Dict.isEmpty"
                             , details =
-                                [ "Dict.size takes as long to run as the list is long"
-                                , "whereas Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
+                                , "Dict.isEmpty runs in constant time."
                                 ]
                             , under = "Dict.size d == 0"
                             }
@@ -1342,34 +1341,33 @@ a : Bool
 a = Dict.isEmpty d 
 """
                         ]
-        , Test.skip <|
-            test "should replace size d == 0 with isEmpty d" <|
-                \() ->
-                    """module A exposing (..)
+        , test "should replace size d == 0 with isEmpty d" <|
+            \() ->
+                """module A exposing (..)
 import Dict as CoreDict exposing (..)
 
 
 a : Bool
 a = size d == 0
 """
-                        |> Review.Test.run ruleWithDefaults
-                        |> Review.Test.expectErrors
-                            [ Review.Test.error
-                                { message = "This can be replaced with a call to Dict.isEmpty"
-                                , details =
-                                    [ "Dict.size takes as long to run as the list is long"
-                                    , "whereas Dict.isEmpty runs in constant time."
-                                    ]
-                                , under = "size d == 0"
-                                }
-                                |> Review.Test.whenFixed """module A exposing (..)
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "This can be replaced with a call to isEmpty"
+                            , details =
+                                [ "Whereas size takes as long to run as the number of elements in the Dict,"
+                                , "isEmpty runs in constant time."
+                                ]
+                            , under = "size d == 0"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
 import Dict as CoreDict exposing (..)
 
 
 a : Bool
 a = isEmpty d 
 """
-                            ]
+                        ]
         , test "should replace 0 == Dict.size d with Dict.isEmpty d" <|
             \() ->
                 """module A exposing (..)
@@ -1381,8 +1379,8 @@ a = 0 == Dict.size d
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Dict.isEmpty"
                             , details =
-                                [ "Dict.size takes as long to run as the list is long"
-                                , "whereas Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
+                                , "Dict.isEmpty runs in constant time."
                                 ]
                             , under = "0 == Dict.size d"
                             }
@@ -1402,8 +1400,8 @@ a = (d |> Dict.size) == 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Dict.isEmpty"
                             , details =
-                                [ "Dict.size takes as long to run as the list is long"
-                                , "whereas Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
+                                , "Dict.isEmpty runs in constant time."
                                 ]
                             , under = "(d |> Dict.size) == 0"
                             }
@@ -1423,8 +1421,8 @@ a = 0 == (d |> Dict.size)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to Dict.isEmpty"
                             , details =
-                                [ "Dict.size takes as long to run as the list is long"
-                                , "whereas Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
+                                , "Dict.isEmpty runs in constant time."
                                 ]
                             , under = "0 == (d |> Dict.size)"
                             }
@@ -1444,8 +1442,8 @@ a = Dict.size d /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not Dict.isEmpty)"
                             , details =
-                                [ "Dict.size takes as long to run as the list is long"
-                                , "whereas Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
+                                , "Dict.isEmpty runs in constant time."
                                 ]
                             , under = "Dict.size d /= 0"
                             }
@@ -1465,8 +1463,8 @@ a = 0 /= Dict.size d
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not Dict.isEmpty)"
                             , details =
-                                [ "Dict.size takes as long to run as the list is long"
-                                , "whereas Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
+                                , "Dict.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= Dict.size d"
                             }
@@ -1486,8 +1484,8 @@ a = (d |> Dict.size) /= 0
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not Dict.isEmpty)"
                             , details =
-                                [ "Dict.size takes as long to run as the list is long"
-                                , "whereas Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
+                                , "Dict.isEmpty runs in constant time."
                                 ]
                             , under = "(d |> Dict.size) /= 0"
                             }
@@ -1507,8 +1505,8 @@ a = 0 /= (d |> Dict.size)
                         [ Review.Test.error
                             { message = "This can be replaced with a call to (not Dict.isEmpty)"
                             , details =
-                                [ "Dict.size takes as long to run as the list is long"
-                                , "whereas Dict.isEmpty runs in constant time."
+                                [ "Whereas Dict.size takes as long to run as the number of elements in the Dict,"
+                                , "Dict.isEmpty runs in constant time."
                                 ]
                             , under = "0 /= (d |> Dict.size)"
                             }


### PR DESCRIPTION
Partially solve https://github.com/jfmengels/elm-review-simplify/issues/26

Remaining work for this PR
- [x] fix whitespace issue. It sounds like this is non-blocking because elm-format runs afterwards. EDIT: Fixed by @mfonism thank you!!
- ~Maybe reduce the number of tests, idk.~ eh, elm-test is very fast. 

Non blocking work that could be in this PR if we want but it's at best nice-to-have
- [ ] Apply same logic to Strings. The issue is that replacing with `== ""` is a little bit harder.
- [ ] Apply same logic to `List.length >= 1` (and `Set.size` etc).
- [ ] Apply same logic to `List.length < 1` 
- [ ] Throw an error without a fix for `List.length < 0`