### PR TITLE
Add List.foldl on List.reverse checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The rule now simplifies:
 - `Set.intersect (Set.intersect set0 set1) set0` to `Set.intersect set0 set1` (any equal inner values across the two arguments, or composition)
 - `Dict.union (Dict.union dict0 dict1) dict0` to `Dict.union dict0 dict1` (any equal inner values across the two arguments, or composition)
 - `Dict.intersect (Dict.intersect dict0 dict1) dict0` to `Dict.intersect dict0 dict1` (any equal inner values across the two arguments, or composition)
+- `List.foldl f x (List.reverse list)` to `List.foldr f x list` (same for `foldr`)
 - `List.foldl f x (Array.toList array)` to `Array.foldl f x array` (same for `foldr`)
 - `Array.foldl f x (Array.fromList list)` to `List.foldl f x array` (same for `foldr`)
 - `List.member x (Set.toList set)` to `Set.member x set` when [`expectNaN`] is not enabled

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -826,6 +826,9 @@ Destructuring using case expressions
     List.foldl (||) True list
     --> True
 
+    List.foldl f initial (List.reverse list)
+    --> List.foldr f initial list
+
     Array.foldl f x (Array.fromList list)
     --> List.foldl f x array
 
@@ -7235,16 +7238,16 @@ listMaximumChecks =
 
 listFoldlChecks : IntoFnCheck
 listFoldlChecks =
-    listFoldChecks "foldl"
+    listFoldChecks "foldl" "foldr"
 
 
 listFoldrChecks : IntoFnCheck
 listFoldrChecks =
-    listFoldChecks "foldr"
+    listFoldChecks "foldr" "foldl"
 
 
-listFoldChecks : String -> IntoFnCheck
-listFoldChecks foldFnName =
+listFoldChecks : String -> String -> IntoFnCheck
+listFoldChecks foldFnName reverseFoldFnName =
     intoFnChecksFirstThatConstructsError
         [ intoFnCheckOnlyCall (emptiableFoldChecks listCollection)
         , intoFnCheckOnlyCall
@@ -7378,6 +7381,12 @@ listFoldChecks foldFnName =
                                     else
                                         Nothing
             )
+        , onConversionFnCallCanBeCombinedCheck
+            { combinedOperationRepresents = "fold a list"
+            , convertFn = Fn.List.reverse
+            , actionRepresents = "reverse it"
+            , combinedFn = ( [ "List" ], reverseFoldFnName )
+            }
         , onConversionFnCallCanBeCombinedCheck
             { combinedOperationRepresents = "fold a set"
             , convertFn = Fn.Set.toList

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -4405,6 +4405,38 @@ a = Dict.keys >> List.foldl (\\a s -> f a s) init
 a = Dict.foldl (\\a _ s -> f a s) init
 """
                         ]
+        , test "should replace List.foldl f x << List.reverse by List.foldr f x" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl f x << List.reverse
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a list, you don't need to reverse it"
+                            , details = [ "Using List.foldr directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.foldr f x
+"""
+                        ]
+        , test "should replace List.foldl f x (List.reverse list) by List.foldr f x list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldl f x (List.reverse list)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a list, you don't need to reverse it"
+                            , details = [ "Using List.foldr directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldl"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.foldr f x list
+"""
+                        ]
         , listFoldlSumTests
         , listFoldlProductTests
         , listFoldlAllTests
@@ -5616,6 +5648,38 @@ a = Dict.keys >> List.foldr (\\a s -> f a s) init
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = Dict.foldr (\\a _ s -> f a s) init
+"""
+                        ]
+        , test "should replace List.foldr f x (List.reverse list) by List.foldl f x list" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr f x (List.reverse list)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a list, you don't need to reverse it"
+                            , details = [ "Using List.foldl directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.foldl f x list
+"""
+                        ]
+        , test "should replace List.foldr f x << List.reverse by List.foldl f x" <|
+            \() ->
+                """module A exposing (..)
+a = List.foldr f x << List.reverse
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "To fold a list, you don't need to reverse it"
+                            , details = [ "Using List.foldl directly is meant for this exact purpose and will also be faster." ]
+                            , under = "List.foldr"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.foldl f x
 """
                         ]
         , listFoldrSumTests

--- a/tests/Simplify/SimplificationCorrectnessTest.elm
+++ b/tests/Simplify/SimplificationCorrectnessTest.elm
@@ -54,6 +54,30 @@ all =
                                 []
                         )
             )
+        , Test.fuzz
+            (Fuzz.list Fuzz.string)
+            "List.reverse >> List.foldl is the same as List.foldr"
+            (\list ->
+                list
+                    |> List.reverse
+                    |> List.foldl (::) []
+                    |> Expect.equalLists
+                        (list
+                            |> List.foldr (::) []
+                        )
+            )
+        , Test.fuzz
+            (Fuzz.list Fuzz.string)
+            "List.reverse >> List.foldr is the same as List.foldl"
+            (\list ->
+                list
+                    |> List.reverse
+                    |> List.foldr (::) []
+                    |> Expect.equalLists
+                        (list
+                            |> List.foldl (::) []
+                        )
+            )
         ]
 
 


### PR DESCRIPTION
Adds this check from #2 (which we should at this point close and re-open in separate issues to make it easier to close them).

```elm
List.foldl f initial (List.reverse list)
--> List.foldr f initial list

List.foldr f initial (List.reverse list)
--> List.foldl f initial list
```

and composition