### PR TITLE
remove incorrect String.toUpper on String.toLower simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ The rule now simplifies:
 - `String.toLower (String.toLower str)` to `String.toLower str`
 - `String.toUpper ""` to `""`
 - `String.toUpper (String.toUpper str)` to `String.toUpper str`
-- `String.toUpper (String.toLower str)` to `String.toUpper str`
 - `String.trimLeft ""` to `""`
 - `String.trimLeft (String.trimLeft str)` to `String.trimLeft str`
 - `String.trimLeft (String.trimRight str)` to `String.trim str`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -491,9 +491,6 @@ Destructuring using case expressions
     String.toUpper (String.toUpper str)
     --> String.toUpper str
 
-    String.toUpper (String.toLower str)
-    --> String.toUpper str
-
     String.reverse ""
     --> ""
 
@@ -7609,14 +7606,6 @@ stringToUpperChecks =
     intoFnChecksFirstThatConstructsError
         [ unnecessaryOnEmptyCheck stringCollection
         , operationDoesNotChangeResultOfOperationCheck
-        , unnecessarySpecificFnBeforeCheck
-            { fn = Fn.String.toLower
-            , fnArgCount = 1
-            , fnLastArgRepresents = "string"
-            , whyUnnecessary =
-                "Lowercasing uppercase characters will be overwritten by the final "
-                    ++ qualifiedToString Fn.String.toUpper
-            }
         ]
 
 

--- a/tests/Simplify/SimplificationCorrectnessTest.elm
+++ b/tests/Simplify/SimplificationCorrectnessTest.elm
@@ -4,7 +4,7 @@ import Dict
 import Expect
 import Fuzz
 import Set
-import Test exposing (Test)
+import Test exposing (Test, test)
 
 
 all : Test
@@ -445,12 +445,12 @@ all =
                     |> Expect.equal
                         (String.toUpper string)
             )
-        , Test.fuzz Fuzz.string
-            "String.toUpper << String.toLower is the same as String.toUpper"
-            (\string ->
-                String.toUpper (String.toLower string)
-                    |> Expect.equal
-                        (String.toUpper string)
+        , test "String.toUpper << String.toLower is NOT the same as String.toUpper"
+            (\() ->
+                -- https://github.com/jfmengels/elm-review-simplify/pull/429#issuecomment-3746681750
+                String.toUpper (String.toLower "Ω")
+                    |> Expect.notEqual
+                        (String.toUpper "Ω")
             )
         , Test.fuzz Fuzz.string
             "String.toLower << String.toLower is the same as String.toLower"

--- a/tests/Simplify/StringTest.elm
+++ b/tests/Simplify/StringTest.elm
@@ -1742,40 +1742,20 @@ a = String.toUpper << String.toUpper
 a = String.toUpper
 """
                         ]
-        , test "should replace String.toUpper (String.toLower str) to String.toUpper str" <|
+        , test "should not report String.toUpper (String.toLower str), see https://github.com/jfmengels/elm-review-simplify/pull/429#issuecomment-3746681750" <|
             \() ->
                 """module A exposing (..)
 a = String.toUpper (String.toLower str)
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary String.toLower before String.toUpper"
-                            , details = [ "Lowercasing uppercase characters will be overwritten by the final String.toUpper. You can replace the String.toLower call by the unchanged string." ]
-                            , under = "String.toUpper"
-                            }
-                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 19 } }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = String.toUpper str
-"""
-                        ]
-        , test "should replace String.toUpper << String.toLower to String.toUpper" <|
+                    |> Review.Test.expectNoErrors
+        , test "should not report String.toUpper << String.toLower, see https://github.com/jfmengels/elm-review-simplify/pull/429#issuecomment-3746681750" <|
             \() ->
                 """module A exposing (..)
 a = String.toUpper << String.toLower
 """
                     |> Review.Test.run ruleWithDefaults
-                    |> Review.Test.expectErrors
-                        [ Review.Test.error
-                            { message = "Unnecessary String.toLower before String.toUpper"
-                            , details = [ "Lowercasing uppercase characters will be overwritten by the final String.toUpper. You can remove the String.toLower call." ]
-                            , under = "String.toUpper"
-                            }
-                            |> Review.Test.atExactly { start = { row = 2, column = 5 }, end = { row = 2, column = 19 } }
-                            |> Review.Test.whenFixed """module A exposing (..)
-a = String.toUpper
-"""
-                        ]
+                    |> Review.Test.expectNoErrors
         ]
 
 


### PR DESCRIPTION
Removes
```elm
String.toUpper (String.toLower str) --> String.toUpper str
String.toUpper << String.toLower --> String.toUpper
```
due to https://github.com/jfmengels/elm-review-simplify/pull/429#issuecomment-3746681750