### PR TITLE
Dict.fromList & Set.fromList duplicate key merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+The rule also simplifies:
+- `Set.fromList [ a, a ]` to `Set.fromList [ a ]`
+- `Dict.fromList [ ( a, v0 ), ( a, v1 ) ]` to `Dict.fromList [ ( a, v1 ) ]`
+
 ## [2.1.5] - 2024-06-28
 
 The rule also simplifies (thanks to [@morteako]):

--- a/src/Simplify/Normalize.elm
+++ b/src/Simplify/Normalize.elm
@@ -1,4 +1,4 @@
-module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, isAnyTheSameAs, normalize)
+module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, isAnyTheSameAs, isAnyTheSameAsBy, normalize)
 
 import Dict
 import Elm.Syntax.Expression as Expression exposing (Expression)
@@ -29,6 +29,25 @@ isAnyTheSameAs resources first rest =
             normalize resources first
     in
     List.any (\node -> normalize resources node == normalizedFirst) rest
+
+
+isAnyTheSameAsBy :
+    Infer.Resources a
+    -> Node Expression
+    -> (element -> Node Expression)
+    -> List element
+    -> Bool
+isAnyTheSameAsBy resources first restElementToNode rest =
+    let
+        normalizedFirst : Node Expression
+        normalizedFirst =
+            normalize resources first
+    in
+    List.any
+        (\node ->
+            normalize resources (restElementToNode node) == normalizedFirst
+        )
+        rest
 
 
 normalize : Infer.Resources a -> Node Expression -> Node Expression

--- a/src/Simplify/Normalize.elm
+++ b/src/Simplify/Normalize.elm
@@ -1,4 +1,4 @@
-module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, normalize)
+module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, isAnyTheSameAs, normalize)
 
 import Dict
 import Elm.Syntax.Expression as Expression exposing (Expression)
@@ -19,6 +19,16 @@ areAllTheSame resources first rest =
             normalize resources first
     in
     List.all (\node -> normalize resources node == normalizedFirst) rest
+
+
+isAnyTheSameAs : Infer.Resources a -> Node Expression -> List (Node Expression) -> Bool
+isAnyTheSameAs resources first rest =
+    let
+        normalizedFirst : Node Expression
+        normalizedFirst =
+            normalize resources first
+    in
+    List.any (\node -> normalize resources node == normalizedFirst) rest
 
 
 normalize : Infer.Resources a -> Node Expression -> Node Expression

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -578,6 +578,17 @@ a = Dict.size (Dict.fromList [(1,1), (2,1), (3,1), (3,2), (0x3,2)])
 import Dict
 a = 3
 """
+                        , Review.Test.error
+                            { message = "Dict.fromList on entries with a duplicate key will only keep the last entry"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove earlier entries with duplicate keys." ]
+                            , under = "3"
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 46 }, end = { row = 3, column = 47 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.size (Dict.fromList [(1,1), (2,1), (3,2), (0x3,2)])
+"""
                         ]
         , test "should replace Dict.size (Dict.fromList [(1.3,()), (-1.3,()), (2.1,()), (2.1,())]) by 3" <|
             \() ->
@@ -595,6 +606,17 @@ a = Dict.size (Dict.fromList [(1.3,()), (-1.3,()), (2.1,()), (2.1,())])
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
 a = 3
+"""
+                        , Review.Test.error
+                            { message = "Dict.fromList on entries with a duplicate key will only keep the last entry"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove earlier entries with duplicate keys." ]
+                            , under = "2.1"
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 53 }, end = { row = 3, column = 56 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.size (Dict.fromList [(1.3,()), (-1.3,()), (2.1,())])
 """
                         ]
         ]

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -613,8 +613,19 @@ a = Set.size (Set.fromList [1, 2, 3, 3, 0x3])
 import Set
 a = 3
 """
+                        , Review.Test.error
+                            { message = "Set.fromList on a list with a duplicate key will only keep one of them"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
+                            , under = "3"
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 35 }, end = { row = 3, column = 36 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.size (Set.fromList [1, 2, 3, 0x3])
+"""
                         ]
-        , test "should replace Set.size (Set.fromList [2, -2, -(-2)]) by 2" <|
+        , test "should replace Set.size (Set.fromList [2, -2, -2]) by 2" <|
             \() ->
                 """module A exposing (..)
 import Set
@@ -630,6 +641,17 @@ a = Set.size (Set.fromList [2, -2, -2])
                             |> Review.Test.whenFixed """module A exposing (..)
 import Set
 a = 2
+"""
+                        , Review.Test.error
+                            { message = "Set.fromList on a list with a duplicate key will only keep one of them"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
+                            , under = "-2"
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 32 }, end = { row = 3, column = 34 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.size (Set.fromList [2, -2])
 """
                         ]
         , test "should replace Set.size (Set.fromList [1.3, -1.3, 2.1, 2.1]) by 3" <|
@@ -649,6 +671,17 @@ a = Set.size (Set.fromList [1.3, -1.3, 2.1, 2.1])
 import Set
 a = 3
 """
+                        , Review.Test.error
+                            { message = "Set.fromList on a list with a duplicate key will only keep one of them"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
+                            , under = "2.1"
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 40 }, end = { row = 3, column = 43 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.size (Set.fromList [1.3, -1.3, 2.1])
+"""
                         ]
         , test "should replace Set.size (Set.fromList [\"foo\", \"bar\", \"foo\"]) by 2" <|
             \() ->
@@ -666,6 +699,17 @@ a = Set.size (Set.fromList ["foo", "bar", "foo"])
                             |> Review.Test.whenFixed """module A exposing (..)
 import Set
 a = 2
+"""
+                        , Review.Test.error
+                            { message = "Set.fromList on a list with a duplicate key will only keep one of them"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
+                            , under = "\"foo\""
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 29 }, end = { row = 3, column = 34 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.size (Set.fromList ["bar", "foo"])
 """
                         ]
         , test "should replace Set.size (Set.fromList ['a', 'b', ('a')]) by 2" <|
@@ -685,6 +729,17 @@ a = Set.size (Set.fromList ['a', 'b', ('a')])
 import Set
 a = 2
 """
+                        , Review.Test.error
+                            { message = "Set.fromList on a list with a duplicate key will only keep one of them"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
+                            , under = "'a'"
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 29 }, end = { row = 3, column = 32 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.size (Set.fromList ['b', ('a')])
+"""
                         ]
         , test "should replace Set.size (Set.fromList [([1, 2], [3, 4]), ([1, 2], [3, 4]), ([], [1])]) by 2" <|
             \() ->
@@ -702,6 +757,17 @@ a = Set.size (Set.fromList [([1, 2], [3, 4]), ([1, 2], [3, 4]), ([], [1])])
                             |> Review.Test.whenFixed """module A exposing (..)
 import Set
 a = 2
+"""
+                        , Review.Test.error
+                            { message = "Set.fromList on a list with a duplicate key will only keep one of them"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
+                            , under = "([1, 2], [3, 4])"
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 29 }, end = { row = 3, column = 45 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.size (Set.fromList [([1, 2], [3, 4]), ([], [1])])
 """
                         ]
         , test "should replace Set.empty |> Set.size by 0" <|


### PR DESCRIPTION
implements #326 except for `insert`

```elm
Set.fromList [ a, a ] --> Set.fromList [ a ]
Dict.fromList [ ( a, v0 ), ( a, v1 ) ] --> Dict.fromList [ ( a, v1 ) ]
```

Honestly I'm surprised we didn't implement this already because it seems pretty useful.

The check for duplicates is `n^2` but I guess that shouldn't be too bad because these explicit `fromList` calls are rare and usually not terribly long in non-codegen code.