### PR TITLE
Add configuration option doNotSimplifyMicroOptimizedCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-New opt-in configuration option [`ignoreMicroOptimizations`] which will disable some simplifications when the user indicates their
+New opt-in configuration option [`doNotSimplifyMicroOptimizedCode`] which will disable some simplifications when the user indicates their
 project uses performance tricks.
 Since this is now disabled by default, the following simplification is now suggested:
   - `x ++ ""` to `x`
@@ -686,4 +686,4 @@ Help would be appreciated to fill the blanks!
 [@w0rm]: https://github.com/w0rm
 
 [`expectNaN`]: https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/latest/Simplify#expectNaN
-[`ignoreMicroOptimizations`]: https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/latest/Simplify#ignoreMicroOptimizations
+[`doNotSimplifyMicroOptimizedCode`]: https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/latest/Simplify#doNotSimplifyMicroOptimizedCode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+New opt-in configuration option [`ignoreMicroOptimizations`] which will disable some simplifications when the user indicates their
+project uses performance tricks.
+Since this is now disabled by default, the following simplification is now suggested:
+  - `x ++ ""` to `x`
+Additionally, this opens the door for previously suggested simplifications like combining `a < b || a > b` that were previously avoided to allow micro-optimization.
+
 ## [2.1.5] - 2024-06-28
 
 The rule also simplifies (thanks to [@morteako]):
@@ -680,3 +686,4 @@ Help would be appreciated to fill the blanks!
 [@w0rm]: https://github.com/w0rm
 
 [`expectNaN`]: https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/latest/Simplify#expectNaN
+[`ignoreMicroOptimizations`]: https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/latest/Simplify#ignoreMicroOptimizations

--- a/tests/Simplify/PlusPlusTest.elm
+++ b/tests/Simplify/PlusPlusTest.elm
@@ -46,7 +46,7 @@ a = "a" ++ ""
 a = "a"
 """
                         ]
-        , test """should not report x ++ "" when ignoreMicroOptimizations is enabled (because this can lead to better performance)""" <|
+        , test """should not report x ++ "" when doNotSimplifyMicroOptimizedCode is enabled (because this can lead to better performance)""" <|
             \() ->
                 """module A exposing (..)
 a = x ++ ""
@@ -54,11 +54,11 @@ a = x ++ ""
                     |> Review.Test.run
                         (Simplify.rule
                             (Simplify.defaults
-                                |> Simplify.ignoreMicroOptimizations
+                                |> Simplify.doNotSimplifyMicroOptimizedCode
                             )
                         )
                     |> Review.Test.expectNoErrors
-        , test """should replace x ++ "" by x when ignoreMicroOptimizations is not enabled""" <|
+        , test """should replace x ++ "" by x when doNotSimplifyMicroOptimizedCode is not enabled""" <|
             \() ->
                 """module A exposing (..)
 a = x ++ ""


### PR DESCRIPTION
The [introduction article for simplify](https://jfmengels.net/simplify/#automatic-fixes-for-unused-constructors) presented snowballing simplifications that includes the step `prefix ++ "" → prefix` – which simplify doesn't do till this day due to performance considerations.

I've argued that the vast majority of users do not and should not care about that.
For those folks it's much more helpful to offer a fix for `++ ""` since that's very likely not intentional.
A similar case is https://github.com/jfmengels/elm-review-simplify/issues/115#issuecomment-1676434266

This PR adds the option `Simplify.doNotSimplifyMicroOptimizedCode` which very similar to `expectNaN` is by default set to provide all simplifications it can.