### PR TITLE
Add tuple access after mapping that part simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ The rule now simplifies:
 - `List.sort (Dict.toList dict)` to `Dict.toList dict`
 - `List.foldl (\v s -> f v s) init (Dict.values dict)` to `Dict.foldl (\_ v s -> f v s) init dict` (same for `foldr`)
 - `List.foldl (\k s -> f k s) init (Dict.keys dict)` to `Dict.foldl (\k _ s -> f k s) init dict` (same for `foldr`)
+- `Tuple.first (Tuple.mapFirst f tuple)` to `f (Tuple.first tuple)`
+- `Tuple.second (Tuple.mapSecond f tuple)` to `f (Tuple.second tuple)`
 
 Other improvements:
 - Now recognizes more lambdas as "equivalent to identity",
@@ -81,6 +83,7 @@ Other improvements:
 - Now recognizes more `if`s as equal or different,
   to for example fix `(if c then 2 else 3) == (if c then 1 else 4)` to `False`
 - Now evaluates `<`, `<=`, `>=`, `>` for any two comparable operands to for example fix `"a" < "b"` to `True`
+- Now fixes `Tuple.first (Tuple.mapBoth changeFirst changeSecond tuple)` to `changeFirst (Tuple.first tuple)` instead of `Tuple.first (Tuple.mapFirst changeFirst tuple)` (same for second)
 
 ## [2.1.10] - 2025-11-21
 

--- a/tests/Simplify/TupleTest.elm
+++ b/tests/Simplify/TupleTest.elm
@@ -178,7 +178,7 @@ a = Tuple.first << Tuple.mapSecond changeSecond
 a = Tuple.first
 """
                         ]
-        , test "should replace Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.first by Tuple.mapFirst changeFirst tuple |> Tuple.first" <|
+        , test "should replace Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.first by changeFirst (Tuple.first tuple)" <|
             \() ->
                 """module A exposing (..)
 a = Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.first
@@ -186,15 +186,15 @@ a = Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.first
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Tuple.mapBoth before Tuple.first is the same as Tuple.mapFirst"
-                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapBoth call by Tuple.mapFirst with the same first mapping and tuple." ]
+                            { message = "Tuple.first on Tuple.mapBoth can be replaced by directly calling the given function on the accessed tuple part"
+                            , details = [ "You can take the 1st function argument of the the Tuple.mapBoth call and call it with the accessed tuple part." ]
                             , under = "Tuple.first"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Tuple.mapFirst changeFirst tuple |> Tuple.first
+a = (changeFirst (Tuple.first tuple))
 """
                         ]
-        , test "should replace Tuple.first << Tuple.mapBoth changeFirst changeSecond by Tuple.first << Tuple.mapFirst changeFirst" <|
+        , test "should replace Tuple.first << Tuple.mapBoth changeFirst changeSecond by changeFirst << Tuple.first" <|
             \() ->
                 """module A exposing (..)
 a = Tuple.first << Tuple.mapBoth changeFirst changeSecond
@@ -202,12 +202,12 @@ a = Tuple.first << Tuple.mapBoth changeFirst changeSecond
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Tuple.mapBoth before Tuple.first is the same as Tuple.mapFirst"
-                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapBoth call by Tuple.mapFirst with the same first mapping." ]
+                            { message = "Tuple.first on Tuple.mapBoth can be replaced by directly calling the given function on the accessed tuple part"
+                            , details = [ "You can take the 1st function argument of the the Tuple.mapBoth call and compose it after the tuple part access." ]
                             , under = "Tuple.first"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Tuple.first << Tuple.mapFirst changeFirst
+a = (changeFirst << Tuple.first)
 """
                         ]
         , test "should replace Tuple.first (List.partition f list) by (List.filter f list)" <|
@@ -488,7 +488,7 @@ a = Tuple.second << Tuple.mapFirst changeSecond
 a = Tuple.second
 """
                         ]
-        , test "should replace Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.second by Tuple.mapFirst changeFirst tuple |> Tuple.second" <|
+        , test "should replace Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.second by changeSecond (Tuple.second tuple)" <|
             \() ->
                 """module A exposing (..)
 a = Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.second
@@ -496,15 +496,15 @@ a = Tuple.mapBoth changeFirst changeSecond tuple |> Tuple.second
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Tuple.mapBoth before Tuple.second is the same as Tuple.mapSecond"
-                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapBoth call by Tuple.mapSecond with the same second mapping and tuple." ]
+                            { message = "Tuple.second on Tuple.mapBoth can be replaced by directly calling the given function on the accessed tuple part"
+                            , details = [ "You can take the 2nd function argument of the the Tuple.mapBoth call and call it with the accessed tuple part." ]
                             , under = "Tuple.second"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Tuple.mapSecond changeSecond tuple |> Tuple.second
+a = (changeSecond (Tuple.second tuple))
 """
                         ]
-        , test "should replace Tuple.second << Tuple.mapBoth changeFirst changeSecond by Tuple.second << Tuple.mapSecond changeSecond" <|
+        , test "should replace Tuple.second << Tuple.mapBoth changeFirst changeSecond by changeSecond << Tuple.second" <|
             \() ->
                 """module A exposing (..)
 a = Tuple.second << Tuple.mapBoth changeFirst changeSecond
@@ -512,12 +512,12 @@ a = Tuple.second << Tuple.mapBoth changeFirst changeSecond
                     |> Review.Test.run ruleWithDefaults
                     |> Review.Test.expectErrors
                         [ Review.Test.error
-                            { message = "Tuple.mapBoth before Tuple.second is the same as Tuple.mapSecond"
-                            , details = [ "Changing a tuple part which ultimately isn't accessed is unnecessary. You can replace the Tuple.mapBoth call by Tuple.mapSecond with the same second mapping." ]
+                            { message = "Tuple.second on Tuple.mapBoth can be replaced by directly calling the given function on the accessed tuple part"
+                            , details = [ "You can take the 2nd function argument of the the Tuple.mapBoth call and compose it after the tuple part access." ]
                             , under = "Tuple.second"
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
-a = Tuple.second << Tuple.mapSecond changeSecond
+a = (changeSecond << Tuple.second)
 """
                         ]
         , test "should replace Tuple.second (Tuple.mapSecond f tuple) by f (Tuple.second tuple)" <|


### PR DESCRIPTION
Implements/closes https://github.com/jfmengels/elm-review-simplify/issues/335
```elm
Tuple.first (Tuple.mapFirst changeFirst tuple)
--> changeFirst (Tuple.first tuple)

Tuple.second (Tuple.mapSecond changeSecond tuple)
--> changeSecond (Tuple.second tuple)
```
including composition.

Also changes the fix of
```elm
-- same for second
Tuple.first (Tuple.mapBoth changeFirst changeSecond tuple)
--> changeFirst (Tuple.first tuple)
-- instead of Tuple.first (Tuple.mapFirst changeFirst tuple)
```

The fixes are done in a let's say "creative" way to avoid extracting source code :sweat_smile: 