### PR TITLE
Remove List.sum/product on list reorder operation simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 ## [Unreleased]
+- Disabled `List.sum` and `List.product` simplifications on list reordering operations: `List.reverse`, `List.sort`, `List.sortBy`, `List.sortWith`.
+  Applying floating point operations across elements using lots of intermediate temporary numbers can loose some amount of precision, and importantly the order in which the numbers are traversed will influence how much precision is lost. An illustrative example by [Sébastien Besnier](https://github.com/sebsheep):
+  ```elm
+  List.sum (1 :: List.repeat 100000 (2^(-53)))
+  ```
+  will result in `1` because the tiny fraction gets "swallowed" by the much larger accumulated value whereas
+  ```elm
+  List.sum (List.reverse (1 :: List.repeat 100000 (2^(-53))))
+  ```
+  will result in a more correct `1.0000000000111022`.
+  
+  You can read more about this problem in the [documentation of javascript's `Math.sumPrecise()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sumPrecise#description)
 
 ## [2.1.13] - 2026-01-07
 

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -790,10 +790,6 @@ Destructuring using case expressions
     List.sum [ a, 0 / 0, b ]
     --> 0 / 0
 
-    -- same for List.sort, List.sortBy, List.sortWith
-    List.sum (List.reverse list)
-    --> List.sum list
-
     List.product []
     --> 1
 
@@ -802,10 +798,6 @@ Destructuring using case expressions
 
     List.product [ a, 1, b ]
     --> List.product [ a, b ]
-
-    -- same for List.sort, List.sortBy, List.sortWith
-    List.product (List.reverse list)
-    --> List.product list
 
     -- when `expectNaN` is not enabled
     List.product [ a, 0, b ]
@@ -8103,7 +8095,6 @@ listSumChecks : IntoFnCheck
 listSumChecks =
     intoFnChecksFirstThatConstructsError
         [ onWrappedReturnsItsValueCheck listCollection
-        , listReorderOperationsBeforeAreUnnecessaryChecks "combined sum"
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 callOnEmptyReturnsCheck { resultAsString = \_ -> "0" } listCollection checkInfo
@@ -8131,7 +8122,6 @@ listProductChecks : IntoFnCheck
 listProductChecks =
     intoFnChecksFirstThatConstructsError
         [ onWrappedReturnsItsValueCheck listCollection
-        , listReorderOperationsBeforeAreUnnecessaryChecks "combined product"
         , intoFnCheckOnlyCall
             (\checkInfo ->
                 callOnEmptyReturnsCheck { resultAsString = \_ -> "1" } listCollection checkInfo

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -3909,70 +3909,16 @@ a = [ a, 0 / 0.0, b ] |> List.sum
 a = (0 / 0.0)
 """
                         ]
-        , test "should replace List.sum (List.reverse list) by List.sum list" <|
+        , test "should not report List.sum (reorderingOperation list) due to precision loss, see the changelog for 2.1.14" <|
             \() ->
                 """module A exposing (..)
-a = List.sum (List.reverse list)
+a0 = List.sum (List.reverse list)
+a1 = List.sum (List.sort list)
+a2 = List.sum (List.sortBy f list)
+a3 = List.sum (List.sortWith f list)
 """
-                    |> Review.Test.run ruleExpectingNaN
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.reverse before List.sum"
-                            , details = [ "Reordering a list does not affect its combined sum. You can replace the List.reverse call by the unchanged list." ]
-                            , under = "List.sum"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.sum list
-"""
-                        ]
-        , test "should replace List.sum (List.sort list) by List.sum list" <|
-            \() ->
-                """module A exposing (..)
-a = List.sum (List.sort list)
-"""
-                    |> Review.Test.run ruleExpectingNaN
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.sort before List.sum"
-                            , details = [ "Reordering a list does not affect its combined sum. You can replace the List.sort call by the unchanged list." ]
-                            , under = "List.sum"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.sum list
-"""
-                        ]
-        , test "should replace List.sum (List.sortBy f list) by List.sum list" <|
-            \() ->
-                """module A exposing (..)
-a = List.sum (List.sortBy f list)
-"""
-                    |> Review.Test.run ruleExpectingNaN
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.sortBy before List.sum"
-                            , details = [ "Reordering a list does not affect its combined sum. You can replace the List.sortBy call by the unchanged list." ]
-                            , under = "List.sum"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.sum list
-"""
-                        ]
-        , test "should replace List.sum (List.sortWith f list) by List.sum list" <|
-            \() ->
-                """module A exposing (..)
-a = List.sum (List.sortWith f list)
-"""
-                    |> Review.Test.run ruleExpectingNaN
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.sortWith before List.sum"
-                            , details = [ "Reordering a list does not affect its combined sum. You can replace the List.sortWith call by the unchanged list." ]
-                            , under = "List.sum"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.sum list
-"""
-                        ]
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
         ]
 
 
@@ -4178,70 +4124,16 @@ a = [ a, 0 / 0.0, b ] |> List.product
 a = (0 / 0.0)
 """
                         ]
-        , test "should replace List.product (List.reverse list) by List.product list" <|
+        , test "should not report List.product (reorderingOperation list) due to precision loss, see the changelog for 2.1.14" <|
             \() ->
                 """module A exposing (..)
-a = List.product (List.reverse list)
+a0 = List.product (List.reverse list)
+a1 = List.product (List.sort list)
+a2 = List.product (List.sortBy f list)
+a3 = List.product (List.sortWith f list)
 """
-                    |> Review.Test.run ruleExpectingNaN
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.reverse before List.product"
-                            , details = [ "Reordering a list does not affect its combined product. You can replace the List.reverse call by the unchanged list." ]
-                            , under = "List.product"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.product list
-"""
-                        ]
-        , test "should replace List.product (List.sort list) by List.product list" <|
-            \() ->
-                """module A exposing (..)
-a = List.product (List.sort list)
-"""
-                    |> Review.Test.run ruleExpectingNaN
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.sort before List.product"
-                            , details = [ "Reordering a list does not affect its combined product. You can replace the List.sort call by the unchanged list." ]
-                            , under = "List.product"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.product list
-"""
-                        ]
-        , test "should replace List.product (List.sortBy f list) by List.product list" <|
-            \() ->
-                """module A exposing (..)
-a = List.product (List.sortBy f list)
-"""
-                    |> Review.Test.run ruleExpectingNaN
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.sortBy before List.product"
-                            , details = [ "Reordering a list does not affect its combined product. You can replace the List.sortBy call by the unchanged list." ]
-                            , under = "List.product"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.product list
-"""
-                        ]
-        , test "should replace List.product (List.sortWith f list) by List.product list" <|
-            \() ->
-                """module A exposing (..)
-a = List.product (List.sortWith f list)
-"""
-                    |> Review.Test.run ruleExpectingNaN
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary List.sortWith before List.product"
-                            , details = [ "Reordering a list does not affect its combined product. You can replace the List.sortWith call by the unchanged list." ]
-                            , under = "List.product"
-                            }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = List.product list
-"""
-                        ]
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
         ]
 
 


### PR DESCRIPTION
As [discussed on slack](https://elmlang.slack.com/archives/C0K384K4Y/p1767786487531849),
`List.sum` and `List.product` can result in floats with different precision on reordered lists, so all such simplifications have been removed