### PR TITLE
Support simplifying ++ "" in more places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The rule now simplifies:
 - `Dict.update k identity dict` to `dict`
 - `Dict.update k (\_ -> Nothing) dict` to `Dict.remove k dict`
 - `Dict.update k (\_ -> Just v) dict` to `Dict.insert k v dict`
+- `"a" ++ "" ++ x"` to `"a" ++ "x"` in more cases
 
 Other improvements:
 - Now recognizes more lambdas as "equivalent to identity",


### PR DESCRIPTION
Seems like we were supporting `"a" ++ ""` -> `"a"`, but if we were to add anything before or after `x ++ "a" ++ "" ++ y` then the simplification would not work.

It was fairly easy to change the code to report an empty string anywhere, but trickier to add the exception to keep `a ++ ""` to enable optimizations (although now that I'm writing this, we should only do that if there is a concatenation, like `a ++ b ++ ""`).

The way I'm doing it is by starting from a string literal  then go to the right. If I find at least one other string literal, then it means I can safely remove one without defeating the `++ ""` optimization.