### PR TITLE
Improvements to fromList key deduplication simplification

### DIFF
--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6201,7 +6201,7 @@ dictFromListChecks =
                                 allDifferentHelp : { entryRange : Range, first : Node Expression } -> List { entryRange : Range, first : Node Expression } -> Maybe { entryRange : Range, keyRange : Range, nextEntryRange : Range }
                                 allDifferentHelp entry otherEntriesToCheck =
                                     case otherEntriesToCheck of
-                                        nextEntry :: _ ->
+                                        nextEntry :: restOfEntries ->
                                             if
                                                 Normalize.isAnyTheSameAsBy checkInfo
                                                     entry.first
@@ -6215,7 +6215,7 @@ dictFromListChecks =
                                                     }
 
                                             else
-                                                allDifferentHelp nextEntry (otherEntriesToCheck |> List.drop 1)
+                                                allDifferentHelp nextEntry restOfEntries
 
                                         [] ->
                                             -- entry is the last element

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6017,7 +6017,12 @@ setFromListChecks =
                                 allDifferent key otherKeysToCheck =
                                     case otherKeysToCheck of
                                         first :: rest ->
-                                            if Normalize.isAnyTheSameAs checkInfo key otherKeysToCheck then
+                                            let
+                                                normalizedFirst : Node Expression
+                                                normalizedFirst =
+                                                    Normalize.normalize checkInfo key
+                                            in
+                                            if List.any (\node -> Normalize.normalize checkInfo node == normalizedFirst) otherKeysToCheck then
                                                 Just
                                                     { keyRange = Node.range key
                                                     , nextKeyRange = Node.range first

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6192,39 +6192,36 @@ dictFromListChecks =
                                         }
                                         (List { entryRange : Range, first : Node Expression })
                                 allDifferent =
-                                    List.foldl
-                                        allDifferentHelp
-                                        (Ok (List.drop 1 knownEntryTuples))
-                                        knownEntryTuples
+                                    case knownEntryTuples of
+                                        [] ->
+                                            Ok []
 
-                                allDifferentHelp : { entryRange : Range, first : Node Expression } -> Result { entryRange : Range, keyRange : Range, nextEntryRange : Range } (List { entryRange : Range, first : Node Expression }) -> Result { entryRange : Range, keyRange : Range, nextEntryRange : Range } (List { entryRange : Range, first : Node Expression })
-                                allDifferentHelp entry otherEntriesToCheckOrFoundDuplicate =
-                                    case otherEntriesToCheckOrFoundDuplicate of
-                                        Err foundDuplicate ->
-                                            Err foundDuplicate
+                                        first :: rest ->
+                                            allDifferentHelp first rest
 
-                                        Ok otherEntriesToCheck ->
-                                            case otherEntriesToCheck of
-                                                nextEntry :: _ ->
-                                                    if
-                                                        Normalize.isAnyTheSameAsBy checkInfo
-                                                            entry.first
-                                                            .first
-                                                            otherEntriesToCheck
-                                                    then
-                                                        Err
-                                                            { entryRange = entry.entryRange
-                                                            , keyRange = Node.range entry.first
-                                                            , nextEntryRange = nextEntry.entryRange
-                                                            }
+                                allDifferentHelp : { entryRange : Range, first : Node Expression } -> List { entryRange : Range, first : Node Expression } -> Result { entryRange : Range, keyRange : Range, nextEntryRange : Range } (List { entryRange : Range, first : Node Expression })
+                                allDifferentHelp entry otherEntriesToCheck =
+                                    case otherEntriesToCheck of
+                                        nextEntry :: _ ->
+                                            if
+                                                Normalize.isAnyTheSameAsBy checkInfo
+                                                    entry.first
+                                                    .first
+                                                    otherEntriesToCheck
+                                            then
+                                                Err
+                                                    { entryRange = entry.entryRange
+                                                    , keyRange = Node.range entry.first
+                                                    , nextEntryRange = nextEntry.entryRange
+                                                    }
 
-                                                    else
-                                                        Ok (otherEntriesToCheck |> List.drop 1)
+                                            else
+                                                allDifferentHelp nextEntry (otherEntriesToCheck |> List.drop 1)
 
-                                                [] ->
-                                                    -- entry is the last element
-                                                    -- so it can't be equal to any other key
-                                                    Ok []
+                                        [] ->
+                                            -- entry is the last element
+                                            -- so it can't be equal to any other key
+                                            Ok []
                             in
                             case allDifferent of
                                 Ok _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6044,25 +6044,30 @@ setFromListChecks =
                                         (Ok (List.drop 1 elements))
                                         elements
                             in
-                            case allDifferent of
-                                Ok _ ->
+                            case elements of
+                                [] ->
                                     Nothing
 
-                                Err firstDuplicateKey ->
-                                    Just
-                                        (Rule.errorWithFix
-                                            { message =
-                                                "Set.fromList on a list with a duplicate key will only keep one of them"
-                                            , details =
-                                                [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
-                                            }
-                                            firstDuplicateKey.keyRange
-                                            [ Fix.removeRange
-                                                { start = firstDuplicateKey.keyRange.start
-                                                , end = firstDuplicateKey.nextKeyRange.start
-                                                }
-                                            ]
-                                        )
+                                first :: rest ->
+                                    case allDifferent of
+                                        Ok _ ->
+                                            Nothing
+
+                                        Err firstDuplicateKey ->
+                                            Just
+                                                (Rule.errorWithFix
+                                                    { message =
+                                                        "Set.fromList on a list with a duplicate key will only keep one of them"
+                                                    , details =
+                                                        [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
+                                                    }
+                                                    firstDuplicateKey.keyRange
+                                                    [ Fix.removeRange
+                                                        { start = firstDuplicateKey.keyRange.start
+                                                        , end = firstDuplicateKey.nextKeyRange.start
+                                                        }
+                                                    ]
+                                                )
 
                         _ ->
                             Nothing

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6191,7 +6191,7 @@ dictFromListChecks =
                                             if
                                                 Normalize.isAnyTheSameAsBy checkInfo
                                                     entry.first
-                                                    .first
+                                                    (.first >> Just)
                                                     otherEntriesToCheck
                                             then
                                                 Just

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6013,12 +6013,12 @@ setFromListChecks =
                     case Node.value checkInfo.firstArg of
                         Expression.ListExpr elements ->
                             let
-                                allDifferent : Node Expression -> List (Node Expression) -> Result { keyRange : Range, nextKeyRange : Range } (List a)
+                                allDifferent : Node Expression -> List (Node Expression) -> Maybe { keyRange : Range, nextKeyRange : Range }
                                 allDifferent key otherKeysToCheck =
                                     case otherKeysToCheck of
                                         first :: rest ->
                                             if Normalize.isAnyTheSameAs checkInfo key otherKeysToCheck then
-                                                Err
+                                                Just
                                                     { keyRange = Node.range key
                                                     , nextKeyRange = Node.range first
                                                     }
@@ -6029,7 +6029,7 @@ setFromListChecks =
                                         [] ->
                                             -- key is the last element
                                             -- so it can't be equal to any other key
-                                            Ok []
+                                            Nothing
                             in
                             case elements of
                                 [] ->
@@ -6037,10 +6037,10 @@ setFromListChecks =
 
                                 first :: rest ->
                                     case allDifferent first rest of
-                                        Ok _ ->
+                                        Nothing ->
                                             Nothing
 
-                                        Err firstDuplicateKey ->
+                                        Just firstDuplicateKey ->
                                             Just
                                                 (Rule.errorWithFix
                                                     { message =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6185,21 +6185,20 @@ dictFromListChecks =
                                             )
 
                                 allDifferent :
-                                    Result
+                                    Maybe
                                         { entryRange : Range
                                         , keyRange : Range
                                         , nextEntryRange : Range
                                         }
-                                        (List { entryRange : Range, first : Node Expression })
                                 allDifferent =
                                     case knownEntryTuples of
                                         [] ->
-                                            Ok []
+                                            Nothing
 
                                         first :: rest ->
                                             allDifferentHelp first rest
 
-                                allDifferentHelp : { entryRange : Range, first : Node Expression } -> List { entryRange : Range, first : Node Expression } -> Result { entryRange : Range, keyRange : Range, nextEntryRange : Range } (List { entryRange : Range, first : Node Expression })
+                                allDifferentHelp : { entryRange : Range, first : Node Expression } -> List { entryRange : Range, first : Node Expression } -> Maybe { entryRange : Range, keyRange : Range, nextEntryRange : Range }
                                 allDifferentHelp entry otherEntriesToCheck =
                                     case otherEntriesToCheck of
                                         nextEntry :: _ ->
@@ -6209,7 +6208,7 @@ dictFromListChecks =
                                                     .first
                                                     otherEntriesToCheck
                                             then
-                                                Err
+                                                Just
                                                     { entryRange = entry.entryRange
                                                     , keyRange = Node.range entry.first
                                                     , nextEntryRange = nextEntry.entryRange
@@ -6221,13 +6220,13 @@ dictFromListChecks =
                                         [] ->
                                             -- entry is the last element
                                             -- so it can't be equal to any other key
-                                            Ok []
+                                            Nothing
                             in
                             case allDifferent of
-                                Ok _ ->
+                                Nothing ->
                                     Nothing
 
-                                Err firstDuplicateKey ->
+                                Just firstDuplicateKey ->
                                     Just
                                         (Rule.errorWithFix
                                             { message =

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6026,11 +6026,11 @@ setFromListChecks =
 
                                                 Ok otherKeysToCheck ->
                                                     case otherKeysToCheck of
-                                                        (Node nextKeyRange _) :: rest ->
+                                                        first :: rest ->
                                                             if Normalize.isAnyTheSameAs checkInfo key otherKeysToCheck then
                                                                 Err
                                                                     { keyRange = Node.range key
-                                                                    , nextKeyRange = nextKeyRange
+                                                                    , nextKeyRange = Node.range first
                                                                     }
 
                                                             else

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6193,36 +6193,38 @@ dictFromListChecks =
                                         (List { entryRange : Range, first : Node Expression })
                                 allDifferent =
                                     List.foldl
-                                        (\entry otherEntriesToCheckOrFoundDuplicate ->
-                                            case otherEntriesToCheckOrFoundDuplicate of
-                                                Err foundDuplicate ->
-                                                    Err foundDuplicate
-
-                                                Ok otherEntriesToCheck ->
-                                                    case otherEntriesToCheck of
-                                                        nextEntry :: _ ->
-                                                            if
-                                                                Normalize.isAnyTheSameAsBy checkInfo
-                                                                    entry.first
-                                                                    .first
-                                                                    otherEntriesToCheck
-                                                            then
-                                                                Err
-                                                                    { entryRange = entry.entryRange
-                                                                    , keyRange = Node.range entry.first
-                                                                    , nextEntryRange = nextEntry.entryRange
-                                                                    }
-
-                                                            else
-                                                                Ok (otherEntriesToCheck |> List.drop 1)
-
-                                                        [] ->
-                                                            -- entry is the last element
-                                                            -- so it can't be equal to any other key
-                                                            Ok []
-                                        )
+                                        allDifferentHelp
                                         (Ok (List.drop 1 knownEntryTuples))
                                         knownEntryTuples
+
+                                allDifferentHelp : { entryRange : Range, first : Node Expression } -> Result { entryRange : Range, keyRange : Range, nextEntryRange : Range } (List { entryRange : Range, first : Node Expression }) -> Result { entryRange : Range, keyRange : Range, nextEntryRange : Range } (List { entryRange : Range, first : Node Expression })
+                                allDifferentHelp entry otherEntriesToCheckOrFoundDuplicate =
+                                    case otherEntriesToCheckOrFoundDuplicate of
+                                        Err foundDuplicate ->
+                                            Err foundDuplicate
+
+                                        Ok otherEntriesToCheck ->
+                                            case otherEntriesToCheck of
+                                                nextEntry :: _ ->
+                                                    if
+                                                        Normalize.isAnyTheSameAsBy checkInfo
+                                                            entry.first
+                                                            .first
+                                                            otherEntriesToCheck
+                                                    then
+                                                        Err
+                                                            { entryRange = entry.entryRange
+                                                            , keyRange = Node.range entry.first
+                                                            , nextEntryRange = nextEntry.entryRange
+                                                            }
+
+                                                    else
+                                                        Ok (otherEntriesToCheck |> List.drop 1)
+
+                                                [] ->
+                                                    -- entry is the last element
+                                                    -- so it can't be equal to any other key
+                                                    Ok []
                             in
                             case allDifferent of
                                 Ok _ ->

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6189,12 +6189,7 @@ dictFromListChecks =
                                         nextEntry :: restOfEntries ->
                                             case entry.first of
                                                 Just firstKey ->
-                                                    if
-                                                        isAnyTheSameAsBy checkInfo
-                                                            firstKey
-                                                            .first
-                                                            otherEntriesToCheck
-                                                    then
+                                                    if isAnyTheSameAsBy checkInfo firstKey otherEntriesToCheck then
                                                         Just
                                                             (Rule.errorWithFix
                                                                 { message =
@@ -6234,13 +6229,8 @@ dictFromListChecks =
         ]
 
 
-isAnyTheSameAsBy :
-    Infer.Resources a
-    -> Node Expression
-    -> (element -> Maybe (Node Expression))
-    -> List element
-    -> Bool
-isAnyTheSameAsBy resources first restElementToNode rest =
+isAnyTheSameAsBy : Infer.Resources a -> Node Expression -> List { b | first : Maybe (Node Expression) } -> Bool
+isAnyTheSameAsBy resources first rest =
     let
         normalizedFirst : Node Expression
         normalizedFirst =
@@ -6248,7 +6238,7 @@ isAnyTheSameAsBy resources first restElementToNode rest =
     in
     List.any
         (\node ->
-            case restElementToNode node of
+            case node.first of
                 Just element ->
                     Normalize.normalize resources element == normalizedFirst
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6190,7 +6190,7 @@ dictFromListChecks =
                                             case entry.first of
                                                 Just firstKey ->
                                                     if
-                                                        Normalize.isAnyTheSameAsBy checkInfo
+                                                        isAnyTheSameAsBy checkInfo
                                                             firstKey
                                                             .first
                                                             otherEntriesToCheck
@@ -6232,6 +6232,30 @@ dictFromListChecks =
                             Nothing
             )
         ]
+
+
+isAnyTheSameAsBy :
+    Infer.Resources a
+    -> Node Expression
+    -> (element -> Maybe (Node Expression))
+    -> List element
+    -> Bool
+isAnyTheSameAsBy resources first restElementToNode rest =
+    let
+        normalizedFirst : Node Expression
+        normalizedFirst =
+            Normalize.normalize resources first
+    in
+    List.any
+        (\node ->
+            case restElementToNode node of
+                Just element ->
+                    Normalize.normalize resources element == normalizedFirst
+
+                Nothing ->
+                    False
+        )
+        rest
 
 
 dictIsEmptyChecks : IntoFnCheck

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6189,7 +6189,7 @@ dictFromListChecks =
                                         nextEntry :: restOfEntries ->
                                             case entry.first of
                                                 Just firstKey ->
-                                                    if isAnyTheSameAsBy checkInfo firstKey otherEntriesToCheck then
+                                                    if isAnyTheSameAsBy firstKey otherEntriesToCheck then
                                                         Just
                                                             (Rule.errorWithFix
                                                                 { message =
@@ -6229,18 +6229,13 @@ dictFromListChecks =
         ]
 
 
-isAnyTheSameAsBy : Infer.Resources a -> Node Expression -> List { b | first : Maybe (Node Expression) } -> Bool
-isAnyTheSameAsBy resources first rest =
-    let
-        normalizedFirst : Node Expression
-        normalizedFirst =
-            Normalize.normalize resources first
-    in
+isAnyTheSameAsBy : Node Expression -> List { a | first : Maybe (Node Expression) } -> Bool
+isAnyTheSameAsBy first rest =
     List.any
         (\node ->
             case node.first of
                 Just element ->
-                    Normalize.normalize resources element == normalizedFirst
+                    Node.value element == Node.value first
 
                 Nothing ->
                     False

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6173,10 +6173,7 @@ dictFromListChecks =
                                                 { entryRange = Node.range entry
                                                 , first =
                                                     AstHelpers.getTuple2 checkInfo.lookupTable entry
-                                                        |> Maybe.map
-                                                            (\tuple ->
-                                                                Node (Node.range tuple.first) (Node.value (Normalize.normalize checkInfo tuple.first))
-                                                            )
+                                                        |> Maybe.map (\tuple -> Normalize.normalizeButKeepRange checkInfo tuple.first)
                                                 }
                                             )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6026,7 +6026,7 @@ setFromListChecks =
 
                                                 Ok otherKeysToCheck ->
                                                     case otherKeysToCheck of
-                                                        (Node nextKeyRange _) :: _ ->
+                                                        (Node nextKeyRange _) :: rest ->
                                                             if Normalize.isAnyTheSameAs checkInfo key otherKeysToCheck then
                                                                 Err
                                                                     { keyRange = Node.range key
@@ -6034,7 +6034,7 @@ setFromListChecks =
                                                                     }
 
                                                             else
-                                                                Ok (otherKeysToCheck |> List.drop 1)
+                                                                Ok rest
 
                                                         [] ->
                                                             -- key is the last element

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6013,43 +6013,35 @@ setFromListChecks =
                     case Node.value checkInfo.firstArg of
                         Expression.ListExpr elements ->
                             let
-                                allDifferent :
-                                    Result
-                                        { keyRange : Range, nextKeyRange : Range }
-                                        (List (Node Expression))
-                                allDifferent =
-                                    List.foldl
-                                        (\key otherKeysToCheckOrFoundDuplicate ->
-                                            case otherKeysToCheckOrFoundDuplicate of
-                                                Err foundDuplicate ->
-                                                    Err foundDuplicate
+                                allDifferent : Node Expression -> Result { keyRange : Range, nextKeyRange : Range } (List (Node Expression)) -> Result { keyRange : Range, nextKeyRange : Range } (List a)
+                                allDifferent key otherKeysToCheckOrFoundDuplicate =
+                                    case otherKeysToCheckOrFoundDuplicate of
+                                        Err foundDuplicate ->
+                                            Err foundDuplicate
 
-                                                Ok otherKeysToCheck ->
-                                                    case otherKeysToCheck of
-                                                        first :: rest ->
-                                                            if Normalize.isAnyTheSameAs checkInfo key otherKeysToCheck then
-                                                                Err
-                                                                    { keyRange = Node.range key
-                                                                    , nextKeyRange = Node.range first
-                                                                    }
+                                        Ok otherKeysToCheck ->
+                                            case otherKeysToCheck of
+                                                first :: rest ->
+                                                    if Normalize.isAnyTheSameAs checkInfo key otherKeysToCheck then
+                                                        Err
+                                                            { keyRange = Node.range key
+                                                            , nextKeyRange = Node.range first
+                                                            }
 
-                                                            else
-                                                                Ok rest
+                                                    else
+                                                        allDifferent first (Ok rest)
 
-                                                        [] ->
-                                                            -- key is the last element
-                                                            -- so it can't be equal to any other key
-                                                            Ok []
-                                        )
-                                        (Ok (List.drop 1 elements))
-                                        elements
+                                                [] ->
+                                                    -- key is the last element
+                                                    -- so it can't be equal to any other key
+                                                    Ok []
                             in
                             case elements of
                                 [] ->
                                     Nothing
 
                                 first :: rest ->
-                                    case allDifferent of
+                                    case allDifferent first (Ok rest) of
                                         Ok _ ->
                                             Nothing
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6174,7 +6174,12 @@ dictFromListChecks =
                                         |> List.map
                                             (\entry ->
                                                 { entryRange = Node.range entry
-                                                , first = AstHelpers.getTuple2 checkInfo.lookupTable entry |> Maybe.map .first
+                                                , first =
+                                                    AstHelpers.getTuple2 checkInfo.lookupTable entry
+                                                        |> Maybe.map
+                                                            (\tuple ->
+                                                                Node (Node.range tuple.first) (Node.value (Normalize.normalize checkInfo tuple.first))
+                                                            )
                                                 }
                                             )
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6017,12 +6017,7 @@ setFromListChecks =
                                 allDifferent key otherKeysToCheck =
                                     case otherKeysToCheck of
                                         first :: rest ->
-                                            let
-                                                normalizedFirst : Node Expression
-                                                normalizedFirst =
-                                                    Normalize.normalize checkInfo key
-                                            in
-                                            if List.any (\node -> Normalize.normalize checkInfo node == normalizedFirst) otherKeysToCheck then
+                                            if List.any (\(Node _ otherKey) -> otherKey == Node.value key) otherKeysToCheck then
                                                 Just
                                                     { keyRange = Node.range key
                                                     , nextKeyRange = Node.range first
@@ -6036,7 +6031,7 @@ setFromListChecks =
                                             -- so it can't be equal to any other key
                                             Nothing
                             in
-                            case elements of
+                            case List.map (Normalize.normalizeButKeepRange checkInfo) elements of
                                 [] ->
                                     Nothing
 

--- a/src/Simplify/Normalize.elm
+++ b/src/Simplify/Normalize.elm
@@ -1,4 +1,4 @@
-module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, isAnyTheSameAs, normalize)
+module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, normalize)
 
 import Dict
 import Elm.Syntax.Expression as Expression exposing (Expression)
@@ -19,16 +19,6 @@ areAllTheSame resources first rest =
             normalize resources first
     in
     List.all (\node -> normalize resources node == normalizedFirst) rest
-
-
-isAnyTheSameAs : Infer.Resources a -> Node Expression -> List (Node Expression) -> Bool
-isAnyTheSameAs resources first rest =
-    let
-        normalizedFirst : Node Expression
-        normalizedFirst =
-            normalize resources first
-    in
-    List.any (\node -> normalize resources node == normalizedFirst) rest
 
 
 normalize : Infer.Resources a -> Node Expression -> Node Expression

--- a/src/Simplify/Normalize.elm
+++ b/src/Simplify/Normalize.elm
@@ -1,4 +1,4 @@
-module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, isAnyTheSameAs, isAnyTheSameAsBy, normalize)
+module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, isAnyTheSameAs, normalize)
 
 import Dict
 import Elm.Syntax.Expression as Expression exposing (Expression)
@@ -29,30 +29,6 @@ isAnyTheSameAs resources first rest =
             normalize resources first
     in
     List.any (\node -> normalize resources node == normalizedFirst) rest
-
-
-isAnyTheSameAsBy :
-    Infer.Resources a
-    -> Node Expression
-    -> (element -> Maybe (Node Expression))
-    -> List element
-    -> Bool
-isAnyTheSameAsBy resources first restElementToNode rest =
-    let
-        normalizedFirst : Node Expression
-        normalizedFirst =
-            normalize resources first
-    in
-    List.any
-        (\node ->
-            case restElementToNode node of
-                Just element ->
-                    normalize resources element == normalizedFirst
-
-                Nothing ->
-                    False
-        )
-        rest
 
 
 normalize : Infer.Resources a -> Node Expression -> Node Expression

--- a/src/Simplify/Normalize.elm
+++ b/src/Simplify/Normalize.elm
@@ -34,7 +34,7 @@ isAnyTheSameAs resources first rest =
 isAnyTheSameAsBy :
     Infer.Resources a
     -> Node Expression
-    -> (element -> Node Expression)
+    -> (element -> Maybe (Node Expression))
     -> List element
     -> Bool
 isAnyTheSameAsBy resources first restElementToNode rest =
@@ -45,7 +45,12 @@ isAnyTheSameAsBy resources first restElementToNode rest =
     in
     List.any
         (\node ->
-            normalize resources (restElementToNode node) == normalizedFirst
+            case restElementToNode node of
+                Just element ->
+                    normalize resources element == normalizedFirst
+
+                Nothing ->
+                    False
         )
         rest
 

--- a/src/Simplify/Normalize.elm
+++ b/src/Simplify/Normalize.elm
@@ -1,4 +1,4 @@
-module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, normalize)
+module Simplify.Normalize exposing (Comparison(..), areAllTheSame, compare, compareWithoutNormalization, getNumberValue, normalize, normalizeButKeepRange)
 
 import Dict
 import Elm.Syntax.Expression as Expression exposing (Expression)
@@ -233,6 +233,11 @@ normalize resources node =
 
         expr ->
             toNode expr
+
+
+normalizeButKeepRange : Infer.Resources a -> Node Expression -> Node Expression
+normalizeButKeepRange checkInfo node =
+    Node (Node.range node) (Node.value (normalize checkInfo node))
 
 
 toNodeAndInfer : Infer.Resources a -> Expression -> Node Expression

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -367,6 +367,26 @@ import Dict
 a = Dict.fromList [ ( key, v1 ) ]
 """
                         ]
+        , test "should replace Dict.fromList [ ( key, v0 ), thing, ( key, v1 ) ] by Dict.fromList [ thing, ( key, v1 ) ]" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.fromList [ ( key, v0 ), thing, ( key, v1 ) ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.fromList on entries with a duplicate key will only keep the last entry"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove earlier entries with duplicate keys." ]
+                            , under = "key"
+                            }
+                            |> Review.Test.atExactly
+                                { start = { row = 3, column = 23 }, end = { row = 3, column = 26 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.fromList [ thing, ( key, v1 ) ]
+"""
+                        ]
         , test "should replace Dict.fromList [ ( ( 1, \"\", [ 'a' ] ), v0 ), ( ( 1, \"\", [ 'a' ] ), v1 ) ] by Dict.fromList [ ( ( 1, \"\", [ 'a' ] ), v1 ) ]" <|
             \() ->
                 """module A exposing (..)

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -1357,6 +1357,25 @@ import Set
 a = Set.fromList [ ( 1, "", [ 'a' ] ) ]
 """
                         ]
+        , test "should replace Set.fromList [ 'a', thing, 'a' ] by Set.fromList [ thing, 'a' ]" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.fromList [ 'a', thing, 'a' ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.fromList on a list with a duplicate key will only keep one of them"
+                            , details = [ "Maybe one of the keys was supposed to be a different value? If not, you can remove one of the duplicate keys." ]
+                            , under = "'a'"
+                            }
+                            |> Review.Test.atExactly { start = { row = 3, column = 20 }, end = { row = 3, column = 23 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.fromList [ thing, 'a' ]
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
I noticed there was a bug where some entries would be removed: We did `Dict.fromList [ ( key, a ), thing, ( key, b ) ] -> Dict.fromList [ ( key, b ) ]` which is incorrectly removing `thing`.

Other improvements:
- The `allDifferent` checks now aborts early when finding an error
- Normalization is done only once instead of once for each comparison with a prior key and once for when it's compared to later keys.

PR can be reviewed commit by commit. 