### PR TITLE
recognize more patterns and expressions as identical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 The rule now simplifies:
 - `Maybe.withDefault Nothing (Maybe.map f maybe)` to `Maybe.andThen f maybe`
 
+Other improvements:
+- Now recognizes more lambdas as "equivalent to identity",
+  to catch issues like `Maybe.map (\(x, y) -> (x, y))`
+
 ## [2.1.10] - 2025-11-21
 
 The rule now simplifies (thanks to [@miniBill]):

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -3503,8 +3503,8 @@ compositionChecks =
     , basicsIdentityCompositionChecks
     , \checkInfo ->
         case
-            ( AstHelpers.getValueOrFnOrFnCall checkInfo.earlier.node
-            , AstHelpers.getValueOrFnOrFnCall checkInfo.later.node
+            ( AstHelpers.getValueOrFnOrFnCall checkInfo.lookupTable checkInfo.earlier.node
+            , AstHelpers.getValueOrFnOrFnCall checkInfo.lookupTable checkInfo.later.node
             )
         of
             ( Just earlierFnOrCall, Just laterFnOrCall ) ->
@@ -13486,7 +13486,7 @@ caseVariantOfWithUnreachableCasesChecks config checkInfo =
                 , cases : List { patternRange : Range, name : String, attachments : List (Node Pattern), expressionNode : Node Expression }
                 }
         maybeVariantCaseOf =
-            case AstHelpers.getValueOrFnOrFnCall config.casedExpressionNode of
+            case AstHelpers.getValueOrFnOrFnCall checkInfo.lookupTable config.casedExpressionNode of
                 Nothing ->
                     Nothing
 
@@ -14585,7 +14585,7 @@ getRecordTypeAliasConstructorCall :
         }
     -> Maybe { nodeRange : Range, args : List (Node Expression), fieldNames : List String }
 getRecordTypeAliasConstructorCall expressionNode checkInfo =
-    case AstHelpers.getValueOrFnOrFnCall expressionNode of
+    case AstHelpers.getValueOrFnOrFnCall checkInfo.lookupTable expressionNode of
         Nothing ->
             Nothing
 


### PR DESCRIPTION
Implements https://github.com/jfmengels/elm-review-simplify/issues/352. In effect, this enables simplifying for example
```elm
Maybe.map (\(a, b) -> (a, b))
```
Includes:
```elm
\() -> ()
\a -> a
\(a) -> ((a))
\(a,b) -> (a,b)
\(a,b,c) -> (a,b,c)
\(a as unused) -> a
\(unused as a) -> a
\({a,b} as r) -> {r|b=b,a=a}
```
and compositions of these.
Does not include `\(Variant a b) -> Variant a b` due to the issues with phantom types etc discussed in the issue referenced above.