### PR TITLE
Add basic String operation simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ The rule now simplifies:
 - `String.toUpper ""` to `""`
 - `String.toUpper (String.toUpper str)` to `String.toUpper str`
 - `String.toUpper (String.toLower str)` to `String.toUpper str`
+- `String.trimLeft ""` to `""`
+- `String.trimLeft (String.trimLeft str)` to `String.trimLeft str`
+- `String.trimLeft (String.trimRight str)` to `String.trim str`
+- `String.trimLeft (String.trim str)` to `String.trim str`
+- `String.trimRight ""` to `""`
+- `String.trimRight (String.trimLeft str)` to `String.trim str`
+- `String.trimRight (String.trimRight str)` to `String.trimRight str`
+- `String.trimRight (String.trim str)` to `String.trim str`
+- `String.trim ""` to `""`
+- `String.trim (String.trimLeft str)` to `String.trim str`
+- `String.trim (String.trimRight str)` to `String.trim str`
+- `String.trim (String.trim str)` to `String.trim str`
 - comparison operations like `List.length l >= min -1 n` to `True` where intervals can be determined to always pass or fail the comparison
 
 Bug fixes:

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -503,6 +503,42 @@ Destructuring using case expressions
     String.reverse (String.reverse str)
     --> str
 
+    String.trimLeft ""
+    --> ""
+
+    String.trimLeft (String.trimLeft str)
+    --> String.trimLeft str
+
+    String.trimLeft (String.trimRight str)
+    --> String.trim str
+
+    String.trimLeft (String.trim str)
+    --> String.trim str
+
+    String.trimRight ""
+    --> ""
+
+    String.trimRight (String.trimLeft str)
+    --> String.trim str
+
+    String.trimRight (String.trimRight str)
+    --> String.trimRight str
+
+    String.trimRight (String.trim str)
+    --> String.trim str
+
+    String.trim ""
+    --> ""
+
+    String.trim (String.trimLeft str)
+    --> String.trim str
+
+    String.trim (String.trimRight str)
+    --> String.trim str
+
+    String.trim (String.trim str)
+    --> String.trim str
+
     String.slice n n str
     --> ""
 
@@ -4142,6 +4178,9 @@ intoFnChecks =
     , ( Fn.String.toLower, ( 1, stringToLowerChecks ) )
     , ( Fn.String.toUpper, ( 1, stringToUpperChecks ) )
     , ( Fn.String.reverse, ( 1, stringReverseChecks ) )
+    , ( Fn.String.trimLeft, ( 1, stringTrimLeftChecks ) )
+    , ( Fn.String.trimRight, ( 1, stringTrimRightChecks ) )
+    , ( Fn.String.trim, ( 1, stringTrimChecks ) )
     , ( Fn.String.slice, ( 3, stringSliceChecks ) )
     , ( Fn.String.left, ( 2, stringLeftChecks ) )
     , ( Fn.String.right, ( 2, stringRightChecks ) )
@@ -7367,6 +7406,58 @@ stringReverseChecks =
     intoFnChecksFirstThatConstructsError
         [ emptiableReverseChecks stringCollection
         , unnecessaryOnWrappedCheck stringCollection
+        ]
+
+
+stringTrimLeftChecks : IntoFnCheck
+stringTrimLeftChecks =
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryOnEmptyCheck stringCollection
+        , operationDoesNotChangeResultOfOperationCheck
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.String.trimRight
+            , combinedFn = Fn.String.trim
+            }
+        , unnecessaryOnSpecificFnCallCheck Fn.String.trim
+        ]
+
+
+stringTrimRightChecks : IntoFnCheck
+stringTrimRightChecks =
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryOnEmptyCheck stringCollection
+        , operationDoesNotChangeResultOfOperationCheck
+        , onSpecificFnCallCanBeCombinedCheck
+            { args = []
+            , earlierFn = Fn.String.trimLeft
+            , combinedFn = Fn.String.trim
+            }
+        , unnecessaryOnSpecificFnCallCheck Fn.String.trim
+        ]
+
+
+stringTrimChecks : IntoFnCheck
+stringTrimChecks =
+    intoFnChecksFirstThatConstructsError
+        [ unnecessaryOnEmptyCheck stringCollection
+        , operationDoesNotChangeResultOfOperationCheck
+        , unnecessarySpecificFnBeforeCheck
+            { fn = Fn.String.trimLeft
+            , fnArgCount = 1
+            , fnLastArgRepresents = "string"
+            , whyUnnecessary =
+                "Trimming from the start is already covered by the final "
+                    ++ qualifiedToString Fn.String.trim
+            }
+        , unnecessarySpecificFnBeforeCheck
+            { fn = Fn.String.trimRight
+            , fnArgCount = 1
+            , fnLastArgRepresents = "string"
+            , whyUnnecessary =
+                "Trimming from the end is already covered by the final "
+                    ++ qualifiedToString Fn.String.trim
+            }
         ]
 
 

--- a/tests/Simplify/SimplificationCorrectnessTest.elm
+++ b/tests/Simplify/SimplificationCorrectnessTest.elm
@@ -414,6 +414,69 @@ all =
                     |> Expect.equal
                         (String.toLower string)
             )
+        , Test.fuzz Fuzz.string
+            "String.trimLeft << String.trimRight is the same as String.trim"
+            (\string ->
+                String.trimLeft (String.trimRight string)
+                    |> Expect.equal
+                        (String.trim string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.trimRight << String.trimLeft is the same as String.trim"
+            (\string ->
+                String.trimRight (String.trimLeft string)
+                    |> Expect.equal
+                        (String.trim string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.trimLeft << String.trim is the same as String.trim"
+            (\string ->
+                String.trimLeft (String.trim string)
+                    |> Expect.equal
+                        (String.trim string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.trimRight << String.trim is the same as String.trim"
+            (\string ->
+                String.trimRight (String.trim string)
+                    |> Expect.equal
+                        (String.trim string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.trim << String.trim is the same as String.trim"
+            (\string ->
+                String.trim (String.trim string)
+                    |> Expect.equal
+                        (String.trim string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.trimRight << String.trimRight is the same as String.trimRight"
+            (\string ->
+                String.trimRight (String.trimRight string)
+                    |> Expect.equal
+                        (String.trimRight string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.trimLeft << String.trimLeft is the same as String.trimLeft"
+            (\string ->
+                String.trimLeft (String.trimLeft string)
+                    |> Expect.equal
+                        (String.trimLeft string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.trim << String.trimLeft is the same as String.trim"
+            (\string ->
+                String.trim (String.trimLeft string)
+                    |> Expect.equal
+                        (String.trim string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.trim << String.trimRight is the same as String.trim"
+            (\string ->
+                String.trim (String.trimRight string)
+                    |> Expect.equal
+                        (String.trim string)
+            )
         ]
 
 

--- a/tests/Simplify/StringTest.elm
+++ b/tests/Simplify/StringTest.elm
@@ -24,6 +24,9 @@ all =
         , stringToLowerTests
         , stringToUpperTests
         , stringReverseTests
+        , stringTrimLeftTests
+        , stringTrimRightTests
+        , stringTrimTests
         , stringSliceTests
         , stringRightTests
         , stringLeftTests
@@ -1773,6 +1776,201 @@ a = String.reverse << (String.reverse << f)
                             |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 19 } }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = (f)
+"""
+                        ]
+        ]
+
+
+stringTrimLeftTests : Test
+stringTrimLeftTests =
+    describe "String.trimLeft"
+        [ test "should not report String.trimLeft with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a0 = String.trimLeft
+a1 = String.trimLeft str
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace String.trimLeft (String.trimLeft str) by String.trimLeft str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trimLeft (String.trimLeft str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary String.trimLeft after String.trimLeft"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "String.trimLeft"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 20 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.trimLeft str
+"""
+                        ]
+        , test "should replace String.trimLeft (String.trimRight str) by String.trim str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trimLeft (String.trimRight str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.trimRight, then String.trimLeft can be combined into String.trim"
+                            , details = [ "You can replace this call by String.trim with the same arguments given to String.trimRight which is meant for this exact purpose." ]
+                            , under = "String.trimLeft"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 20 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (String.trim str)
+"""
+                        ]
+        , test "should replace String.trimLeft (String.trim str) by String.trim str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trimLeft (String.trim str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary String.trimLeft on a String.trim call"
+                            , details = [ "You can replace this call by the given String.trim call." ]
+                            , under = "String.trimLeft"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 20 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.trim str
+"""
+                        ]
+        ]
+
+
+stringTrimRightTests : Test
+stringTrimRightTests =
+    describe "String.trimRight"
+        [ test "should not report String.trimRight with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a0 = String.trimRight
+a1 = String.trimRight str
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace String.trimRight (String.trimRight str) by String.trimRight str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trimRight (String.trimRight str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary String.trimRight after String.trimRight"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "String.trimRight"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 21 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.trimRight str
+"""
+                        ]
+        , test "should replace String.trimRight (String.trimLeft str) by String.trim str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trimRight (String.trimLeft str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.trimLeft, then String.trimRight can be combined into String.trim"
+                            , details = [ "You can replace this call by String.trim with the same arguments given to String.trimLeft which is meant for this exact purpose." ]
+                            , under = "String.trimRight"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 21 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (String.trim str)
+"""
+                        ]
+        , test "should replace String.trimRight (String.trim str) by String.trim str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trimRight (String.trim str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary String.trimRight on a String.trim call"
+                            , details = [ "You can replace this call by the given String.trim call." ]
+                            , under = "String.trimRight"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 21 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.trim str
+"""
+                        ]
+        ]
+
+
+stringTrimTests : Test
+stringTrimTests =
+    describe "String.trim"
+        [ test "should not report String.trim with okay arguments" <|
+            \() ->
+                """module A exposing (..)
+a0 = String.trim
+a1 = String.trim str
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectNoErrors
+        , test "should replace String.trim (String.trim str) by String.trim str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trim (String.trim str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary String.trim after String.trim"
+                            , details = [ "You can remove this additional operation." ]
+                            , under = "String.trim"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 16 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.trim str
+"""
+                        ]
+        , test "should replace String.trim (String.trimLeft str) by String.trim str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trim (String.trimLeft str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary String.trimLeft before String.trim"
+                            , details = [ "Trimming from the start is already covered by the final String.trim. You can replace the String.trimLeft call by the unchanged string." ]
+                            , under = "String.trim"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 16 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.trim str
+"""
+                        ]
+        , test "should replace String.trim (String.trimRight str) by String.trim str" <|
+            \() ->
+                """module A exposing (..)
+a = String.trim (String.trimRight str)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Unnecessary String.trimRight before String.trim"
+                            , details = [ "Trimming from the end is already covered by the final String.trim. You can replace the String.trimRight call by the unchanged string." ]
+                            , under = "String.trim"
+                            }
+                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 16 } }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = String.trim str
 """
                         ]
         ]


### PR DESCRIPTION
A bunch of String operations don't have simplifiations, this adds simple ones.
Full list in the changelog diff. Composition also implemented.