### PR TITLE
Add Dict and Set union with singleton simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+The rule now simplifies:
+- `Set.union (Set.singleton a) set` to `Set.insert a set`
+- `Set.union set (Set.singleton a)` to `Set.insert set a`
+- `Dict.union (Dict.singleton k v) dict` to `Dict.insert k v dict`
+
 ## [2.1.6] - 2025-01-12
 
 The rule now simplifies:

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -6599,7 +6599,7 @@ dictUnionChecks =
             { combinedFn = Fn.Dict.insert
             , wrapFn = Fn.Dict.singleton
             , wrapFnArgCount = 2
-            , articleWrapperName = "a dict singleton"
+            , articleWrapperName = "a singleton dict"
             , wrapFnArgumentsDescription = "key and value"
             }
         ]

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -1811,6 +1811,98 @@ import Dict
 a = value.field
 """
                         ]
+        , test "should replace Dict.union (Dict.singleton k v) dict by (Dict.insert k v)" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.union (Dict.singleton k v)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = (Dict.insert k v)
+"""
+                        ]
+        , test "should replace Dict.union (Dict.singleton k v) <| dict by (Dict.insert k v) <| dict" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = Dict.union (Dict.singleton k v) <| dict
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = (Dict.insert k v) <| dict
+"""
+                        ]
+        , test "should replace dict |> Dict.union (Dict.singleton k v) by dict |> (Dict.insert k v)" <|
+            \() ->
+                """module A exposing (..)
+import Dict
+a = dict |> Dict.union (Dict.singleton k v)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict |> (Dict.insert k v)
+"""
+                        ]
+        , test "should replace dict |> Dict.union (Dict.singleton k <| v) by dict |> (Dict.insert k <| v)" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Dict
+a = dict |> Dict.union (Dict.singleton k <| v)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict |> (Dict.insert k <| v)
+"""
+                        ]
+        , test "should replace dict |> (Dict.union <| Dict.singleton k <| v) by dict |> (Dict.insert k <| v)" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Dict
+a = dict |> (Dict.union <| Dict.singleton k <| v)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = dict |> (Dict.insert k <| v)
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -1820,7 +1820,7 @@ a = Dict.union (Dict.singleton k v)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            { message = "Dict.union with a singleton dict can be combined into Dict.insert"
                             , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
                             , under = "Dict.union"
                             }
@@ -1838,7 +1838,7 @@ a = Dict.union (Dict.singleton k v) <| dict
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            { message = "Dict.union with a singleton dict can be combined into Dict.insert"
                             , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
                             , under = "Dict.union"
                             }
@@ -1856,7 +1856,7 @@ a = dict |> Dict.union (Dict.singleton k v)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            { message = "Dict.union with a singleton dict can be combined into Dict.insert"
                             , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
                             , under = "Dict.union"
                             }
@@ -1875,7 +1875,7 @@ a = dict |> Dict.union (Dict.singleton k <| v)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            { message = "Dict.union with a singleton dict can be combined into Dict.insert"
                             , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
                             , under = "Dict.union"
                             }
@@ -1894,7 +1894,7 @@ a = dict |> (Dict.union <| Dict.singleton k <| v)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            { message = "Dict.union with a singleton dict can be combined into Dict.insert"
                             , details = [ "You can replace this call by Dict.insert with the same key and value given to Dict.singleton which is meant for this exact purpose." ]
                             , under = "Dict.union"
                             }
@@ -1913,7 +1913,7 @@ a = Dict.union << Dict.singleton k
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            { message = "Dict.union with a singleton dict can be combined into Dict.insert"
                             , details = [ "You can replace this composition by Dict.insert with the same argument given to Dict.singleton which is meant for this exact purpose." ]
                             , under = "Dict.union"
                             }
@@ -1932,7 +1932,7 @@ a = Dict.union << (Dict.singleton <| k)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            { message = "Dict.union with a singleton dict can be combined into Dict.insert"
                             , details = [ "You can replace this composition by Dict.insert with the same argument given to Dict.singleton which is meant for this exact purpose." ]
                             , under = "Dict.union"
                             }
@@ -1951,7 +1951,7 @@ a = Dict.union << (k |> Dict.singleton)
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            { message = "Dict.union with a singleton dict can be combined into Dict.insert"
                             , details = [ "You can replace this composition by Dict.insert with the same argument given to Dict.singleton which is meant for this exact purpose." ]
                             , under = "Dict.union"
                             }

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -1903,6 +1903,63 @@ import Dict
 a = dict |> (Dict.insert k <| v)
 """
                         ]
+        , test "should replace Dict.union << Dict.singleton k by Dict.insert k" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Dict
+a = Dict.union << Dict.singleton k
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            , details = [ "You can replace this composition by Dict.insert with the same argument given to Dict.singleton which is meant for this exact purpose." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = Dict.insert k
+"""
+                        ]
+        , test "should replace Dict.union << (Dict.singleton <| k) by (Dict.insert <| k)" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Dict
+a = Dict.union << (Dict.singleton <| k)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            , details = [ "You can replace this composition by Dict.insert with the same argument given to Dict.singleton which is meant for this exact purpose." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = (Dict.insert <| k)
+"""
+                        ]
+        , test "should replace Dict.union << (k |> Dict.singleton) by (k |> Dict.insert)" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Dict
+a = Dict.union << (k |> Dict.singleton)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Dict.union with a dict singleton can be combined into Dict.insert"
+                            , details = [ "You can replace this composition by Dict.insert with the same argument given to Dict.singleton which is meant for this exact purpose." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict
+a = (k |> Dict.insert)
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -2177,6 +2177,194 @@ import Set
 a = value.field
 """
                         ]
+        , test "should replace Set.union (Set.singleton k) set by (Set.insert k)" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.union (Set.singleton k)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this call by Set.insert with the same element given to Set.singleton which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = (Set.insert k)
+"""
+                        ]
+        , test "should replace Set.union (Set.singleton k) <| set by (Set.insert k) <| set" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.union (Set.singleton k) <| set
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this call by Set.insert with the same element given to Set.singleton which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = (Set.insert k) <| set
+"""
+                        ]
+        , test "should replace set |> Set.union (Set.singleton k) by set |> (Set.insert k)" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = set |> Set.union (Set.singleton k)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this call by Set.insert with the same element given to Set.singleton which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = set |> (Set.insert k)
+"""
+                        ]
+        , test "should replace set |> Set.union (Set.singleton <| k) by set |> (Set.insert <| k)" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Set
+a = set |> Set.union (Set.singleton <| k)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this call by Set.insert with the same element given to Set.singleton which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = set |> (Set.insert <| k)
+"""
+                        ]
+        , test "should replace set |> (Set.union <| Set.singleton <| k) by set |> (Set.insert <| k)" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Set
+a = set |> (Set.union <| Set.singleton <| k)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this call by Set.insert with the same element given to Set.singleton which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = set |> (Set.insert <| k)
+"""
+                        ]
+        , test "should replace Set.union set (Set.singleton k) by Set.insert k set" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Set
+a = Set.union set (Set.singleton k)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this call by Set.insert with the same element given to Set.singleton which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.insert k set
+"""
+                        ]
+        , test "should replace Set.union set (Set.singleton <| ..multiline..) by Set.insert (..multiline with original indent preserved..) set" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Set
+a = Set.union set (Set.singleton <| let _ = 0
+                                        _ = 1 in k)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this call by Set.insert with the same element given to Set.singleton which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.insert
+                                   (let _ = 0
+                                        _ = 1 in k) set
+"""
+                        ]
+        , test "should replace Set.union set <| Set.singleton <| k by Set.insert k set" <|
+            \() ->
+                -- note that the parenthesis are mandatory
+                """module A exposing (..)
+import Set
+a = Set.union set <| Set.singleton <| k
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this call by Set.insert with the same element given to Set.singleton which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.insert k set
+"""
+                        ]
+        , test "should replace Set.union << Set.singleton by Set.insert" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.union << Set.singleton
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this composition by Set.insert which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.insert
+"""
+                        ]
+        , test "should replace Set.singleton >> Set.union by Set.insert" <|
+            \() ->
+                """module A exposing (..)
+import Set
+a = Set.singleton >> Set.union
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Set.union with a singleton set can be combined into Set.insert"
+                            , details = [ "You can replace this composition by Set.insert which is meant for this exact purpose." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set
+a = Set.insert
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
The uncontroversial half of the simplifications suggested in https://github.com/jfmengels/elm-review-simplify/issues/342:
```elm
Set.union (Set.singleton a) set
--> Set.insert a set
Set.union << Set.singleton
--> Set.insert

Set.union set (Set.singleton a)
--> Set.insert a set

Dict.union (Dict.singleton k v) dict
--> Dict.insert k v dict
Dict.union << Dict.singleton k
--> Dict.insert k
```

`Set.union set << Set.singleton` is not simplified because I don't know of a way to fix it without creating a lambda or using flip.