### PR TITLE
Rename test files for consistency

### DIFF
--- a/tests/Simplify/ResultTest.elm
+++ b/tests/Simplify/ResultTest.elm
@@ -1,4 +1,4 @@
-module Simplify.ResultTests exposing (all)
+module Simplify.ResultTest exposing (all)
 
 import Review.Test
 import Test exposing (Test, describe, test)

--- a/tests/Simplify/SetTest.elm
+++ b/tests/Simplify/SetTest.elm
@@ -1,4 +1,4 @@
-module Simplify.SetTests exposing (all)
+module Simplify.SetTest exposing (all)
 
 import Review.Test
 import Test exposing (Test, describe, test)


### PR DESCRIPTION
All test files are in the form `XyzTest`, except these two that had a trailing "s".