### PR TITLE
Add List.any/all identity on List.map simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The rule now simplifies:
 - `List.any f (List.repeat n a)` to `n >= 1 && f a`
 - `List.member needle (List.repeat n b)` to `n >= 1 && needle == b`
 - `List.all f (List.repeat n a)` to `n <= 0 || f a`
+- `List.any identity (List.map f list)` to `List.any f list`
+- `List.all identity (List.map f list)` to `List.all f list`
 - `List.isEmpty (List.filter f list)` to `not (List.any f list)`
 - `List.isEmpty (List.filter (not << f) list)` to `List.all f list`
 - `not (List.any (not << f) list)` to `List.all f list`

--- a/src/Simplify.elm
+++ b/src/Simplify.elm
@@ -1030,6 +1030,9 @@ Destructuring using case expressions
     List.all f (List.repeat n a)
     --> n <= 0 || f a
 
+    List.all identity (List.map f list)
+    --> List.all f list
+
     not (List.all (not << f) list)
     --> List.any f list
 
@@ -1056,6 +1059,9 @@ Destructuring using case expressions
 
     List.any f (List.repeat n a)
     --> n >= 1 && f a
+
+    List.any identity (List.map f list)
+    --> List.any f list
 
     not (List.any (not << f) list)
     --> List.all f list
@@ -9984,12 +9990,15 @@ listLengthChecks =
 
 listAllChecks : IntoFnCheck
 listAllChecks =
-    intoFnCheckOnlyCall
-        (\checkInfo ->
-            emptiableAllChecks listCollection checkInfo
-                |> onNothing (\() -> collectionAllChecks listCollection checkInfo)
-                |> onNothing (\() -> listAllOnRepeatCallCheck checkInfo)
-        )
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall
+            (\checkInfo ->
+                emptiableAllChecks listCollection checkInfo
+                    |> onNothing (\() -> collectionAllChecks listCollection checkInfo)
+                    |> onNothing (\() -> listAllOnRepeatCallCheck checkInfo)
+            )
+        , mapToOperationWithIdentityCanBeCombinedToOperationChecks listCollection
+        ]
 
 
 listAllOnRepeatCallCheck : CallCheckInfo -> Maybe (Error {})
@@ -10050,14 +10059,17 @@ listAllOnRepeatCallCheck checkInfo =
 
 listAnyChecks : IntoFnCheck
 listAnyChecks =
-    intoFnCheckOnlyCall
-        (\checkInfo ->
-            emptiableAnyChecks listCollection checkInfo
-                |> onNothing (\() -> collectionAnyChecks listCollection checkInfo)
-                |> onNothing
-                    (\() -> operationWithEqualsConstantIsEquivalentToFnWithThatConstantCheck Fn.List.member checkInfo)
-                |> onNothing (\() -> listAnyOnRepeatCallCheck checkInfo)
-        )
+    intoFnChecksFirstThatConstructsError
+        [ intoFnCheckOnlyCall
+            (\checkInfo ->
+                emptiableAnyChecks listCollection checkInfo
+                    |> onNothing (\() -> collectionAnyChecks listCollection checkInfo)
+                    |> onNothing
+                        (\() -> operationWithEqualsConstantIsEquivalentToFnWithThatConstantCheck Fn.List.member checkInfo)
+                    |> onNothing (\() -> listAnyOnRepeatCallCheck checkInfo)
+            )
+        , mapToOperationWithIdentityCanBeCombinedToOperationChecks listCollection
+        ]
 
 
 listAnyOnRepeatCallCheck : CallCheckInfo -> Maybe (Error {})

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -8070,6 +8070,38 @@ a = List.all (f <| y) <| List.repeat n <| g <| x
 a = ((n <= 0) || ((f <| y) <| (g <| x)))
 """
                         ]
+        , test "should replace List.all identity (List.map f list) by List.all f list" <|
+            \() ->
+                """module A exposing (..)
+a = List.all identity (List.map f list)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map, then List.all with an identity function can be combined into List.all"
+                            , details = [ "You can replace this call by List.all with the same arguments given to List.map which is meant for this exact purpose." ]
+                            , under = "List.all"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.all f list)
+"""
+                        ]
+        , test "should replace List.all identity << List.map f by List.all f" <|
+            \() ->
+                """module A exposing (..)
+a = List.all identity << List.map f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map, then List.all with an identity function can be combined into List.all"
+                            , details = [ "You can replace this composition by List.all with the same arguments given to List.map which is meant for this exact purpose." ]
+                            , under = "List.all"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.all f
+"""
+                        ]
         ]
 
 
@@ -8294,6 +8326,38 @@ a = List.any (f <| y) <| List.repeat n <| g <| x
                             }
                             |> Review.Test.whenFixed """module A exposing (..)
 a = ((n >= 1) && ((f <| y) <| (g <| x)))
+"""
+                        ]
+        , test "should replace List.any identity (List.map f list) by List.any f list" <|
+            \() ->
+                """module A exposing (..)
+a = List.any identity (List.map f list)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map, then List.any with an identity function can be combined into List.any"
+                            , details = [ "You can replace this call by List.any with the same arguments given to List.map which is meant for this exact purpose." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.any f list)
+"""
+                        ]
+        , test "should replace List.any identity << List.map f by List.any f" <|
+            \() ->
+                """module A exposing (..)
+a = List.any identity << List.map f
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.map, then List.any with an identity function can be combined into List.any"
+                            , details = [ "You can replace this composition by List.any with the same arguments given to List.map which is meant for this exact purpose." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = List.any f
 """
                         ]
         ]


### PR DESCRIPTION
Implements/closes https://github.com/jfmengels/elm-review-simplify/issues/428
```elm
List.all identity (List.map f list)
--> List.all f list

List.any identity (List.map f list)
--> List.any f list
```
including composition