### PR TITLE
expand "f a a --> a" checks to any equal inner call values across the two arguments and composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,10 @@ The rule now simplifies:
 - `String.left n (String.left n string)` to `String.left n string`
 - `String.right n (String.right n string)` to `String.right n string`
 - `Basics.min n n` to `n`
+- `Basics.min (Basics.min n0 n1) n0` to `Basics.min n0 n1` (any equal inner values across the two arguments, or composition)
 - `Basics.min 3 4` to `3`
 - `Basics.max n n` to `n`
+- `Basics.max (Basics.max n0 n1) n0` to `Basics.max n0 n1` (any equal inner values across the two arguments, or composition)
 - `Basics.max 3 4` to `4`
 - `Basics.compare n n` to `EQ` when [`expectNaN`] is not enabled
 - `Basics.compare 3 4` to `LT`
@@ -36,6 +38,10 @@ The rule now simplifies:
 - `n <= n` to `False` when [`expectNaN`] is not enabled
 - `n >= n` to `False`
 - `Basics.truncate 23.4` to `23` (same for `round`, `floor`, `ceiling`)
+- `Set.union (Set.union set0 set1) set0` to `Set.union set0 set1` (any equal inner values across the two arguments, or composition)
+- `Set.intersect (Set.intersect set0 set1) set0` to `Set.intersect set0 set1` (any equal inner values across the two arguments, or composition)
+- `Dict.union (Dict.union dict0 dict1) dict0` to `Dict.union dict0 dict1` (any equal inner values across the two arguments, or composition)
+- `Dict.intersect (Dict.intersect dict0 dict1) dict0` to `Dict.intersect dict0 dict1` (any equal inner values across the two arguments, or composition)
 
 Other improvements:
 - Now recognizes more lambdas as "equivalent to identity",

--- a/src/Simplify/CoreHelpers.elm
+++ b/src/Simplify/CoreHelpers.elm
@@ -1,6 +1,6 @@
 module Simplify.CoreHelpers exposing
-    ( isJust, isNothing, onNothing
-    , consIf, countUnique, countUniqueBy, findMap, indexedFindMap, findMapAndAllBefore, findMapNeighboring, listAll2, list2AreSameLengthAndAll, drop2EndingsWhile, listIndexedFilterMap, listLast, traverse, traverseConcat, uniqueByThenMap, listMapToStringsThenJoin
+    ( isJust, isNothing, onNothing, maybeWithDefaultLazy
+    , consIf, countUnique, countUniqueBy, findMap, listFind, indexedFindMap, findMapAndAllBefore, findMapNeighboring, listAll2, list2AreSameLengthAndAll, drop2EndingsWhile, listIndexedFilterMap, listLast, traverse, traverseConcat, uniqueByThenMap, listMapToStringsThenJoin
     , listFilledFromList, listFilledHead, listFilledInit, listFilledLast, listFilledLength, listFilledMap, listFilledTail, listFilledToList
     )
 
@@ -10,12 +10,12 @@ moved to a separate module for easier testing etc.
 
 ## Maybe
 
-@docs isJust, isNothing, onNothing
+@docs isJust, isNothing, onNothing, maybeWithDefaultLazy
 
 
 ## List
 
-@docs consIf, countUnique, countUniqueBy, findMap, indexedFindMap, findMapAndAllBefore, findMapNeighboring, listAll2, list2AreSameLengthAndAll, drop2EndingsWhile, listIndexedFilterMap, listLast, traverse, traverseConcat, uniqueByThenMap, listMapToStringsThenJoin
+@docs consIf, countUnique, countUniqueBy, findMap, listFind, indexedFindMap, findMapAndAllBefore, findMapNeighboring, listAll2, list2AreSameLengthAndAll, drop2EndingsWhile, listIndexedFilterMap, listLast, traverse, traverseConcat, uniqueByThenMap, listMapToStringsThenJoin
 
 
 ## `( a, List a )`
@@ -141,6 +141,20 @@ findMap mapper nodes =
 
                 Nothing ->
                     findMap mapper rest
+
+
+listFind : (a -> Bool) -> List a -> Maybe a
+listFind isFound list =
+    case list of
+        [] ->
+            Nothing
+
+        head :: tail ->
+            if isFound head then
+                Just head
+
+            else
+                listFind isFound tail
 
 
 indexedFindMap : (Int -> a -> Maybe b) -> List a -> Maybe b
@@ -446,6 +460,18 @@ listMapToStringsThenJoinAfter soFar elementToString separator list =
 
 
 -- MAYBE HELPERS
+
+
+{-| `Maybe.withDefault` evaluates its value eagerly, which results in wasted computation
+-}
+maybeWithDefaultLazy : (() -> a) -> Maybe a -> a
+maybeWithDefaultLazy fallbackOnNothing maybe =
+    case maybe of
+        Just value ->
+            value
+
+        Nothing ->
+            fallbackOnNothing ()
 
 
 {-| Like `Maybe.andThen` but for the `Nothing` case.

--- a/tests/Simplify/DictTest.elm
+++ b/tests/Simplify/DictTest.elm
@@ -1691,6 +1691,7 @@ import Dict
 a = Dict.intersect
 b = Dict.intersect x
 c = Dict.intersect x y
+d = Dict.intersect (Dict.intersect dict0 dict1) (Dict.union dict2 dict3)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -1781,7 +1782,61 @@ a = value.field |> Dict.intersect (.field value)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = (.field value)
+a = value.field
+"""
+                        ]
+        , test "should replace intersect (intersect (intersect dict2 dict3) dict0) (intersect dict1 dict0) by intersect (intersect dict2 dict3) (intersect dict1 dict0)" <|
+            \() ->
+                """module A exposing (..)
+import Dict exposing (intersect)
+a = Dict.intersect (intersect (intersect dict2 dict3) dict0) (intersect dict1 dict0)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "nested Dict.intersect contains unnecessary equal dicts across both arguments"
+                            , details = [ "You can replace the call that has an equal argument by its other argument." ]
+                            , under = "Dict.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict exposing (intersect)
+a = Dict.intersect (intersect dict2 dict3) (intersect dict1 dict0)
+"""
+                        ]
+        , test "should replace intersect dict0 << intersect dict0 by intersect dict0" <|
+            \() ->
+                """module A exposing (..)
+import Dict exposing (intersect)
+a = Dict.intersect dict0 << intersect dict0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Dict.intersect on Dict.intersect with an equal dict"
+                            , details = [ "You can replace this composition by either its left or right function as both are equivalent." ]
+                            , under = "Dict.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict exposing (intersect)
+a = intersect dict0
+"""
+                        ]
+        , test "should replace intersect dict0 >> intersect dict0 by intersect dict0" <|
+            \() ->
+                """module A exposing (..)
+import Dict exposing (intersect)
+a = intersect dict0 >> Dict.intersect dict0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Dict.intersect on Dict.intersect with an equal dict"
+                            , details = [ "You can replace this composition by either its left or right function as both are equivalent." ]
+                            , under = "Dict.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict exposing (intersect)
+a = intersect dict0
 """
                         ]
         ]
@@ -1969,6 +2024,7 @@ dictUnionTests =
                 """module A exposing (..)
 import Dict
 a = Dict.union x y
+b = Dict.union (Dict.union dict0 dict1) (Dict.union dict2 dict3)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -2239,7 +2295,61 @@ a = value.field |> Dict.union (.field value)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Dict
-a = (.field value)
+a = value.field
+"""
+                        ]
+        , test "should replace union (union (union dict2 dict3) dict0) (union dict1 dict0) by union (union dict2 dict3) (union dict1 dict0)" <|
+            \() ->
+                """module A exposing (..)
+import Dict exposing (union)
+a = Dict.union (union (union dict2 dict3) dict0) (union dict1 dict0)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "nested Dict.union contains unnecessary equal dicts across both arguments"
+                            , details = [ "You can replace the call that has an equal argument by its other argument." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict exposing (union)
+a = Dict.union (union dict2 dict3) (union dict1 dict0)
+"""
+                        ]
+        , test "should replace union dict0 << union dict0 by union dict0" <|
+            \() ->
+                """module A exposing (..)
+import Dict exposing (union)
+a = Dict.union dict0 << union dict0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Dict.union on Dict.union with an equal dict"
+                            , details = [ "You can replace this composition by either its left or right function as both are equivalent." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict exposing (union)
+a = union dict0
+"""
+                        ]
+        , test "should replace union dict0 >> union dict0 by union dict0" <|
+            \() ->
+                """module A exposing (..)
+import Dict exposing (union)
+a = union dict0 >> Dict.union dict0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Dict.union on Dict.union with an equal dict"
+                            , details = [ "You can replace this composition by either its left or right function as both are equivalent." ]
+                            , under = "Dict.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Dict exposing (union)
+a = union dict0
 """
                         ]
         , test "should replace Dict.union (Dict.singleton k v) dict by (Dict.insert k v)" <|

--- a/tests/Simplify/SetTests.elm
+++ b/tests/Simplify/SetTests.elm
@@ -1938,7 +1938,61 @@ a = value.field |> Set.intersect (.field value)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Set
-a = (.field value)
+a = value.field
+"""
+                        ]
+        , test "should replace intersect (intersect (intersect set2 set3) set0) (intersect set1 set0) by intersect (intersect set2 set3) (intersect set1 set0)" <|
+            \() ->
+                """module A exposing (..)
+import Set exposing (intersect)
+a = Set.intersect (intersect (intersect set2 set3) set0) (intersect set1 set0)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "nested Set.intersect contains unnecessary equal sets across both arguments"
+                            , details = [ "You can replace the call that has an equal argument by its other argument." ]
+                            , under = "Set.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set exposing (intersect)
+a = Set.intersect (intersect set2 set3) (intersect set1 set0)
+"""
+                        ]
+        , test "should replace intersect set0 << intersect set0 by intersect set0" <|
+            \() ->
+                """module A exposing (..)
+import Set exposing (intersect)
+a = Set.intersect set0 << intersect set0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Set.intersect on Set.intersect with an equal set"
+                            , details = [ "You can replace this composition by either its left or right function as both are equivalent." ]
+                            , under = "Set.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set exposing (intersect)
+a = intersect set0
+"""
+                        ]
+        , test "should replace intersect set0 >> intersect set0 by intersect set0" <|
+            \() ->
+                """module A exposing (..)
+import Set exposing (intersect)
+a = intersect set0 >> Set.intersect set0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Set.intersect on Set.intersect with an equal set"
+                            , details = [ "You can replace this composition by either its left or right function as both are equivalent." ]
+                            , under = "Set.intersect"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set exposing (intersect)
+a = intersect set0
 """
                         ]
         ]
@@ -2020,6 +2074,7 @@ setUnionTests =
                 """module A exposing (..)
 import Set
 a = Set.union set1 set2
+b = Set.union (Set.union set0 set1) (Set.union set2 set3)
 """
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectNoErrors
@@ -2290,7 +2345,61 @@ a = value.field |> Set.union (.field value)
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 import Set
-a = (.field value)
+a = value.field
+"""
+                        ]
+        , test "should replace union (union (union set2 set3) set0) (union set1 set0) by union (union set2 set3) (union set1 set0)" <|
+            \() ->
+                """module A exposing (..)
+import Set exposing (union)
+a = Set.union (union (union set2 set3) set0) (union set1 set0)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "nested Set.union contains unnecessary equal sets across both arguments"
+                            , details = [ "You can replace the call that has an equal argument by its other argument." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set exposing (union)
+a = Set.union (union set2 set3) (union set1 set0)
+"""
+                        ]
+        , test "should replace union set0 << union set0 by union set0" <|
+            \() ->
+                """module A exposing (..)
+import Set exposing (union)
+a = Set.union set0 << union set0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Set.union on Set.union with an equal set"
+                            , details = [ "You can replace this composition by either its left or right function as both are equivalent." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set exposing (union)
+a = union set0
+"""
+                        ]
+        , test "should replace union set0 >> union set0 by union set0" <|
+            \() ->
+                """module A exposing (..)
+import Set exposing (union)
+a = union set0 >> Set.union set0
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary Set.union on Set.union with an equal set"
+                            , details = [ "You can replace this composition by either its left or right function as both are equivalent." ]
+                            , under = "Set.union"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+import Set exposing (union)
+a = union set0
 """
                         ]
         , test "should replace Set.union (Set.singleton k) set by (Set.insert k)" <|


### PR DESCRIPTION
For `Basics.max`, `Basics.min`, `Set.union`, `Dict.union`, `Set.intersect`, `Dict.intersect` (should apply to any "extremum" function that has the same input and output types), we previously simplified:
```elm
f a a --> a
```
This rule can actually be expanded to cover e.g.
```elm
f (f a d) (f (f a c) b) --> f d (f (f a c) b)
f a >> f (f (f a c) b) --> f (f (f a c) b)
```
or any arbitrarily nested call or composition. Kind of tricky!