### PR TITLE
copy List.member checks for Set.member and Dict.member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 The rule also simplifies:
 - `Set.fromList [ a, a ]` to `Set.fromList [ a ]`
+- `Set.member x (Set.singleton y)` to `x == y`
+- `Set.member x (Set.fromList [ y, x ])` to `True`
+- `Set.member -999 (Set.fromList [ 0, 1 ])` to `False`
 - `Dict.fromList [ a, a ]` to `Dict.fromList [ a ]`
 - `Dict.fromList [ ( a, v0 ), ( a, v1 ) ]` to `Dict.fromList [ ( a, v1 ) ]`
+- `Dict.member x [ ( y, v0 ), ( x, v1 ) ]` to `True`
+- `Dict.member -999 [ ( 0, v0 ), ( 1, v1 ) ]` to `False`
+- `List.member -999 [ 0, 1 ]` to `False`
 
 Other improvements:
 - When having `expectNaN` enabled, we now still check expressions we know can't contain NaN like literal numbers. For example `List.member 0 [ 0, 1 ]` would previously not have been reported when expecting NaN, now it is.

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -739,40 +739,6 @@ import Dict
 a = False
 """
                         ]
-        ]
-
-
-dictRemoveTests : Test
-dictRemoveTests =
-    describe "Dict.remove"
-        [ test "should not report Dict.remove used with okay arguments" <|
-            \() ->
-                """module A exposing (..)
-import Dict
-a0 = Dict.remove
-a1 = Dict.remove k
-a2 = Dict.remove k dict
-"""
-                    |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectNoErrors
-        , test "should replace Dict.remove k Dict.empty by Dict.empty" <|
-            \() ->
-                """module A exposing (..)
-import Dict
-a = Dict.remove k Dict.empty
-"""
-                    |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Dict.remove on Dict.empty will result in Dict.empty"
-                            , details = [ "You can replace this call by Dict.empty." ]
-                            , under = "Dict.remove"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-import Dict
-a = Dict.empty
-"""
-                        ]
         , test "should replace Dict.member 1 (Dict.fromList [ ( 0, () ), ( 1, () ), ( 2, () ) ]) by True" <|
             \() ->
                 """module A exposing (..)
@@ -843,6 +809,40 @@ a = Dict.member 0 (Dict.fromList [ ( 2, () ), ( 3, () ), ( 1, () ) ])
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
 a = False
+"""
+                        ]
+        ]
+
+
+dictRemoveTests : Test
+dictRemoveTests =
+    describe "Dict.remove"
+        [ test "should not report Dict.remove used with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a0 = Dict.remove
+a1 = Dict.remove k
+a2 = Dict.remove k dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace Dict.remove k Dict.empty by Dict.empty" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.remove k Dict.empty
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.remove on Dict.empty will result in Dict.empty"
+                            , details = [ "You can replace this call by Dict.empty." ]
+                            , under = "Dict.remove"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.empty
 """
                         ]
         ]

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -773,6 +773,78 @@ import Dict
 a = Dict.empty
 """
                         ]
+        , test "should replace Dict.member 1 (Dict.fromList [ ( 0, () ), ( 1, () ), ( 2, () ) ]) by True" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.member 1 (Dict.fromList [ ( 0, () ), ( 1, () ), ( 2, () ) ])
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.member on a dict which contains the given key will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "Dict.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = True
+"""
+                        ]
+        , test "should replace Dict.member 1 (Dict.fromList [ ( 0, () ), ( 1, () ), ( 2, () ) ]) by True when expecting NaN" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.member 1 (Dict.fromList [ ( 0, () ), ( 1, () ), ( 2, () ) ])
+"""
+                    |> Review.Test.run ruleExpectingNaN
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.member on a dict which contains the given key will result in True"
+                            , details = [ "You can replace this call by True." ]
+                            , under = "Dict.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = True
+"""
+                        ]
+        , test "should replace Dict.member 0 (Dict.fromList [ ( 2, () ), ( 3, () ), ( 1, () ) ]) by False" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.member 0 (Dict.fromList [ ( 2, () ), ( 3, () ), ( 1, () ) ])
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.member on a dict which does not contain the given key will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "Dict.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = False
+"""
+                        ]
+        , test "should replace Dict.member 0 (Dict.fromList [ ( 2, () ), ( 3, () ), ( 1, () ) ]) by False when expecting NaN" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.member 0 (Dict.fromList [ ( 2, () ), ( 3, () ), ( 1, () ) ])
+"""
+                    |> Review.Test.run ruleExpectingNaN
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.member on a dict which does not contain the given key will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "Dict.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = False
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -1631,6 +1631,38 @@ a = List.member e (b :: c :: d :: eToZ)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
+        , test "should replace List.member 0 [ 2, 3, 1 ] by False" <|
+            \() ->
+                """module A exposing (..)
+a = List.member 0 [ 2, 3, 1 ]
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.member on a list which does not contain the given element will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = False
+"""
+                        ]
+        , test "should replace List.member 0 [ 2, 3, 1 ] by False when expecting NaN" <|
+            \() ->
+                """module A exposing (..)
+a = List.member 0 [ 2, 3, 1 ]
+"""
+                    |> Review.Test.run ruleExpectingNaN
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.member on a list which does not contain the given element will result in False"
+                            , details = [ "You can replace this call by False." ]
+                            , under = "List.member"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = False
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Fully implements/closes #332:
```elm
Set.member x (Set.fromList [ y, x ]) --> True
Set.member -999 (Set.fromList [ 0, 1 ]) --> False
Dict.member x [ ( y, v0 ), ( x, v1 ) ] --> True
Dict.member -999 [ ( 0, v0 ), ( 1, v1 ) ] --> False
List.member -999 [ 0, 1 ] --> False
```
Bonus:
- copy the singleton checks from List.member for Set.member
  ```elm
  Set.member x (Set.singleton y) --> x == y
  ```