### PR TITLE
Add any/all (always True/False) simplifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The rule now simplifies:
 - `List.all f (List.repeat n a)` to `n <= 0 || f a`
 - `List.all (always False) list` to `List.isEmpty list`
 - `String.all (always False) str` to `String.isEmpty str`
+- `List.any (always True) list` to `not (List.isEmpty list)`
+- `String.any (always True) str` to `not (String.isEmpty str)`
 - `List.any identity (List.map f list)` to `List.any f list`
 - `List.all identity (List.map f list)` to `List.all f list`
 - `List.isEmpty (List.filter f list)` to `not (List.any f list)`

--- a/tests/Simplify/ListTest.elm
+++ b/tests/Simplify/ListTest.elm
@@ -8424,6 +8424,102 @@ a = List.any identity << List.map f
 a = List.any f
 """
                         ]
+        , test "should replace List.any (always True) list by not (List.isEmpty list)" <|
+            \() ->
+                """module A exposing (..)
+a = List.any (always True) list
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with a function that will always return True is the same as Basics.not on List.isEmpty"
+                            , details = [ "You can replace this call by Basics.not on List.isEmpty on the list given to the List.any call." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = not (List.isEmpty list)
+"""
+                        ]
+        , test "should replace List.any (always True) <| f <| x by not <| List.isEmpty <| f <| x" <|
+            \() ->
+                """module A exposing (..)
+a = List.any (always True) <| f <| x
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with a function that will always return True is the same as Basics.not on List.isEmpty"
+                            , details = [ "You can replace this call by Basics.not on List.isEmpty on the list given to the List.any call." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = not <| List.isEmpty <| f <| x
+"""
+                        ]
+        , test "should replace x |> f |> List.any (always True) by x |> f |> List.isEmpty |> not" <|
+            \() ->
+                """module A exposing (..)
+a = x |> f |> List.any (always True)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with a function that will always return True is the same as Basics.not on List.isEmpty"
+                            , details = [ "You can replace this call by Basics.not on List.isEmpty on the list given to the List.any call." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = x |> f |> List.isEmpty |> not
+"""
+                        ]
+        , test "should replace List.any (always True) by not << List.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = List.any (always True)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with a function that will always return True is the same as Basics.not on List.isEmpty"
+                            , details = [ "You can replace this call by List.isEmpty, then Basics.not." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (not << List.isEmpty)
+"""
+                        ]
+        , test "should replace List.any <| always True by not << List.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = List.any <| always True
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with a function that will always return True is the same as Basics.not on List.isEmpty"
+                            , details = [ "You can replace this call by List.isEmpty, then Basics.not." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (not << List.isEmpty)
+"""
+                        ]
+        , test "should replace always True |> List.any by List.isEmpty >> not" <|
+            \() ->
+                """module A exposing (..)
+a = always True |> List.any
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "List.any with a function that will always return True is the same as Basics.not on List.isEmpty"
+                            , details = [ "You can replace this call by List.isEmpty, then Basics.not." ]
+                            , under = "List.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (List.isEmpty >> not)
+"""
+                        ]
         ]
 
 

--- a/tests/Simplify/SimplificationCorrectnessTest.elm
+++ b/tests/Simplify/SimplificationCorrectnessTest.elm
@@ -522,6 +522,20 @@ all =
                     |> Expect.equal
                         (String.trim string)
             )
+        , Test.fuzz Fuzz.string
+            "String.all (always False) is the same as String.isEmpty"
+            (\string ->
+                String.all (always False) string
+                    |> Expect.equal
+                        (String.isEmpty string)
+            )
+        , Test.fuzz Fuzz.string
+            "String.any (always True) is the same as not << String.isEmpty"
+            (\string ->
+                String.any (always True) string
+                    |> Expect.equal
+                        (Basics.not (String.isEmpty string))
+            )
         ]
 
 

--- a/tests/Simplify/StringTest.elm
+++ b/tests/Simplify/StringTest.elm
@@ -3072,6 +3072,38 @@ a = String.any (always False)
 a = always False
 """
                         ]
+        , test "should replace String.any (always True) string by not (String.isEmpty string)" <|
+            \() ->
+                """module A exposing (..)
+a = String.any (always True) string
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.any with a function that will always return True is the same as Basics.not on String.isEmpty"
+                            , details = [ "You can replace this call by Basics.not on String.isEmpty on the string given to the String.any call." ]
+                            , under = "String.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = not (String.isEmpty string)
+"""
+                        ]
+        , test "should replace String.any (always True) by not << String.isEmpty" <|
+            \() ->
+                """module A exposing (..)
+a = String.any (always True)
+"""
+                    |> Review.Test.run ruleWithDefaults
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "String.any with a function that will always return True is the same as Basics.not on String.isEmpty"
+                            , details = [ "You can replace this call by String.isEmpty, then Basics.not." ]
+                            , under = "String.any"
+                            }
+                            |> Review.Test.whenFixed """module A exposing (..)
+a = (not << String.isEmpty)
+"""
+                        ]
         ]
 
 


### PR DESCRIPTION
Implements/closes https://github.com/jfmengels/elm-review-simplify/issues/424
```elm
String.any (always True) str
--> not (String.isEmpty str)

String.all (always False) str
--> String.isEmpty str

List.all (always False) list
--> List.isEmpty list

List.any (always True) list
--> not (List.isEmpty list)
```
including without the last argument