### PR TITLE
Allow some expressions even when expecting nan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The rule also simplifies:
 - `Dict.fromList [ a, a ]` to `Dict.fromList [ a ]`
 - `Dict.fromList [ ( a, v0 ), ( a, v1 ) ]` to `Dict.fromList [ ( a, v1 ) ]`
 
+Other improvements:
+- When having `expectNaN` enabled, we now still check expressions we know can't contain NaN like literal numbers. For example `List.member 0 [ 0, 1 ]` would previously not have been reported when expecting NaN, now it is.
+
 ## [2.1.5] - 2024-06-28
 
 The rule also simplifies (thanks to [@morteako]):

--- a/review/elm.json
+++ b/review/elm.json
@@ -9,15 +9,15 @@
         "direct": {
             "elm/core": "1.0.5",
             "elm/project-metadata-utils": "1.0.2",
-            "jfmengels/elm-review": "2.13.1",
-            "jfmengels/elm-review-code-style": "1.1.4",
+            "jfmengels/elm-review": "2.14.1",
+            "jfmengels/elm-review-code-style": "1.2.0",
             "jfmengels/elm-review-common": "1.3.3",
             "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-documentation": "2.0.4",
-            "jfmengels/elm-review-unused": "1.2.0",
+            "jfmengels/elm-review-unused": "1.2.3",
             "pzp1997/assoc-list": "1.0.0",
             "sparksp/elm-review-forbidden-words": "1.0.1",
-            "stil4m/elm-syntax": "7.3.1",
+            "stil4m/elm-syntax": "7.3.8",
             "truqu/elm-review-noleftpizza": "2.0.1"
         },
         "indirect": {
@@ -29,15 +29,14 @@
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/virtual-dom": "1.0.3",
-            "elm-explorations/test": "2.1.2",
-            "miniBill/elm-unicode": "1.0.3",
+            "elm-explorations/test": "2.2.0",
             "rtfeldman/elm-hex": "1.0.0",
             "stil4m/structured-writer": "1.0.3"
         }
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "2.1.2"
+            "elm-explorations/test": "2.2.0"
         },
         "indirect": {}
     }

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3470,8 +3470,8 @@ addingOppositesCheck : OperatorApplicationCheckInfo -> Maybe (Error {})
 addingOppositesCheck checkInfo =
     if
         checkInfo.expectNaN
-            && (AstHelpers.isPotentialNaNKey checkInfo.left
-                    || AstHelpers.isPotentialNaNKey checkInfo.right
+            && (AstHelpers.couldBeValueContainingNaN checkInfo.left
+                    || AstHelpers.couldBeValueContainingNaN checkInfo.right
                )
     then
         Nothing
@@ -3527,8 +3527,8 @@ checkIfMinusResultsInZero : OperatorApplicationCheckInfo -> Maybe (Error {})
 checkIfMinusResultsInZero checkInfo =
     if
         checkInfo.expectNaN
-            && (AstHelpers.isPotentialNaNKey checkInfo.left
-                    || AstHelpers.isPotentialNaNKey checkInfo.right
+            && (AstHelpers.couldBeValueContainingNaN checkInfo.left
+                    || AstHelpers.couldBeValueContainingNaN checkInfo.right
                )
     then
         Nothing
@@ -3575,7 +3575,7 @@ Basics.isInfinite: https://package.elm-lang.org/packages/elm/core/latest/Basics#
                                 (Range.combine [ checkInfo.operatorRange, Node.range side.node ])
                                 (if
                                     checkInfo.expectNaN
-                                        && AstHelpers.isPotentialNaNKey side.otherNode
+                                        && AstHelpers.couldBeValueContainingNaN side.otherNode
                                  then
                                     []
 
@@ -3636,7 +3636,7 @@ divisionChecks checkInfo =
 
         else if
             checkInfo.expectNaN
-                && AstHelpers.isPotentialNaNKey checkInfo.right
+                && AstHelpers.couldBeValueContainingNaN checkInfo.right
         then
             Nothing
 
@@ -3934,8 +3934,8 @@ equalityChecks isEqual =
                 Normalize.ConfirmedEquality ->
                     if
                         checkInfo.expectNaN
-                            && (AstHelpers.isPotentialNaNKey checkInfo.left
-                                    || AstHelpers.isPotentialNaNKey checkInfo.right
+                            && (AstHelpers.couldBeValueContainingNaN checkInfo.left
+                                    || AstHelpers.couldBeValueContainingNaN checkInfo.right
                                )
                     then
                         Nothing
@@ -5324,7 +5324,7 @@ listProductChecks =
                 , \checkInfo ->
                     if
                         checkInfo.expectNaN
-                            && List.any AstHelpers.isPotentialNaNKey
+                            && List.any AstHelpers.couldBeValueContainingNaN
                                 (checkInfo.firstArg :: checkInfo.argsAfterFirst)
                     then
                         callOnCollectionWithAbsorbingElementChecks (qualifiedToString checkInfo.fn)
@@ -6067,7 +6067,7 @@ allValuesDifferent expectingNaN errorDetails (Node keyRange keyValue) otherKeysT
     case otherKeysToCheck of
         first :: rest ->
             if
-                not (expectingNaN && AstHelpers.isPotentialNaNKey first)
+                not (expectingNaN && AstHelpers.couldBeValueContainingNaN first)
                     && List.any (\(Node _ otherKey) -> otherKey == keyValue) otherKeysToCheck
             then
                 Just
@@ -6227,7 +6227,7 @@ allKeysDifferent expectingNaN entry otherEntriesToCheck =
             case entry.first of
                 Just firstKey ->
                     if
-                        (not expectingNaN || not (AstHelpers.isPotentialNaNKey firstKey))
+                        (not expectingNaN || not (AstHelpers.couldBeValueContainingNaN firstKey))
                             && isAnyTheSameAsBy firstKey otherEntriesToCheck
                     then
                         Just
@@ -9016,8 +9016,8 @@ knownMemberChecks collection checkInfo =
                     if
                         checkInfo.expectNaN
                             && (not collectionElements.allKnown
-                                    || (AstHelpers.isPotentialNaNKey needleArg
-                                            || List.any AstHelpers.isPotentialNaNKey
+                                    || (AstHelpers.couldBeValueContainingNaN needleArg
+                                            || List.any AstHelpers.couldBeValueContainingNaN
                                                 collectionElements.known
                                        )
                                )

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -65,7 +65,7 @@ module Simplify.AstHelpers exposing
 
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Exposing as Exposing
-import Elm.Syntax.Expression as Expression exposing (Expression)
+import Elm.Syntax.Expression as Expression exposing (Expression(..))
 import Elm.Syntax.ModuleName exposing (ModuleName)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern as Pattern exposing (Pattern)
@@ -1064,8 +1064,13 @@ couldBeValueContainingNaNHelp nodes =
                 Expression.RecordAccess _ _ ->
                     True
 
-                Expression.RecordUpdateExpression _ _ ->
-                    couldBeValueContainingNaNHelp rest
+                Expression.RecordUpdateExpression (Node recordRange record) fields ->
+                    couldBeValueContainingNaNHelp
+                        (Node recordRange (FunctionOrValue [] record)
+                            :: (List.map (\(Node _ ( _, value )) -> value) fields
+                                    ++ rest
+                               )
+                        )
 
                 Expression.LetExpression { expression } ->
                     couldBeValueContainingNaNHelp (expression :: rest)
@@ -1079,8 +1084,11 @@ couldBeValueContainingNaNHelp nodes =
                 Expression.LambdaExpression _ ->
                     couldBeValueContainingNaNHelp rest
 
-                Expression.RecordExpr _ ->
-                    couldBeValueContainingNaNHelp rest
+                Expression.RecordExpr fields ->
+                    couldBeValueContainingNaNHelp
+                        (List.map (\(Node _ ( _, value )) -> value) fields
+                            ++ rest
+                        )
 
                 Expression.UnitExpr ->
                     couldBeValueContainingNaNHelp rest

--- a/src/Simplify/AstHelpers.elm
+++ b/src/Simplify/AstHelpers.elm
@@ -952,9 +952,13 @@ isSpecificUnappliedBinaryOperation symbol checkInfo expression =
             False
 
 
-{-| Indicates whether this value is potentially NaN in the context of a Dict key or Set value, meaning that it could return `False` when `==` with itself.
+{-| Indicates whether this value is potentially NaN,
+meaning that it could return `False` when `==` with itself.
 
-This will return `False` for expressions that are known to not be `comparable` (e.g. records) nor `numbers`.
+This will return `False` for expressions that are known to
+only contain literals (e.g. [ ( 0, { name = "string" } ) ]),
+are known operations that never produce NaN (e.g. `a ++ b`),
+or aren't values at all (e.g. `(++)`).
 
 -}
 isPotentialNaNKey : Node Expression -> Bool

--- a/tests/Simplify/AstHelpersTest.elm
+++ b/tests/Simplify/AstHelpersTest.elm
@@ -10,106 +10,106 @@ import Test exposing (Test, describe, test)
 
 all : Test
 all =
-    describe "AstHelpers.isPotentialNaNKey"
+    describe "AstHelpers.couldBeValueContainingNaN"
         [ test "String literals don't contain NaN" <|
             \() ->
                 "\"a\""
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Char literals don't contain NaN" <|
             \() ->
                 "'a'"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Integer literals don't contain NaN" <|
             \() ->
                 "0"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Float literals don't contain NaN" <|
             \() ->
                 "0.0"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Number addition don't contain literals if all sub-expression can't contain NaN" <|
             \() ->
                 "0.0 + 0"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Float division can contain NaN" <|
             \() ->
                 "0 / 0"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         , test "Float division can't contain NaN" <|
             \() ->
                 "0 // 0"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Applied || can't contain NaN" <|
             \() ->
                 "a || b"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Applied && can't contain NaN" <|
             \() ->
                 "a && b"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Applied ++ with string literals can't contain NaN" <|
             \() ->
                 "\"a\" ++ \"b\""
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Applied ++ with unknown values can contain NaN" <|
             \() ->
                 "a ++ b"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         , test "Applied <?> can't contain NaN" <|
             \() ->
                 "a <?> b"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "References can contain NaN" <|
             \() ->
                 "reference"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         , test "Lists with only non-NaN can't contain NaN" <|
             \() ->
                 "[ 0, 1, 2 ]"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Lists with only potential NaN can contain NaN" <|
             \() ->
                 "[ 0, reference, 2 ]"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         , test "Function calls can return NaN" <|
             \() ->
                 "fn 0"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         , test "Function calls with <| can return NaN" <|
             \() ->
                 "fn <| 0"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         , test "Function calls with |> can return NaN" <|
             \() ->
                 "0 |> fn"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         , test "Record access functions can't return NaN" <|
             \() ->
                 ".field"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "Record access can return NaN" <|
             \() ->
                 "record.field"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         , test "let expression checks for the `in` value (literal)" <|
             \() ->
                 "let _ = 1 in 0"
-                    |> isPotentialNaNKey False
+                    |> couldBeValueContainingNaN False
         , test "let expression checks for the `in` value (reference)" <|
             \() ->
                 "let _ = 1 in reference"
-                    |> isPotentialNaNKey True
+                    |> couldBeValueContainingNaN True
         ]
 
 
-isPotentialNaNKey : Bool -> String -> Expectation
-isPotentialNaNKey expected source =
+couldBeValueContainingNaN : Bool -> String -> Expectation
+couldBeValueContainingNaN expected source =
     case Elm.Parser.parseToFile (wrapSource source) of
         Ok ast ->
             case List.head ast.declarations of
                 Just (Node _ (Elm.Syntax.Declaration.FunctionDeclaration { declaration })) ->
                     (Node.value declaration).expression
-                        |> AstHelpers.isPotentialNaNKey
+                        |> AstHelpers.couldBeValueContainingNaN
                         |> Expect.equal expected
 
                 _ ->

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1383,6 +1383,16 @@ d = List.member g (List.filter f list)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+        , test "should not report List.member used with okay arguments when expecting NaN" <|
+            \() ->
+                """module A exposing (..)
+a = List.member 0 (0 :: 1 :: unknown)
+b = List.member g [ 0, 1 ]
+c = List.member 0 list
+d = List.member 0 [ 0, 1, 2, g ]
+"""
+                    |> Review.Test.run ruleExpectingNaN
+                    |> Review.Test.expectNoErrors
         , test "should replace List.member a [] by False" <|
             \() ->
                 """module A exposing (..)
@@ -1533,6 +1543,22 @@ a = b == c
 a = List.member d [ b, c, d ]
 """
                     |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.member on a list which contains the given element will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = True
+"""
+                        ]
+        , test "should replace List.member 0 [ 2, 0, 1 ] by True when expecting NaN" <|
+            \() ->
+                """module A exposing (..)
+a = List.member 0 [ 2, 0, 1 ]
+"""
+                    |> Review.Test.run ruleExpectingNaN
                     |> Review.Test.expectErrors
                         [ Review.Test.error
                             { message = "List.member on a list which contains the given element will result in True"


### PR DESCRIPTION
Thanks to the new "could be NaN" helper introduced in #330 , we can enable some existing checks even when expecting NaN, for example
```elm
-- expectNaN enabled
List.member 0 [ 0, 1 ] --> True
```

Bonus:
- fixes the helper as commented in https://github.com/jfmengels/elm-review-simplify/pull/330#issuecomment-2579724094
- gives the helper a more general name
- upgrades elm-review bc it didn't work
